### PR TITLE
chore: add eslint-plugin-eslint-plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,8 +3,12 @@
 const globals = require('./index').environments.globals.globals;
 
 module.exports = {
-  extends: ['eslint:recommended', 'prettier'],
-  plugins: ['prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:eslint-plugin/recommended',
+    'prettier',
+  ],
+  plugins: ['eslint-plugin', 'prettier'],
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@commitlint/config-conventional": "^6.0.2",
     "eslint": "^4.10.0",
     "eslint-config-prettier": "^2.7.0",
+    "eslint-plugin-eslint-plugin": "^1.4.0",
     "eslint-plugin-prettier": "^2.3.1",
     "husky": "^0.14.3",
     "jest": "^22.0.4",

--- a/rules/prefer_to_be_null.js
+++ b/rules/prefer_to_be_null.js
@@ -8,31 +8,36 @@ const expectNotToBeCase = require('./util').expectNotToBeCase;
 const method = require('./util').method;
 const method2 = require('./util').method2;
 
-module.exports = context => {
-  return {
-    CallExpression(node) {
-      const is = expectToBeCase(node, null) || expectToEqualCase(node, null);
-      const isNot =
-        expectNotToEqualCase(node, null) || expectNotToBeCase(node, null);
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const is = expectToBeCase(node, null) || expectToEqualCase(node, null);
+        const isNot =
+          expectNotToEqualCase(node, null) || expectNotToBeCase(node, null);
 
-      if (is || isNot) {
-        context.report({
-          fix(fixer) {
-            if (is) {
+        if (is || isNot) {
+          context.report({
+            fix(fixer) {
+              if (is) {
+                return [
+                  fixer.replaceText(method(node), 'toBeNull'),
+                  fixer.remove(argument(node)),
+                ];
+              }
               return [
-                fixer.replaceText(method(node), 'toBeNull'),
-                fixer.remove(argument(node)),
+                fixer.replaceText(method2(node), 'toBeNull'),
+                fixer.remove(argument2(node)),
               ];
-            }
-            return [
-              fixer.replaceText(method2(node), 'toBeNull'),
-              fixer.remove(argument2(node)),
-            ];
-          },
-          message: 'Use toBeNull() instead',
-          node: is ? method(node) : method2(node),
-        });
-      }
-    },
-  };
+            },
+            message: 'Use toBeNull() instead',
+            node: is ? method(node) : method2(node),
+          });
+        }
+      },
+    };
+  },
 };

--- a/rules/prefer_to_be_undefined.js
+++ b/rules/prefer_to_be_undefined.js
@@ -8,33 +8,38 @@ const expectNotToEqualCase = require('./util').expectNotToEqualCase;
 const method = require('./util').method;
 const method2 = require('./util').method2;
 
-module.exports = context => {
-  return {
-    CallExpression(node) {
-      const is =
-        expectToBeCase(node, undefined) || expectToEqualCase(node, undefined);
-      const isNot =
-        expectNotToEqualCase(node, undefined) ||
-        expectNotToBeCase(node, undefined);
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const is =
+          expectToBeCase(node, undefined) || expectToEqualCase(node, undefined);
+        const isNot =
+          expectNotToEqualCase(node, undefined) ||
+          expectNotToBeCase(node, undefined);
 
-      if (is || isNot) {
-        context.report({
-          fix(fixer) {
-            if (is) {
+        if (is || isNot) {
+          context.report({
+            fix(fixer) {
+              if (is) {
+                return [
+                  fixer.replaceText(method(node), 'toBeUndefined'),
+                  fixer.remove(argument(node)),
+                ];
+              }
               return [
-                fixer.replaceText(method(node), 'toBeUndefined'),
-                fixer.remove(argument(node)),
+                fixer.replaceText(method2(node), 'toBeUndefined'),
+                fixer.remove(argument2(node)),
               ];
-            }
-            return [
-              fixer.replaceText(method2(node), 'toBeUndefined'),
-              fixer.remove(argument2(node)),
-            ];
-          },
-          message: 'Use toBeUndefined() instead',
-          node: is ? method(node) : method2(node),
-        });
-      }
-    },
-  };
+            },
+            message: 'Use toBeUndefined() instead',
+            node: is ? method(node) : method2(node),
+          });
+        }
+      },
+    };
+  },
 };

--- a/rules/prefer_to_have_length.js
+++ b/rules/prefer_to_have_length.js
@@ -5,39 +5,44 @@ const expectResolveCase = require('./util').expectResolveCase;
 const expectRejectCase = require('./util').expectRejectCase;
 const method = require('./util').method;
 
-module.exports = context => {
-  return {
-    CallExpression(node) {
-      if (
-        !(
-          expectNotCase(node) ||
-          expectResolveCase(node) ||
-          expectRejectCase(node)
-        ) &&
-        expectCase(node) &&
-        (method(node).name === 'toBe' || method(node).name === 'toEqual') &&
-        node.arguments[0].property &&
-        node.arguments[0].property.name === 'length'
-      ) {
-        const propertyDot = context
-          .getSourceCode()
-          .getFirstTokenBetween(
-            node.arguments[0].object,
-            node.arguments[0].property,
-            token => token.value === '.'
-          );
-        context.report({
-          fix(fixer) {
-            return [
-              fixer.remove(propertyDot),
-              fixer.remove(node.arguments[0].property),
-              fixer.replaceText(method(node), 'toHaveLength'),
-            ];
-          },
-          message: 'Use toHaveLength() instead',
-          node: method(node),
-        });
-      }
-    },
-  };
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          !(
+            expectNotCase(node) ||
+            expectResolveCase(node) ||
+            expectRejectCase(node)
+          ) &&
+          expectCase(node) &&
+          (method(node).name === 'toBe' || method(node).name === 'toEqual') &&
+          node.arguments[0].property &&
+          node.arguments[0].property.name === 'length'
+        ) {
+          const propertyDot = context
+            .getSourceCode()
+            .getFirstTokenBetween(
+              node.arguments[0].object,
+              node.arguments[0].property,
+              token => token.value === '.'
+            );
+          context.report({
+            fix(fixer) {
+              return [
+                fixer.remove(propertyDot),
+                fixer.remove(node.arguments[0].property),
+                fixer.replaceText(method(node), 'toHaveLength'),
+              ];
+            },
+            message: 'Use toHaveLength() instead',
+            node: method(node),
+          });
+        }
+      },
+    };
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,6 +1587,10 @@ eslint-config-prettier@^2.7.0:
   dependencies:
     get-stdin "^5.0.1"
 
+eslint-plugin-eslint-plugin@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-1.4.0.tgz#382dc6692a741a52072d5f3fff5dacdcf291ef49"
+
 eslint-plugin-prettier@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz#85cab0775c6d5e3344ef01e78d960f166fb93aae"


### PR DESCRIPTION
This PR adds [eslint-plugin-eslint-plugin](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) and its recommended configuration to this project's ESLint configuration. It has some useful rules for ESLint plugin codebases.

When adding the recommended configuration, there were three reports of this codebase violating the [require-meta-fixable](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-fixable.md) rule, which I have addressed in this PR.

In the future, I would like to include and fix the [require-meta-docs-url](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-docs-url.md) rule as well, but I wanted to see if you were open to this addition to the codebase first.

It may be easier to append `?w=1` to the URL in your browser when reviewing this PR (like [this](https://github.com/jest-community/eslint-plugin-jest/pull/59/files?w=1)), which will show the diff with whitespace ignored.