### PR TITLE
Introduce a lint rule to report error when testing promises. If a exp…

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ for more information about extending configuration files.
 | [prefer-to-be-undefined](docs/rules/prefer-to-be-undefined.md)     | Suggest using `toBeUndefined()`                                 |                                                                         | ![fixable](https://img.shields.io/badge/-fixable-green.svg) |
 | [prefer-expect-assertions](docs/rules/prefer-expect-assertions.md) | Suggest using `expect.assertions()` OR `expect.hasAssertions()` |                                                                         |                                                             |
 | [valid-expect](docs/rules/valid-expect.md)                         | Enforce valid `expect()` usage                                  | ![recommended](https://img.shields.io/badge/-recommended-lightgrey.svg) |                                                             |
+| [valid-expect-in-promise](docs/rules/valid-expect-in-promise.md)   | Enforce having return statement when testing with promises      |                                                                         |                                                             |
 
 ## Credit
 

--- a/docs/rules/valid-expect-in-promise.md
+++ b/docs/rules/valid-expect-in-promise.md
@@ -1,0 +1,33 @@
+# Enforce having return statement when testing with promises (valid-expect-in-promise)
+
+Ensure to return promise when having assertions in `then` or `catch` block of
+promise
+
+## Rule details
+
+This rule triggers a warning if,
+
+* test is having assertions in `then` or `catch` block of a promise
+* and that promise is not returned from the test
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+it('promise test', () => {
+  somePromise.then(data => {
+    expect(data).toEqual('foo');
+  });
+});
+```
+
+The following pattern is not warning:
+
+```js
+it('promise test', () => {
+  return somePromise.then(data => {
+    expect(data).toEqual('foo');
+  });
+});
+```

--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ module.exports = {
         'jest/no-identical-title': 'error',
         'jest/prefer-to-have-length': 'warn',
         'jest/valid-expect': 'error',
-        'jest/valid-expect-in-promise': 'error',
       },
     },
   },

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const preferToBeUndefined = require('./rules/prefer_to_be_undefined');
 const preferToHaveLength = require('./rules/prefer_to_have_length');
 const validExpect = require('./rules/valid_expect');
 const preferExpectAssertions = require('./rules/prefer_expect_assertions');
+const validExpectInPromise = require('./rules/valid_expect_in_promise');
 
 const snapshotProcessor = require('./processors/snapshot-processor');
 
@@ -25,6 +26,7 @@ module.exports = {
         'jest/no-identical-title': 'error',
         'jest/prefer-to-have-length': 'warn',
         'jest/valid-expect': 'error',
+        'jest/valid-expect-in-promise': 'error',
       },
     },
   },
@@ -64,5 +66,6 @@ module.exports = {
     'prefer-to-have-length': preferToHaveLength,
     'valid-expect': validExpect,
     'prefer-expect-assertions': preferExpectAssertions,
+    'valid-expect-in-promise': validExpectInPromise,
   },
 };

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -105,6 +105,19 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
         },
       ],
     },
+    {
+      code:
+        "it('test function', " +
+        '\n() => {Builder.getPromiseBuilder()..get().build()' +
+        "\n.then((data) => {expect(data).toEqual('Hi');});});",
+      errors: [
+        {
+          column: 8,
+          endColumn: 48,
+          message: expectedMsg,
+        },
+      ],
+    },
   ],
 
   valid: [
@@ -180,5 +193,9 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
       'const promise = nodeCrawl({}).' +
       "\nthen(data => {expect(childProcess.spawn).lastCalledWith('find');});" +
       '\nreturn promise;});',
+
+    "it('test function', " +
+      '\n() => {return Builder.getPromiseBuilder().get().build()' +
+      "\n.then((data) => {expect(data).toEqual('Hi');});});",
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -165,5 +165,7 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
          }).toThrow();
        }));
     `,
+
+    "it('promise test', () => {const somePromise = getThatPromise();\nsomePromise.then((data) => {expect(data).toEqual('foo');});\nexpect(somePromise).toBeDefined();\nreturn somePromise;});",
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -218,5 +218,7 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
       "\n.then((data) => {expect(data).toEqual('Hi');});});",
 
     'it("it1", () => somePromise.then(() => {expect(someThing).toEqual(true)}))',
+
+    'it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))',
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -118,6 +118,21 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
         },
       ],
     },
+    {
+      code:
+        'it("it1", () => { somePromise.' +
+        '\nthen(() => {\n' +
+        '\ndoSomeOperation();' +
+        '\nexpect(someThing).toEqual(true);' +
+        '\n})})',
+      errors: [
+        {
+          column: 19,
+          endColumn: 3,
+          message: expectedMsg,
+        },
+      ],
+    },
   ],
 
   valid: [

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -220,5 +220,15 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
     'it("it1", () => somePromise.then(() => {expect(someThing).toEqual(true)}))',
 
     'it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))',
+
+    `it('promise test with done', (done) => {
+      const promise = getPromise();
+      promise.then(() => expect(someThing).toEqual(true));
+    });`,
+
+    `it('name of done param does not matter', (nameDoesNotMatter) => {
+      const promise = getPromise();
+      promise.then(() => expect(someThing).toEqual(true));
+    });`,
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -148,5 +148,22 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
     "it('it1', () => {return somePromise." +
       'then(() => {expect(someThing).toEqual(true);})' +
       '.catch(() => {expect(someThing).toEqual(false);})});',
+    `
+     test('later return', () => {
+       const promise = something().then(value => {
+         expect(value).toBe('red');
+       });
+
+       return promise;
+     });
+    `,
+    `
+     it('shorthand arrow', () =>
+       something().then(value => {
+         expect(() => {
+           value();
+         }).toThrow();
+       }));
+    `,
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -166,6 +166,19 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
        }));
     `,
 
-    "it('promise test', () => {const somePromise = getThatPromise();\nsomePromise.then((data) => {expect(data).toEqual('foo');});\nexpect(somePromise).toBeDefined();\nreturn somePromise;});",
+    "it('promise test', () => {const somePromise = getThatPromise();" +
+      "\nsomePromise.then((data) => {expect(data).toEqual('foo');});" +
+      '\nexpect(somePromise).toBeDefined();' +
+      '\nreturn somePromise;});',
+
+    "test('promise test', function() { let somePromise = getThatPromise();" +
+      "\nsomePromise.then((data) => {expect(data).toEqual('foo');});" +
+      '\nexpect(somePromise).toBeDefined();' +
+      '\nreturn somePromise;});',
+
+    "it('crawls for files based on patterns', () => {" +
+      'const promise = nodeCrawl({}).' +
+      "\nthen(data => {expect(childProcess.spawn).lastCalledWith('find');});" +
+      '\nreturn promise;});',
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -201,5 +201,7 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
     "notATestFunction('not a test function', " +
       '\n() => {Builder.getPromiseBuilder().get().build()' +
       "\n.then((data) => {expect(data).toEqual('Hi');});});",
+
+    'it("it1", () => somePromise.then(() => {expect(someThing).toEqual(true)}))',
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rules = require('../..').rules;
+
+const ruleTester = new RuleTester();
+const expectedMsg =
+  'Promise should be returned to test its fulfillment or rejection';
+
+ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
+  invalid: [
+    {
+      code:
+        'it("it1", () => { somePromise.then(' +
+        '() => {expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 19,
+          endColumn: 76,
+          message: expectedMsg,
+        },
+      ],
+      parserOptions: { ecmaVersion: 6 },
+    },
+    {
+      code:
+        'it("it1", function() { getSomeThing().getPromise().then(' +
+        'function() {expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 24,
+          endColumn: 102,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code:
+        'it("it1", function() { Promise.resolve().then(' +
+        'function() {expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 24,
+          endColumn: 92,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code:
+        'it("it1", function() { somePromise.catch(' +
+        'function() {expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 24,
+          endColumn: 87,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code:
+        'it("it1", function() { somePromise.then(' +
+        'function() { expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 24,
+          endColumn: 87,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code:
+        'it("it1", function() { Promise.resolve().then(' +
+        'function() { /*fulfillment*/ expect(someThing).toEqual(true)}, ' +
+        'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 24,
+          endColumn: 170,
+          message: expectedMsg,
+        },
+        {
+          column: 24,
+          endColumn: 170,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code:
+        'it("it1", function() { Promise.resolve().then(' +
+        'function() { /*fulfillment*/}, ' +
+        'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
+      errors: [
+        {
+          column: 24,
+          endColumn: 138,
+          message: expectedMsg,
+        },
+      ],
+    },
+  ],
+
+  valid: [
+    {
+      code:
+        'it("it1", () => { return somePromise.then(() => {expect(someThing).toEqual(true)})})',
+      parserOptions: { sourceType: 'module' },
+    },
+
+    'it("it1", function() { return somePromise.catch(' +
+      'function() {expect(someThing).toEqual(true)})})',
+
+    'it("it1", function() { somePromise.then(' +
+      'function() {doSomeThingButNotExpect()})})',
+
+    'it("it1", function() { return getSomeThing().getPromise().then(' +
+      'function() {expect(someThing).toEqual(true)})})',
+
+    'it("it1", function() { return Promise.resolve().then(' +
+      'function() {expect(someThing).toEqual(true)})})',
+
+    'it("it1", function() { return Promise.resolve().then(' +
+      'function() { /*fulfillment*/ expect(someThing).toEqual(true)}, ' +
+      'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
+
+    'it("it1", function() { return Promise.resolve().then(' +
+      'function() { /*fulfillment*/}, ' +
+      'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
+
+    'it("it1", function() { return somePromise.then()})',
+  ],
+});

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -140,5 +140,13 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
 
     'it("it1", async () => { await getSomeThing().getPromise().then(' +
       'function() {expect(someThing).toEqual(true)})})',
+
+    "it('it1', () => {return somePromise." +
+      'then(() => {expect(someThing).toEqual(true);})' +
+      '.then(() => {expect(someThing).toEqual(true);})});',
+
+    "it('it1', () => {return somePromise." +
+      'then(() => {expect(someThing).toEqual(true);})' +
+      '.catch(() => {expect(someThing).toEqual(false);})});',
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -15,131 +15,165 @@ const expectedMsg =
 ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
   invalid: [
     {
-      code:
-        'it("it1", () => { somePromise.then(' +
-        '() => {expect(someThing).toEqual(true)})})',
+      code: `
+         it('it1', () => {
+           somePromise.then(() => {
+             expect(someThing).toEqual(true);
+           });
+         });
+      `,
       errors: [
         {
-          column: 19,
-          endColumn: 76,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", function() { getSomeThing().getPromise().then(' +
-        'function() {expect(someThing).toEqual(true)})})',
-      errors: [
-        {
-          column: 24,
-          endColumn: 102,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", function() { Promise.resolve().then(' +
-        'function() {expect(someThing).toEqual(true)})})',
-      errors: [
-        {
-          column: 24,
-          endColumn: 92,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", function() { somePromise.catch(' +
-        'function() {expect(someThing).toEqual(true)})})',
-      errors: [
-        {
-          column: 24,
-          endColumn: 87,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", function() { somePromise.then(' +
-        'function() { expect(someThing).toEqual(true)})})',
-      errors: [
-        {
-          column: 24,
-          endColumn: 87,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", function() { Promise.resolve().then(' +
-        'function() { /*fulfillment*/ expect(someThing).toEqual(true)}, ' +
-        'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
-      errors: [
-        {
-          column: 24,
-          endColumn: 170,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", function() { Promise.resolve().then(' +
-        'function() { /*fulfillment*/}, ' +
-        'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
-      errors: [
-        {
-          column: 24,
-          endColumn: 138,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        "it('test function', " +
-        '\n() => {Builder.getPromiseBuilder().get().build()' +
-        "\n.then((data) => {expect(data).toEqual('Hi');});});",
-      errors: [
-        {
-          column: 8,
-          endColumn: 48,
-          message: expectedMsg,
-        },
-      ],
-    },
-    {
-      code:
-        'it("it1", () => { somePromise.' +
-        '\nthen(() => {\n' +
-        '\ndoSomeOperation();' +
-        '\nexpect(someThing).toEqual(true);' +
-        '\n})})',
-      errors: [
-        {
-          column: 19,
-          endColumn: 3,
+          column: 12,
+          endColumn: 15,
           message: expectedMsg,
         },
       ],
     },
     {
       code: `
-     test('invalid return', () => {
-       const promise = something().then(value => {
-         return expect(value).toBe('red');
-       });
-     });
-    `,
+        it('it1', function() {
+            getSomeThing().getPromise().then(function() {
+              expect(someThing).toEqual(true);
+            });
+        });
+      `,
       errors: [
         {
-          column: 14,
-          endColumn: 10,
+          column: 13,
+          endColumn: 16,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            Promise.resolve().then(function() {
+              expect(someThing).toEqual(true);
+            });
+          });
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 16,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            somePromise.catch(function() {
+              expect(someThing).toEqual(true)
+            })
+          }
+        )
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function() {
+            somePromise.then(function() {
+              expect(someThing).toEqual(true)
+            })
+          }
+        )
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function () {
+          Promise.resolve().then(/*fulfillment*/ function () {
+            expect(someThing).toEqual(true);
+          }, /*rejection*/ function () {
+            expect(someThing).toEqual(true);
+          })
+        })
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 13,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', function () {
+          Promise.resolve().then(/*fulfillment*/ function () {
+          }, /*rejection*/ function () {
+            expect(someThing).toEqual(true)
+          })
+        });
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 13,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('test function', () => {
+          Builder.getPromiseBuilder().get().build().then((data) => expect(data).toEqual('Hi'));
+        });
+      `,
+      errors: [
+        {
+          column: 11,
+          endColumn: 96,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+        it('it1', () => {
+            somePromise.then(() => {
+              doSomeOperation();
+              expect(someThing).toEqual(true);
+            })
+          });
+      `,
+      errors: [
+        {
+          column: 13,
+          endColumn: 15,
+          message: expectedMsg,
+        },
+      ],
+    },
+    {
+      code: `
+         test('invalid return', () => {
+           const promise = something().then(value => {
+             return expect(value).toBe('red');
+           });
+         });
+      `,
+      errors: [
+        {
+          column: 18,
+          endColumn: 14,
           message: expectedMsg,
         },
       ],
@@ -147,46 +181,121 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
   ],
 
   valid: [
-    'it("it1", () => { return somePromise.then(() => {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', () => {
+        return somePromise.then(() => {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
 
-    'it("it1", function() { return somePromise.catch(' +
-      'function() {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', function() {
+        return somePromise.catch(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
 
-    'it("it1", function() { somePromise.then(' +
-      'function() {doSomeThingButNotExpect()})})',
+    `
+      it('it1', function() {
+        return somePromise.then(function() {
+          doSomeThingButNotExpect();
+        });
+      });
+    `,
 
-    'it("it1", function() { return getSomeThing().getPromise().then(' +
-      'function() {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', function() {
+        return getSomeThing().getPromise().then(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
 
-    'it("it1", function() { return Promise.resolve().then(' +
-      'function() {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', function() {
+        return Promise.resolve().then(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
 
-    'it("it1", function() { return Promise.resolve().then(' +
-      'function() { /*fulfillment*/ expect(someThing).toEqual(true)}, ' +
-      'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
+    `
+      it('it1', function () {
+        return Promise.resolve().then(function () {
+          /*fulfillment*/
+          expect(someThing).toEqual(true);
+        }, function () {
+          /*rejection*/
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
 
-    'it("it1", function() { return Promise.resolve().then(' +
-      'function() { /*fulfillment*/}, ' +
-      'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
+    `
+      it('it1', function () {
+        return Promise.resolve().then(function () {
+          /*fulfillment*/
+        }, function () {
+          /*rejection*/
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
 
-    'it("it1", function() { return somePromise.then()})',
+    `
+      it('it1', function () {
+        return somePromise.then()
+      });
+    `,
 
-    'it("it1", async () => { await Promise.resolve().then(' +
-      'function() {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', async () => {
+        await Promise.resolve().then(function () {
+          expect(someThing).toEqual(true)
+        });
+      });
+    `,
 
-    'it("it1", async () => ' +
-      '{ await somePromise.then(() => {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', async () => {
+        await somePromise.then(() => {
+          expect(someThing).toEqual(true)
+        });
+      });
+    `,
 
-    'it("it1", async () => { await getSomeThing().getPromise().then(' +
-      'function() {expect(someThing).toEqual(true)})})',
+    `
+      it('it1', async () => {
+        await getSomeThing().getPromise().then(function () {
+          expect(someThing).toEqual(true)
+        });
+      });
+    `,
 
-    "it('it1', () => {return somePromise." +
-      'then(() => {expect(someThing).toEqual(true);})' +
-      '.then(() => {expect(someThing).toEqual(true);})});',
+    `
+      it('it1', () => {
+        return somePromise.then(() => {
+            expect(someThing).toEqual(true);
+          })
+          .then(() => {
+            expect(someThing).toEqual(true);
+          })
+      });
+    `,
 
-    "it('it1', () => {return somePromise." +
-      'then(() => {expect(someThing).toEqual(true);})' +
-      '.catch(() => {expect(someThing).toEqual(false);})});',
+    `
+      it('it1', () => {
+        return somePromise.then(() => {
+            expect(someThing).toEqual(true);
+          })
+          .catch(() => {
+            expect(someThing).toEqual(false);
+          })
+      });
+    `,
+
     `
      test('later return', () => {
        const promise = something().then(value => {
@@ -196,6 +305,7 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
        return promise;
      });
     `,
+
     `
      it('shorthand arrow', () =>
        something().then(value => {
@@ -205,41 +315,77 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
        }));
     `,
 
-    "it('promise test', () => {const somePromise = getThatPromise();" +
-      "\nsomePromise.then((data) => {expect(data).toEqual('foo');});" +
-      '\nexpect(somePromise).toBeDefined();' +
-      '\nreturn somePromise;});',
+    `
+      it('promise test', () => {
+        const somePromise = getThatPromise();
+        somePromise.then((data) => {
+          expect(data).toEqual('foo');
+        });
+        expect(somePromise).toBeDefined();
+        return somePromise;
+      });
+    `,
 
-    "test('promise test', function() { let somePromise = getThatPromise();" +
-      "\nsomePromise.then((data) => {expect(data).toEqual('foo');});" +
-      '\nexpect(somePromise).toBeDefined();' +
-      '\nreturn somePromise;});',
+    `
+      test('promise test', function () {
+        let somePromise = getThatPromise();
+        somePromise.then((data) => {
+          expect(data).toEqual('foo');
+        });
+        expect(somePromise).toBeDefined();
+        return somePromise;
+      });
+    `,
 
-    "it('crawls for files based on patterns', () => {" +
-      'const promise = nodeCrawl({}).' +
-      "\nthen(data => {expect(childProcess.spawn).lastCalledWith('find');});" +
-      '\nreturn promise;});',
+    `
+      it('crawls for files based on patterns', () => {
+        const promise = nodeCrawl({}).then(data => {
+          expect(childProcess.spawn).lastCalledWith('find');
+        });
+        return promise;
+      });
+    `,
 
-    "it('test function', " +
-      '\n() => {return Builder.getPromiseBuilder().get().build()' +
-      "\n.then((data) => {expect(data).toEqual('Hi');});});",
+    `
+      it('test function',
+        () => {
+          return Builder.getPromiseBuilder().get().build()
+            .then((data) => {
+              expect(data).toEqual('Hi');
+            });
+      });
+    `,
 
-    "notATestFunction('not a test function', " +
-      '\n() => {Builder.getPromiseBuilder().get().build()' +
-      "\n.then((data) => {expect(data).toEqual('Hi');});});",
+    `
+      notATestFunction('not a test function',
+        () => {
+          Builder.getPromiseBuilder().get().build()
+            .then((data) => {
+              expect(data).toEqual('Hi');
+            });
+      });
+    `,
 
-    'it("it1", () => somePromise.then(() => {expect(someThing).toEqual(true)}))',
+    `
+      it("it1", () => somePromise.then(() => {
+        expect(someThing).toEqual(true)
+      }))
+    `,
 
-    'it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))',
+    ` it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))`,
 
-    `it('promise test with done', (done) => {
-      const promise = getPromise();
-      promise.then(() => expect(someThing).toEqual(true));
-    });`,
+    `
+      it('promise test with done', (done) => {
+        const promise = getPromise();
+        promise.then(() => expect(someThing).toEqual(true));
+      });
+    `,
 
-    `it('name of done param does not matter', (nameDoesNotMatter) => {
-      const promise = getPromise();
-      promise.then(() => expect(someThing).toEqual(true));
-    });`,
+    `
+      it('name of done param does not matter', (nameDoesNotMatter) => {
+        const promise = getPromise();
+        promise.then(() => expect(someThing).toEqual(true));
+      });
+    `,
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -108,7 +108,7 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
     {
       code:
         "it('test function', " +
-        '\n() => {Builder.getPromiseBuilder()..get().build()' +
+        '\n() => {Builder.getPromiseBuilder().get().build()' +
         "\n.then((data) => {expect(data).toEqual('Hi');});});",
       errors: [
         {
@@ -196,6 +196,10 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
 
     "it('test function', " +
       '\n() => {return Builder.getPromiseBuilder().get().build()' +
+      "\n.then((data) => {expect(data).toEqual('Hi');});});",
+
+    "notATestFunction('not a test function', " +
+      '\n() => {Builder.getPromiseBuilder().get().build()' +
       "\n.then((data) => {expect(data).toEqual('Hi');});});",
   ],
 });

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -133,6 +133,22 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
         },
       ],
     },
+    {
+      code: `
+     test('invalid return', () => {
+       const promise = something().then(value => {
+         return expect(value).toBe('red');
+       });
+     });
+    `,
+      errors: [
+        {
+          column: 14,
+          endColumn: 10,
+          message: expectedMsg,
+        },
+      ],
+    },
   ],
 
   valid: [

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -85,11 +85,6 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
           endColumn: 170,
           message: expectedMsg,
         },
-        {
-          column: 24,
-          endColumn: 170,
-          message: expectedMsg,
-        },
       ],
     },
     {

--- a/rules/__tests__/valid_expect_in_promise.test.js
+++ b/rules/__tests__/valid_expect_in_promise.test.js
@@ -3,7 +3,12 @@
 const RuleTester = require('eslint').RuleTester;
 const rules = require('../..').rules;
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+});
+
 const expectedMsg =
   'Promise should be returned to test its fulfillment or rejection';
 
@@ -20,7 +25,6 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
           message: expectedMsg,
         },
       ],
-      parserOptions: { ecmaVersion: 6 },
     },
     {
       code:
@@ -104,11 +108,7 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
   ],
 
   valid: [
-    {
-      code:
-        'it("it1", () => { return somePromise.then(() => {expect(someThing).toEqual(true)})})',
-      parserOptions: { sourceType: 'module' },
-    },
+    'it("it1", () => { return somePromise.then(() => {expect(someThing).toEqual(true)})})',
 
     'it("it1", function() { return somePromise.catch(' +
       'function() {expect(someThing).toEqual(true)})})',
@@ -131,5 +131,14 @@ ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
       'function() { /*rejection*/ expect(someThing).toEqual(true)})})',
 
     'it("it1", function() { return somePromise.then()})',
+
+    'it("it1", async () => { await Promise.resolve().then(' +
+      'function() {expect(someThing).toEqual(true)})})',
+
+    'it("it1", async () => ' +
+      '{ await somePromise.then(() => {expect(someThing).toEqual(true)})})',
+
+    'it("it1", async () => { await getSomeThing().getPromise().then(' +
+      'function() {expect(someThing).toEqual(true)})})',
   ],
 });

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -113,16 +113,19 @@ module.exports = context => {
         node.parent.type == 'CallExpression' &&
         !isAwaitExpression(node)
       ) {
-        const parent = node.parent;
-        const arg1 = parent.arguments[0];
-        const arg2 = parent.arguments[1];
+        const testFunctionBody = getTestFuncBody(node);
+        if (testFunctionBody) {
+          const parent = node.parent;
+          const arg1 = parent.arguments[0];
+          const arg2 = parent.arguments[1];
 
-        // then block can have two args, fulfillment & rejection
-        // then block can have one args, fulfillment
-        // catch block can have one args, rejection
-        // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-        verifyExpectWithReturn(arg1, node, context);
-        verifyExpectWithReturn(arg2, node, context);
+          // then block can have two args, fulfillment & rejection
+          // then block can have one args, fulfillment
+          // catch block can have one args, rejection
+          // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+          verifyExpectWithReturn(arg1, node, context);
+          verifyExpectWithReturn(arg2, node, context);
+        }
       }
     },
   };

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -45,7 +45,6 @@ const verifyExpectWithReturn = (argument, node, context) => {
   if (
     argument &&
     isFunction(argument.type) &&
-    //$FlowFixMe
     isBodyCallExpression(argument.body)
   ) {
     const calleeInThenOrCatch = argument.body.body[0].expression.callee.object;
@@ -57,18 +56,21 @@ const verifyExpectWithReturn = (argument, node, context) => {
   }
 };
 
+const isAwaitExpression = node => {
+  return node.parent.parent && node.parent.parent.type == 'AwaitExpression';
+};
+
 module.exports = context => {
   return {
     MemberExpression(node) {
       if (
         node.type == 'MemberExpression' &&
         isThenOrCatch(node) &&
-        node.parent.type == 'CallExpression'
+        node.parent.type == 'CallExpression' &&
+        !isAwaitExpression(node)
       ) {
         const parent = node.parent;
-        // $FlowFixMe
         const arg1 = parent.arguments[0];
-        // $FlowFixMe
         const arg2 = parent.arguments[1];
 
         // then block can have two args, fulfillment & rejection

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -69,7 +69,10 @@ const getTestFuncBody = node => {
   let parent = node.parent;
   while (parent) {
     if (isFunction(parent.type) && isTestFunc(parent.parent)) {
-      return parent.body.body;
+      if (parent.body.type === 'BlockStatement') return parent.body.body;
+      if (parent.body.type === 'CallExpression')
+        //arrow-short-hand-fn
+        return parent.body;
     }
     parent = parent.parent;
   }
@@ -77,6 +80,7 @@ const getTestFuncBody = node => {
 
 const isParentThenOrPromiseReturned = (node, testFunctionBody) => {
   return (
+    testFunctionBody.type == 'CallExpression' ||
     node.parent.parent.type == 'ReturnStatement' ||
     isPromiseReturnedLater(node, testFunctionBody) ||
     isThenOrCatch(node.parent.parent)

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -41,6 +41,18 @@ const reportReturnRequired = (context, node) => {
   });
 };
 
+const isParentThenOrReturn = node => {
+  try {
+    return (
+      node.parent.parent.type == 'ReturnStatement' ||
+      node.parent.parent.property.name === 'then' ||
+      node.parent.parent.property.name === 'catch'
+    );
+  } catch (e) {
+    return false;
+  }
+};
+
 const verifyExpectWithReturn = (argument, node, context) => {
   if (
     argument &&
@@ -49,7 +61,7 @@ const verifyExpectWithReturn = (argument, node, context) => {
   ) {
     const calleeInThenOrCatch = argument.body.body[0].expression.callee.object;
     if (isExpectCall(calleeInThenOrCatch)) {
-      if (node.parent.parent.type != 'ReturnStatement') {
+      if (!isParentThenOrReturn(node)) {
         reportReturnRequired(context, node);
       }
     }

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -17,7 +17,9 @@ const isFunction = type => {
 const isExpectCallPresentInFunction = body => {
   if (body.type === 'BlockStatement') {
     return body.body.find(line => {
-      return isExpectCall(line.expression);
+      if (line.type === 'ExpressionStatement')
+        return isExpectCall(line.expression);
+      if (line.type === 'ReturnStatement') return isExpectCall(line.argument);
     });
   } else {
     return isExpectCall(body);

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const reportMsg =
+  'Promise should be returned to test its fulfillment or rejection';
+
+const isThenOrCatch = node => {
+  return node.property.name == 'then' || node.property.name == 'catch';
+};
+
+const isFunction = type => {
+  return type == 'FunctionExpression' || type == 'ArrowFunctionExpression';
+};
+
+const isBodyCallExpression = argumentBody => {
+  try {
+    return argumentBody.body[0].expression.type == 'CallExpression';
+  } catch (e) {
+    return false;
+  }
+};
+
+const isExpectCall = calleeObject => {
+  try {
+    return calleeObject.callee.name == 'expect';
+  } catch (e) {
+    return false;
+  }
+};
+
+const reportReturnRequired = (context, node) => {
+  context.report({
+    loc: {
+      end: {
+        column: node.parent.parent.loc.end.column,
+        line: node.parent.parent.loc.end.line,
+      },
+      start: node.parent.parent.loc.start,
+    },
+    message: reportMsg,
+    node,
+  });
+};
+
+const verifyExpectWithReturn = (argument, node, context) => {
+  if (
+    argument &&
+    isFunction(argument.type) &&
+    //$FlowFixMe
+    isBodyCallExpression(argument.body)
+  ) {
+    const calleeInThenOrCatch = argument.body.body[0].expression.callee.object;
+    if (isExpectCall(calleeInThenOrCatch)) {
+      if (node.parent.parent.type != 'ReturnStatement') {
+        reportReturnRequired(context, node);
+      }
+    }
+  }
+};
+
+module.exports = context => {
+  return {
+    MemberExpression(node) {
+      if (
+        node.type == 'MemberExpression' &&
+        isThenOrCatch(node) &&
+        node.parent.type == 'CallExpression'
+      ) {
+        const parent = node.parent;
+        // $FlowFixMe
+        const arg1 = parent.arguments[0];
+        // $FlowFixMe
+        const arg2 = parent.arguments[1];
+
+        // then block can have two args, fulfillment & rejection
+        // then block can have one args, fulfillment
+        // catch block can have one args, rejection
+        // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+        verifyExpectWithReturn(arg1, node, context);
+        verifyExpectWithReturn(arg2, node, context);
+      }
+    },
+  };
+};

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -139,14 +139,19 @@ module.exports = context => {
         if (testFunction && !isHavingAsyncCallBackParam(testFunction)) {
           const testFunctionBody = getFunctionBody(testFunction);
           const parent = node.parent;
-          const arg1 = parent.arguments[0];
-          const arg2 = parent.arguments[1];
+          const fulfillmentCallback = parent.arguments[0];
+          const rejectionCallback = parent.arguments[1];
 
           // then block can have two args, fulfillment & rejection
           // then block can have one args, fulfillment
           // catch block can have one args, rejection
           // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-          verifyExpectWithReturn([arg1, arg2], node, context, testFunctionBody);
+          verifyExpectWithReturn(
+            [fulfillmentCallback, rejectionCallback],
+            node,
+            context,
+            testFunctionBody
+          );
         }
       }
     },

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -95,14 +95,23 @@ const isParentThenOrPromiseReturned = (node, testFunctionBody) => {
   );
 };
 
-const verifyExpectWithReturn = (argument, node, context, testFunctionBody) => {
-  if (argument && isFunction(argument.type)) {
-    if (isExpectCallPresentInFunction(argument.body)) {
-      if (!isParentThenOrPromiseReturned(node, testFunctionBody)) {
+const verifyExpectWithReturn = (
+  promiseCallbacks,
+  node,
+  context,
+  testFunctionBody
+) => {
+  promiseCallbacks.some(promiseCallback => {
+    if (promiseCallback && isFunction(promiseCallback.type)) {
+      if (
+        isExpectCallPresentInFunction(promiseCallback.body) &&
+        !isParentThenOrPromiseReturned(node, testFunctionBody)
+      ) {
         reportReturnRequired(context, node);
+        return true;
       }
     }
-  }
+  });
 };
 
 const isAwaitExpression = node => {
@@ -137,8 +146,7 @@ module.exports = context => {
           // then block can have one args, fulfillment
           // catch block can have one args, rejection
           // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
-          verifyExpectWithReturn(arg1, node, context, testFunctionBody);
-          verifyExpectWithReturn(arg2, node, context, testFunctionBody);
+          verifyExpectWithReturn([arg1, arg2], node, context, testFunctionBody);
         }
       }
     },

--- a/rules/valid_expect_in_promise.js
+++ b/rules/valid_expect_in_promise.js
@@ -22,12 +22,14 @@ const isBodyCallExpression = argumentBody => {
   }
 };
 
-const isExpectCall = calleeObject => {
-  try {
-    return calleeObject.callee.name == 'expect';
-  } catch (e) {
-    return false;
-  }
+const isExpectCallPresent = body => {
+  return body.find(line => {
+    return (
+      line.expression.type === 'CallExpression' &&
+      line.expression.callee.type === 'MemberExpression' &&
+      line.expression.callee.object.callee.name === 'expect'
+    );
+  });
 };
 
 const reportReturnRequired = (context, node) => {
@@ -93,8 +95,7 @@ const verifyExpectWithReturn = (argument, node, context, testFunctionBody) => {
     isFunction(argument.type) &&
     isBodyCallExpression(argument.body)
   ) {
-    const calleeInThenOrCatch = argument.body.body[0].expression.callee.object;
-    if (isExpectCall(calleeInThenOrCatch)) {
+    if (isExpectCallPresent(argument.body.body)) {
       if (!isParentThenOrPromiseReturned(node, testFunctionBody)) {
         reportReturnRequired(context, node);
       }


### PR DESCRIPTION
…ectation is added inside a then or catch block of promise then as per jest docs, it is mandatory to return that promise for succesfull execution of that expectation. This rull will report all such expectations where promise is not returned.

**Summary**
Implements  #41

As jest user I work on a project that heavily uses promises and jest is our tool to write tests. We were aware that as per [jest docs](https://facebook.github.io/jest/docs/en/tutorial-async.html), it is required to return a promise, if you want to test some thing in its fulfillment or rejection block.

If you do not return that promise and write some exceptions in its then or catch block. Then that test will always be green, as the expectation in then or catch block is never executed. If you return that promise then the expectation will be executed and tests will be red or green depending on the actual result of that expectation.

In this situation it becomes very important to make sure that,
a) You make that test red before making it green for the final push. Which will assure that the exception is  getting executed.

As human, we may forget to do that and hence this lint rule will be helpful.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
1. Added a unit test case with many combinations.
2. Tested on an existing project which uses jest & promises.
3. Ran all tests using 'yarn test' command

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Limitations**
1. If the expectation inside then or catch is a expect statement then this rule will work correctly. In case, there is call expression to some function, from then or catch block and that function has the expect statement then this rule will not be able to detect that. I will work on that issue but I feel that as 'Good to Have' and should be next step to improve this rule and current PR changes can be very well considered as 'Step 1' which is very useful in its current state.
