### PR TITLE
fix(valid-expect): validate async expect calls

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -33,6 +33,19 @@ expect('something', 'else');
 expect('something');
 expect(true).toBeDefined;
 expect(Promise.resolve('hello')).resolves;
+
+// 👎 expect(Promise).resolves is not returned
+test('foo', () => {
+  expect(Promise.resolve('hello')).resolves.toBeDefined();
+});
+// 👎 expect(Promise).resolves is not awaited
+test('foo', async () => {
+  expect(Promise.resolve('hello')).resolves.toBeDefined();
+});
+// 👎 expect(awaited Promise) should not use .resolves or .rejects property
+test('foo', async () => {
+  expect(await Promise.resolve('hello')).resolves.toBeDefined();
+});
 ```
 
 The following patterns are not warnings:
@@ -42,4 +55,23 @@ expect('something').toEqual('something');
 expect([1, 2, 3]).toEqual([1, 2, 3]);
 expect(true).toBeDefined();
 expect(Promise.resolve('hello')).resolves.toEqual('hello');
+
+// 👍 expect(Promise).resolves is returned
+test('foo', () => {
+  return expect(Promise.resolve('hello')).resolves.toBeDefined();
+});
+// 👍 expect(Promise).resolves is awaited
+test('foo', async () => {
+  await expect(Promise.resolve('hello')).resolves.toBeDefined();
+});
+// 👍 expect(Promise).rejects is implicitly returned
+test('foo', () => expect(Promise.reject('hello')).rejects.toBeDefined());
+// 👍 expect(awaited Promise) is not used with .resolves
+test('foo', async () => {
+  expect(await Promise.resolve('hello')).toBeDefined();
+});
+// 👍 expect(awaited Promise) is not used with .rejects
+test('foo', async () => {
+  expect(await Promise.reject('hello')).toBeDefined();
+});
 ```

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
   },
   "commitlint": {
     "extends": ["@commitlint/config-conventional"]
+  },
+  "dependencies": {
+    "lodash.get": "^4.4.2"
   }
 }

--- a/rules/__tests__/valid-expect.test.js
+++ b/rules/__tests__/valid-expect.test.js
@@ -173,5 +173,19 @@ ruleTester.run('valid-expect', rule, {
         { message: "Cannot use 'rejects' with an awaited expect expression" },
       ],
     },
+    {
+      code:
+        'test("foo", async () => { expect(await Promise.resolve(undefined)).resolves.not.toBeDefined(); });',
+      errors: [
+        { message: "Cannot use 'resolves' with an awaited expect expression" },
+      ],
+    },
+    {
+      code:
+        'test("foo", async () => { expect(await Promise.reject(undefined)).rejects.not.toBeDefined(); });',
+      errors: [
+        { message: "Cannot use 'rejects' with an awaited expect expression" },
+      ],
+    },
   ],
 });

--- a/rules/__tests__/valid-expect.test.js
+++ b/rules/__tests__/valid-expect.test.js
@@ -3,7 +3,11 @@
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../valid-expect');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+});
 
 ruleTester.run('valid-expect', rule, {
   valid: [
@@ -11,8 +15,12 @@ ruleTester.run('valid-expect', rule, {
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
     'expect(undefined).not.toBeDefined();',
-    'expect(Promise.resolve(2)).resolves.toBeDefined();',
-    'expect(Promise.reject(2)).rejects.toBeDefined();',
+    'test("foo", () => { return expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+    'test("foo", async () => { await expect(Promise.reject(2)).rejects.toBeDefined(); });',
+    'test("foo", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
+    'test("foo", async () => await expect(Promise.reject(2)).rejects.toBeDefined());',
+    'test("foo", async () => { expect(await Promise.resolve(2)).toBeDefined(); });',
+    'test("foo", async () => { expect(await Promise.reject(2)).toBeDefined(); });',
   ],
 
   invalid: [
@@ -129,6 +137,40 @@ ruleTester.run('valid-expect', rule, {
           column: 14,
           message: '"not" needs to call a matcher.',
         },
+      ],
+    },
+    {
+      code:
+        'test("foo", () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      errors: [{ message: "Must return or await 'expect.resolves' statement" }],
+    },
+    {
+      code:
+        'test("foo", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      errors: [{ message: "Must await 'expect.resolves' statement" }],
+    },
+    {
+      code:
+        'test("foo", () => { expect(Promise.reject(2)).rejects.toBeDefined(); });',
+      errors: [{ message: "Must return or await 'expect.rejects' statement" }],
+    },
+    {
+      code:
+        'test("foo", async () => { expect(Promise.reject(2)).rejects.toBeDefined(); });',
+      errors: [{ message: "Must await 'expect.rejects' statement" }],
+    },
+    {
+      code:
+        'test("foo", async () => { expect(await Promise.resolve(2)).resolves.toBeDefined(); });',
+      errors: [
+        { message: "Cannot use 'resolves' with an awaited expect expression" },
+      ],
+    },
+    {
+      code:
+        'test("foo", async () => { expect(await Promise.reject(2)).rejects.toBeDefined(); });',
+      errors: [
+        { message: "Cannot use 'rejects' with an awaited expect expression" },
       ],
     },
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3660,6 +3660,10 @@ lodash.camelcase@4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.kebabcase@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"


### PR DESCRIPTION
Resolves #54 

I first tried working my way up the tree - to find a parent node of an `expect()` call that was a `ReturnStatement` or `AwaitStatement` and then finding the function that contained the `expect()` call, but I had trouble thinking through how to do that with the current `valid-expect` rule code. I ended up checking for a test case `CallExpression` and working my way down the tree - into the body of the callback function:

```js
test("foo", () => {
  // validate each `expect().resolves` and `expect().rejects` in this block
})
```

One downside is that this results in some really deeply nested property accessing (like `node.expression.callee.object.object.arguments[0].type`).

Am I approaching this the right way? Feedback is certainly welcome on how to improve this.