### PR TITLE
docs: Use link to tagged version for rule docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,13 +18,6 @@ module.exports = {
   rules: {
     eqeqeq: ['error', 'smart'],
     strict: 'error',
-    'eslint-plugin/require-meta-docs-url': [
-      'error',
-      {
-        pattern:
-          'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/{{name}}.md',
-      },
-    ],
     'node/no-unsupported-features': 'error',
     'prettier/prettier': 'error',
   },

--- a/rules/consistent-test-it.js
+++ b/rules/consistent-test-it.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
 const getNodeName = require('./util').getNodeName;
 const isTestCase = require('./util').isTestCase;
 const isDescribe = require('./util').isDescribe;
@@ -7,8 +8,7 @@ const isDescribe = require('./util').isDescribe;
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/consistent-test-it.md',
+      url: getDocsUrl('consistent-test-it.md'),
     },
     fixable: 'code',
     schema: [

--- a/rules/lowercase-name.js
+++ b/rules/lowercase-name.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 const isItTestOrDescribeFunction = node => {
   return (
     node.type === 'CallExpression' &&
@@ -48,8 +50,7 @@ const descriptionBeginsWithLowerCase = node => {
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/lowercase-name.md',
+      url: getDocsUrl('lowercase-name.md'),
     },
   },
   create(context) {

--- a/rules/no-disabled-tests.js
+++ b/rules/no-disabled-tests.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 function getName(node) {
   function joinNames(a, b) {
     return a && b ? a + '.' + b : null;
@@ -20,8 +22,7 @@ function getName(node) {
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-disabled-tests.md',
+      url: getDocsUrl('no-disabled-tests.md'),
     },
   },
   create(context) {

--- a/rules/no-focused-tests.js
+++ b/rules/no-focused-tests.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 const testFunctions = Object.assign(Object.create(null), {
   describe: true,
   it: true,
@@ -20,8 +22,7 @@ const isCallToTestOnlyFunction = callee =>
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-focused-tests.md',
+      url: getDocsUrl('no-focused-tests.md'),
     },
   },
   create: context => ({

--- a/rules/no-hooks.js
+++ b/rules/no-hooks.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-hooks.md',
+      url: getDocsUrl('no-hooks.md'),
     },
   },
   schema: [

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
 const isDescribe = require('./util').isDescribe;
 const isTestCase = require('./util').isTestCase;
 
@@ -39,8 +40,7 @@ const isFirstArgLiteral = node =>
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-identical-title.md',
+      url: getDocsUrl('no-identical-title.md'),
     },
   },
   create(context) {

--- a/rules/no-large-snapshots.js
+++ b/rules/no-large-snapshots.js
@@ -1,10 +1,11 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md',
+      url: getDocsUrl('no-large-snapshots.md'),
     },
   },
   create(context) {

--- a/rules/no-test-prefixes.js
+++ b/rules/no-test-prefixes.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
 const getNodeName = require('./util').getNodeName;
 const isTestCase = require('./util').isTestCase;
 const isDescribe = require('./util').isDescribe;
@@ -7,8 +8,7 @@ const isDescribe = require('./util').isDescribe;
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-test-prefixes.md',
+      url: getDocsUrl('no-test-prefixes.md'),
     },
     fixable: 'code',
   },

--- a/rules/prefer-expect-assertions.js
+++ b/rules/prefer-expect-assertions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 const ruleMsg =
   'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';
 
@@ -63,8 +65,7 @@ const reportMsg = (context, node) => {
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-expect-assertions.md',
+      url: getDocsUrl('prefer-expect-assertions.md'),
     },
   },
   create(context) {

--- a/rules/prefer-to-be-null.js
+++ b/rules/prefer-to-be-null.js
@@ -1,4 +1,6 @@
 'use strict';
+
+const getDocsUrl = require('./util').getDocsUrl;
 const argument = require('./util').argument;
 const argument2 = require('./util').argument2;
 const expectToBeCase = require('./util').expectToBeCase;
@@ -11,8 +13,7 @@ const method2 = require('./util').method2;
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-null.md',
+      url: getDocsUrl('prefer-to-be-null.md'),
     },
     fixable: 'code',
   },

--- a/rules/prefer-to-be-undefined.js
+++ b/rules/prefer-to-be-undefined.js
@@ -5,14 +5,14 @@ const expectToBeCase = require('./util').expectToBeCase;
 const expectNotToBeCase = require('./util').expectNotToBeCase;
 const expectToEqualCase = require('./util').expectToEqualCase;
 const expectNotToEqualCase = require('./util').expectNotToEqualCase;
+const getDocsUrl = require('./util').getDocsUrl;
 const method = require('./util').method;
 const method2 = require('./util').method2;
 
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-be-undefined.md',
+      url: getDocsUrl('prefer-to-be-undefined.md'),
     },
     fixable: 'code',
   },

--- a/rules/prefer-to-have-length.js
+++ b/rules/prefer-to-have-length.js
@@ -1,4 +1,6 @@
 'use strict';
+
+const getDocsUrl = require('./util').getDocsUrl;
 const expectCase = require('./util').expectCase;
 const expectNotCase = require('./util').expectNotCase;
 const expectResolveCase = require('./util').expectResolveCase;
@@ -8,8 +10,7 @@ const method = require('./util').method;
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/prefer-to-have-length.md',
+      url: getDocsUrl('prefer-to-have-length.md'),
     },
     fixable: 'code',
   },

--- a/rules/util.js
+++ b/rules/util.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const pkg = require('../package');
+const pkg = require('../package.json');
 
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 

--- a/rules/util.js
+++ b/rules/util.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const pkg = require('../package');
+
+const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
+
 const expectCase = node =>
   node.callee.name === 'expect' &&
   node.arguments.length === 1 &&
@@ -118,6 +122,17 @@ const isDescribe = node =>
 const isFunction = node =>
   node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
 
+/**
+ * Generates the URL to documentation for the given rule name. It uses the
+ * package version to build the link to a tagged version of the
+ * documentation file.
+ *
+ * @param {string} ruleName - Name of the eslint rule
+ * @returns {string} URL to the documentation for the given rule
+ */
+const getDocsUrl = ruleName =>
+  `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`;
+
 module.exports = {
   method: method,
   method2: method2,
@@ -137,4 +152,5 @@ module.exports = {
   isDescribe: isDescribe,
   isFunction: isFunction,
   isTestCase: isTestCase,
+  getDocsUrl: getDocsUrl,
 };

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
 const isDescribe = require('./util').isDescribe;
 const isFunction = require('./util').isFunction;
 
@@ -29,8 +30,7 @@ const paramsLocation = params => {
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-describe.md',
+      url: getDocsUrl('valid-describe.md'),
     },
   },
   create(context) {

--- a/rules/valid-expect-in-promise.js
+++ b/rules/valid-expect-in-promise.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const getDocsUrl = require('./util').getDocsUrl;
 const isFunction = require('./util').isFunction;
 
 const reportMsg =
@@ -127,8 +128,7 @@ const isHavingAsyncCallBackParam = testFunction => {
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect-in-promise.md',
+      url: getDocsUrl('valid-expect-in-promise.md'),
     },
   },
   create(context) {

--- a/rules/valid-expect.js
+++ b/rules/valid-expect.js
@@ -5,13 +5,14 @@
  * MIT license, Tom Vincent.
  */
 
+const getDocsUrl = require('./util').getDocsUrl;
+
 const expectProperties = ['not', 'resolves', 'rejects'];
 
 module.exports = {
   meta: {
     docs: {
-      url:
-        'https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-expect.md',
+      url: getDocsUrl('valid-expect.md'),
     },
   },
   create(context) {


### PR DESCRIPTION
This adds a utility function and uses the version present in package.json for generating the URL to tagged version of the rule documentation. I think this is good because the documentation will match the version the user has installed. This way, even if a rule is changed or removed in the future, the user can find the documentation with ease.

Note: The rule `eslint-plugin/require-meta-docs-url` cannot be used with a function which would return the URL(see [not-an-aardvark/eslint-plugin-eslint-plugin#58](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/58)) so I have disabled it.