### PR TITLE
fix: support identifiers in to-be-undefined

### DIFF
--- a/rules/__tests__/prefer_to_be_null.test.js
+++ b/rules/__tests__/prefer_to_be_null.test.js
@@ -6,7 +6,11 @@ const rules = require('../../').rules;
 const ruleTester = new RuleTester();
 
 ruleTester.run('prefer_to_be_null', rules['prefer-to-be-null'], {
-  valid: ['expect(null).toBeNull();', 'expect(null).toEqual();'],
+  valid: [
+    'expect(null).toBeNull();',
+    'expect(null).toEqual();',
+    "expect(something).toEqual('a string');",
+  ],
 
   invalid: [
     {

--- a/rules/__tests__/prefer_to_be_null.test.js
+++ b/rules/__tests__/prefer_to_be_null.test.js
@@ -9,6 +9,14 @@ ruleTester.run('prefer_to_be_null', rules['prefer-to-be-null'], {
   valid: [
     'expect(null).toBeNull();',
     'expect(null).toEqual();',
+    'expect(null).not.toBeNull();',
+    'expect(null).not.toEqual();',
+    'expect(null).toBe(undefined);',
+    'expect(null).not.toBe(undefined);',
+    'expect(null).toBe();',
+    'expect(null).toMatchSnapshot();',
+    'expect("a string").toMatchSnapshot(null);',
+    'expect("a string").not.toMatchSnapshot();',
     "expect(something).toEqual('a string');",
   ],
 
@@ -34,6 +42,28 @@ ruleTester.run('prefer_to_be_null', rules['prefer-to-be-null'], {
         },
       ],
       output: 'expect(null).toBeNull();',
+    },
+    {
+      code: 'expect("a string").not.toBe(null);',
+      errors: [
+        {
+          message: 'Use toBeNull() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeNull();',
+    },
+    {
+      code: 'expect("a string").not.toEqual(null);',
+      errors: [
+        {
+          message: 'Use toBeNull() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeNull();',
     },
   ],
 });

--- a/rules/__tests__/prefer_to_be_undefined.test.js
+++ b/rules/__tests__/prefer_to_be_undefined.test.js
@@ -11,6 +11,10 @@ ruleTester.run('prefer_to_be_undefined', rules['prefer-to-be-undefined'], {
     'expect(true).not.toBeUndefined();',
     'expect({}).toEqual({});',
     'expect(null).toEqual(null);',
+    'expect(something).toBe(somethingElse)',
+    'expect(something).toEqual(somethingElse)',
+    'expect(something).not.toBe(somethingElse)',
+    'expect(something).not.toEqual(somethingElse)',
   ],
 
   invalid: [

--- a/rules/__tests__/prefer_to_be_undefined.test.js
+++ b/rules/__tests__/prefer_to_be_undefined.test.js
@@ -40,5 +40,27 @@ ruleTester.run('prefer_to_be_undefined', rules['prefer-to-be-undefined'], {
       ],
       output: 'expect(undefined).toBeUndefined();',
     },
+    {
+      code: 'expect("a string").not.toBe(undefined);',
+      errors: [
+        {
+          message: 'Use toBeUndefined() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeUndefined();',
+    },
+    {
+      code: 'expect("a string").not.toEqual(undefined);',
+      errors: [
+        {
+          message: 'Use toBeUndefined() instead',
+          column: 24,
+          line: 1,
+        },
+      ],
+      output: 'expect("a string").not.toBeUndefined();',
+    },
   ],
 });

--- a/rules/prefer_to_be_null.js
+++ b/rules/prefer_to_be_null.js
@@ -1,22 +1,36 @@
 'use strict';
 const argument = require('./util').argument;
+const argument2 = require('./util').argument2;
 const expectToBeCase = require('./util').expectToBeCase;
 const expectToEqualCase = require('./util').expectToEqualCase;
+const expectNotToEqualCase = require('./util').expectNotToEqualCase;
+const expectNotToBeCase = require('./util').expectNotToBeCase;
 const method = require('./util').method;
+const method2 = require('./util').method2;
 
 module.exports = context => {
   return {
     CallExpression(node) {
-      if (expectToBeCase(node, null) || expectToEqualCase(node, null)) {
+      const is = expectToBeCase(node, null) || expectToEqualCase(node, null);
+      const isNot =
+        expectNotToEqualCase(node, null) || expectNotToBeCase(node, null);
+
+      if (is || isNot) {
         context.report({
           fix(fixer) {
+            if (is) {
+              return [
+                fixer.replaceText(method(node), 'toBeNull'),
+                fixer.remove(argument(node)),
+              ];
+            }
             return [
-              fixer.replaceText(method(node), 'toBeNull'),
-              fixer.remove(argument(node)),
+              fixer.replaceText(method2(node), 'toBeNull'),
+              fixer.remove(argument2(node)),
             ];
           },
           message: 'Use toBeNull() instead',
-          node: method(node),
+          node: is ? method(node) : method2(node),
         });
       }
     },

--- a/rules/prefer_to_be_undefined.js
+++ b/rules/prefer_to_be_undefined.js
@@ -1,25 +1,38 @@
 'use strict';
 const argument = require('./util').argument;
+const argument2 = require('./util').argument2;
 const expectToBeCase = require('./util').expectToBeCase;
+const expectNotToBeCase = require('./util').expectNotToBeCase;
 const expectToEqualCase = require('./util').expectToEqualCase;
+const expectNotToEqualCase = require('./util').expectNotToEqualCase;
 const method = require('./util').method;
+const method2 = require('./util').method2;
 
 module.exports = context => {
   return {
     CallExpression(node) {
-      if (
-        expectToBeCase(node, undefined) ||
-        expectToEqualCase(node, undefined)
-      ) {
+      const is =
+        expectToBeCase(node, undefined) || expectToEqualCase(node, undefined);
+      const isNot =
+        expectNotToEqualCase(node, undefined) ||
+        expectNotToBeCase(node, undefined);
+
+      if (is || isNot) {
         context.report({
           fix(fixer) {
+            if (is) {
+              return [
+                fixer.replaceText(method(node), 'toBeUndefined'),
+                fixer.remove(argument(node)),
+              ];
+            }
             return [
-              fixer.replaceText(method(node), 'toBeUndefined'),
-              fixer.remove(argument(node)),
+              fixer.replaceText(method2(node), 'toBeUndefined'),
+              fixer.remove(argument2(node)),
             ];
           },
           message: 'Use toBeUndefined() instead',
-          node: method(node),
+          node: is ? method(node) : method2(node),
         });
       }
     },

--- a/rules/util.js
+++ b/rules/util.js
@@ -27,8 +27,10 @@ const expectToBeCase = (node, arg) =>
   expectCase(node) &&
   methodName(node) === 'toBe' &&
   argument(node) &&
-  argument(node).value === arg &&
-  (arg === null || argument(node).name);
+  ((argument(node).type === 'Literal' &&
+    argument(node).value === null &&
+    arg === null) ||
+    (argument(node).name === 'undefined' && arg === undefined));
 
 const expectNotToBeCase = (node, arg) =>
   expectNotCase(node) &&
@@ -42,8 +44,10 @@ const expectToEqualCase = (node, arg) =>
   expectCase(node) &&
   methodName(node) === 'toEqual' &&
   argument(node) &&
-  argument(node).value === arg &&
-  (arg === null || argument(node).name);
+  ((argument(node).type === 'Literal' &&
+    argument(node).value === null &&
+    arg === null) ||
+    (argument(node).name === 'undefined' && arg === undefined));
 
 const expectNotToEqualCase = (node, arg) =>
   expectNotCase(node) &&

--- a/rules/util.js
+++ b/rules/util.js
@@ -36,8 +36,10 @@ const expectNotToBeCase = (node, arg) =>
   expectNotCase(node) &&
   methodName2(node) === 'toBe' &&
   argument2(node) &&
-  argument2(node).value === arg &&
-  (arg === null || argument2(node).name);
+  ((argument2(node).type === 'Literal' &&
+    argument2(node).value === null &&
+    arg === null) ||
+    (argument2(node).name === 'undefined' && arg === undefined));
 
 const expectToEqualCase = (node, arg) =>
   !(expectNotCase(node) || expectResolveCase(node) || expectRejectCase(node)) &&
@@ -53,8 +55,10 @@ const expectNotToEqualCase = (node, arg) =>
   expectNotCase(node) &&
   methodName2(node) === 'toEqual' &&
   argument2(node) &&
-  argument2(node).value === arg &&
-  (arg === null || argument2(node).name);
+  ((argument2(node).type === 'Literal' &&
+    argument2(node).value === null &&
+    arg === null) ||
+    (argument2(node).name === 'undefined' && arg === undefined));
 
 const expectToBeUndefinedCase = node =>
   !(expectNotCase(node) || expectResolveCase(node) || expectRejectCase(node)) &&


### PR DESCRIPTION
I've ran the plugin with all rules enabled over the jest code base. Found a false positive, but with this change, it looks pretty great 🙂 

`expect(something).to{Be,Equal}(somethingElse)` were the false positives. The other assertions were added as precautions as I broke all of them while fixing the first one.

/cc @xfumihiro 