### PR TITLE
fix(valid-expect): error on missing async matchers

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -32,6 +32,7 @@ expect().toEqual('something');
 expect('something', 'else');
 expect('something');
 expect(true).toBeDefined;
+expect(Promise.resolve('hello')).resolves;
 ```
 
 The following patterns are not warnings:
@@ -40,4 +41,5 @@ The following patterns are not warnings:
 expect('something').toEqual('something');
 expect([1, 2, 3]).toEqual([1, 2, 3]);
 expect(true).toBeDefined();
+expect(Promise.resolve('hello')).resolves.toEqual('hello');
 ```

--- a/rules/__tests__/valid_expect.test.js
+++ b/rules/__tests__/valid_expect.test.js
@@ -107,7 +107,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         {
           endColumn: 22,
           column: 14,
-          message: '"resolves" needs a matcher.',
+          message: '"resolves" needs to call a matcher.',
         },
       ],
     },
@@ -117,7 +117,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         {
           endColumn: 21,
           column: 14,
-          message: '"rejects" needs a matcher.',
+          message: '"rejects" needs to call a matcher.',
         },
       ],
     },
@@ -127,7 +127,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         {
           endColumn: 17,
           column: 14,
-          message: '"not" needs a matcher.',
+          message: '"not" needs to call a matcher.',
         },
       ],
     },

--- a/rules/__tests__/valid_expect.test.js
+++ b/rules/__tests__/valid_expect.test.js
@@ -101,5 +101,35 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         },
       ],
     },
+    {
+      code: 'expect(true).resolves;',
+      errors: [
+        {
+          endColumn: 22,
+          column: 14,
+          message: '"resolves" needs a matcher.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).rejects;',
+      errors: [
+        {
+          endColumn: 21,
+          column: 14,
+          message: '"rejects" needs a matcher.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not;',
+      errors: [
+        {
+          endColumn: 17,
+          column: 14,
+          message: '"not" needs a matcher.',
+        },
+      ],
+    },
   ],
 });

--- a/rules/valid_expect.js
+++ b/rules/valid_expect.js
@@ -83,11 +83,18 @@ module.exports = context => {
 
           // matcher was not called
           if (grandParent.type === 'ExpressionStatement') {
+            let message;
+            if (expectProperties.indexOf(propertyName) > -1) {
+              message = `"${propertyName}" needs a matcher.`;
+            } else {
+              message = `"${propertyName}" was not called.`;
+            }
+
             context.report({
               // For some reason `endColumn` isn't set in tests if `loc` is not
               // added
               loc: parentProperty.loc,
-              message: `"${propertyName}" was not called.`,
+              message,
               node: parentProperty,
             });
           }

--- a/rules/valid_expect.js
+++ b/rules/valid_expect.js
@@ -85,7 +85,7 @@ module.exports = context => {
           if (grandParent.type === 'ExpressionStatement') {
             let message;
             if (expectProperties.indexOf(propertyName) > -1) {
-              message = `"${propertyName}" needs a matcher.`;
+              message = `"${propertyName}" needs to call a matcher.`;
             } else {
               message = `"${propertyName}" was not called.`;
             }


### PR DESCRIPTION
We got an error previously as well, but with a misleading message (`"resolves" was not called.`).