### PR TITLE
Add failing test for prefer-to-be-undefined

### DIFF
--- a/rules/__tests__/prefer_to_be_undefined.test.js
+++ b/rules/__tests__/prefer_to_be_undefined.test.js
@@ -6,7 +6,10 @@ const rules = require('../../').rules;
 const ruleTester = new RuleTester();
 
 ruleTester.run('prefer_to_be_undefined', rules['prefer-to-be-undefined'], {
-  valid: ['expect(undefined).toBeUndefined();'],
+  valid: [
+    'expect(undefined).toBeUndefined();',
+    'expect(undefined).not.toBeUndefined();',
+  ],
 
   invalid: [
     {


### PR DESCRIPTION
This throws. We should create a util which analyses a `CallExpression` and gives you useful properties out (like value, matcher, if it's `not`, `resolves` or `rejects`, argument in matcher, etc)

/cc @xfumihiro 