### PR TITLE
feat: add warning to describe

### DIFF
--- a/rules/__tests__/valid-describe.test.js
+++ b/rules/__tests__/valid-describe.test.js
@@ -11,7 +11,6 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('valid-describe', rules['valid-describe'], {
   valid: [
-    'describe("foo")',
     'describe("foo", function() {})',
     'describe("foo", () => {})',
     'xdescribe("foo", () => {})',
@@ -36,6 +35,31 @@ ruleTester.run('valid-describe', rules['valid-describe'], {
     `,
   ],
   invalid: [
+    {
+      code: 'describe(() => {})',
+      errors: [
+        {
+          message: 'First argument must be name',
+          line: 1,
+          column: 10,
+        },
+        {
+          message: 'Describe requires name and callback arguments',
+          line: 1,
+          column: 10,
+        },
+      ],
+    },
+    {
+      code: 'describe("foo")',
+      errors: [
+        {
+          message: 'Describe requires name and callback arguments',
+          line: 1,
+          column: 10,
+        },
+      ],
+    },
     {
       code: 'describe("foo", async () => {})',
       errors: [{ message: 'No async describe callback', line: 1, column: 17 }],

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -33,7 +33,20 @@ module.exports = {
     return {
       CallExpression(node) {
         if (isDescribe(node)) {
+          const name = node.arguments[0];
           const callbackFunction = node.arguments[1];
+          if (name.type !== 'Literal') {
+            context.report({
+              message: 'First argument must be name',
+              loc: paramsLocation(node.arguments),
+            });
+          }
+          if (callbackFunction === undefined) {
+            context.report({
+              message: 'Describe requires name and callback arguments',
+              loc: paramsLocation(node.arguments),
+            });
+          }
           if (callbackFunction && isFunction(callbackFunction)) {
             if (isAsync(callbackFunction)) {
               context.report({


### PR DESCRIPTION
Adds a warning if the callback is used as the first argument, it also adds a warning if describe is used without a name argument. Addresses #61 & #57.