### PR TITLE
docs: Improve docs URL resolution

### DIFF
--- a/rules/consistent-test-it.js
+++ b/rules/consistent-test-it.js
@@ -8,7 +8,7 @@ const isDescribe = require('./util').isDescribe;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('consistent-test-it.md'),
+      url: getDocsUrl(__filename),
     },
     fixable: 'code',
     schema: [

--- a/rules/lowercase-name.js
+++ b/rules/lowercase-name.js
@@ -50,7 +50,7 @@ const descriptionBeginsWithLowerCase = node => {
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('lowercase-name.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/no-disabled-tests.js
+++ b/rules/no-disabled-tests.js
@@ -22,7 +22,7 @@ function getName(node) {
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('no-disabled-tests.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/no-focused-tests.js
+++ b/rules/no-focused-tests.js
@@ -22,7 +22,7 @@ const isCallToTestOnlyFunction = callee =>
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('no-focused-tests.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create: context => ({

--- a/rules/no-hooks.js
+++ b/rules/no-hooks.js
@@ -5,7 +5,7 @@ const getDocsUrl = require('./util').getDocsUrl;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('no-hooks.md'),
+      url: getDocsUrl(__filename),
     },
   },
   schema: [

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -40,7 +40,7 @@ const isFirstArgLiteral = node =>
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('no-identical-title.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/no-large-snapshots.js
+++ b/rules/no-large-snapshots.js
@@ -5,7 +5,7 @@ const getDocsUrl = require('./util').getDocsUrl;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('no-large-snapshots.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/no-test-prefixes.js
+++ b/rules/no-test-prefixes.js
@@ -8,7 +8,7 @@ const isDescribe = require('./util').isDescribe;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('no-test-prefixes.md'),
+      url: getDocsUrl(__filename),
     },
     fixable: 'code',
   },

--- a/rules/prefer-expect-assertions.js
+++ b/rules/prefer-expect-assertions.js
@@ -65,7 +65,7 @@ const reportMsg = (context, node) => {
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('prefer-expect-assertions.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/prefer-to-be-null.js
+++ b/rules/prefer-to-be-null.js
@@ -13,7 +13,7 @@ const method2 = require('./util').method2;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('prefer-to-be-null.md'),
+      url: getDocsUrl(__filename),
     },
     fixable: 'code',
   },

--- a/rules/prefer-to-be-undefined.js
+++ b/rules/prefer-to-be-undefined.js
@@ -12,7 +12,7 @@ const method2 = require('./util').method2;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('prefer-to-be-undefined.md'),
+      url: getDocsUrl(__filename),
     },
     fixable: 'code',
   },

--- a/rules/prefer-to-have-length.js
+++ b/rules/prefer-to-have-length.js
@@ -10,7 +10,7 @@ const method = require('./util').method;
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('prefer-to-have-length.md'),
+      url: getDocsUrl(__filename),
     },
     fixable: 'code',
   },

--- a/rules/util.js
+++ b/rules/util.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const pkg = require('../package.json');
 
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
@@ -129,9 +131,18 @@ const isFunction = node =>
  *
  * @param {string} ruleName - Name of the eslint rule
  * @returns {string} URL to the documentation for the given rule
+ * @throws {Error} If the documentation file for the given rule is not present.
  */
-const getDocsUrl = ruleName =>
-  `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`;
+const getDocsUrl = filename => {
+  const ruleName = path.basename(filename, '.js');
+
+  const docsFile = path.join(__dirname, `../docs/rules/${ruleName}.md`);
+  if (!fs.existsSync(docsFile)) {
+    throw new Error(`Could not find documentation file for rule "${ruleName}"`);
+  }
+
+  return `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`;
+};
 
 module.exports = {
   method: method,

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -30,7 +30,7 @@ const paramsLocation = params => {
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('valid-describe.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/valid-expect-in-promise.js
+++ b/rules/valid-expect-in-promise.js
@@ -128,7 +128,7 @@ const isHavingAsyncCallBackParam = testFunction => {
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('valid-expect-in-promise.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {

--- a/rules/valid-expect.js
+++ b/rules/valid-expect.js
@@ -12,7 +12,7 @@ const expectProperties = ['not', 'resolves', 'rejects'];
 module.exports = {
   meta: {
     docs: {
-      url: getDocsUrl('valid-expect.md'),
+      url: getDocsUrl(__filename),
     },
   },
   create(context) {


### PR DESCRIPTION
- Use `__filename` to determine the rule name and build the docs link. This also fixes an inadvertent bug where the URL ended with `.md.md`(ex: `https://github.com/jest-community/eslint-plugin-jest/blob/v0.0.0-development/docs/rules/valid-expect.md.md` for `valid-expect`).
- Check the docs file exists and throw an error otherwise.