### PR TITLE
style: tweak eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,8 @@ module.exports = {
   rules: {
     eqeqeq: ['error', 'smart'],
     strict: 'error',
+    'prefer-template': 'warn',
+    'object-shorthand': ['warn', 'always', { avoidExplicitReturnArrows: true }],
     'node/no-unsupported-features': 'error',
     'prettier/prettier': 'error',
   },

--- a/rules/lowercase-name.js
+++ b/rules/lowercase-name.js
@@ -62,7 +62,7 @@ module.exports = {
           context.report({
             message: '`{{ method }}`s should begin with lowercase',
             data: { method: erroneousMethod },
-            node: node,
+            node,
           });
         }
       },

--- a/rules/no-disabled-tests.js
+++ b/rules/no-disabled-tests.js
@@ -4,7 +4,7 @@ const getDocsUrl = require('./util').getDocsUrl;
 
 function getName(node) {
   function joinNames(a, b) {
-    return a && b ? a + '.' + b : null;
+    return a && b ? `${a}.${b}` : null;
   }
 
   switch (node && node.type) {
@@ -30,7 +30,7 @@ module.exports = {
     let testDepth = 0;
 
     return {
-      CallExpression: node => {
+      CallExpression(node) {
         const functionName = getName(node.callee);
 
         switch (functionName) {
@@ -83,7 +83,7 @@ module.exports = {
         }
       },
 
-      'CallExpression:exit': node => {
+      'CallExpression:exit'(node) {
         const functionName = getName(node.callee);
 
         switch (functionName) {

--- a/rules/no-large-snapshots.js
+++ b/rules/no-large-snapshots.js
@@ -14,7 +14,7 @@ module.exports = {
         (context.options[0] && context.options[0].maxSize) || 50;
 
       return {
-        ExpressionStatement: node => {
+        ExpressionStatement(node) {
           const startLine = node.loc.start.line;
           const endLine = node.loc.end.line;
           const lineCount = endLine - startLine;

--- a/rules/no-test-prefixes.js
+++ b/rules/no-test-prefixes.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   create(context) {
     return {
-      CallExpression: node => {
+      CallExpression(node) {
         const nodeName = getNodeName(node.callee);
 
         if (!isDescribe(node) && !isTestCase(node)) return;
@@ -40,10 +40,10 @@ function getPreferredNodeName(nodeName) {
   const firstChar = nodeName.charAt(0);
 
   if (firstChar === 'f') {
-    return nodeName.slice(1) + '.only';
+    return `${nodeName.slice(1)}.only`;
   }
 
   if (firstChar === 'x') {
-    return nodeName.slice(1) + '.skip';
+    return `${nodeName.slice(1)}.skip`;
   }
 }

--- a/rules/util.js
+++ b/rules/util.js
@@ -108,7 +108,7 @@ const testCaseNames = Object.assign(Object.create(null), {
 
 const getNodeName = node => {
   if (node.type === 'MemberExpression') {
-    return node.object.name + '.' + node.property.name;
+    return `${node.object.name}.${node.property.name}`;
   }
   return node.name;
 };
@@ -145,23 +145,23 @@ const getDocsUrl = filename => {
 };
 
 module.exports = {
-  method: method,
-  method2: method2,
-  argument: argument,
-  argument2: argument2,
-  expectCase: expectCase,
-  expectNotCase: expectNotCase,
-  expectResolveCase: expectResolveCase,
-  expectRejectCase: expectRejectCase,
-  expectToBeCase: expectToBeCase,
-  expectNotToBeCase: expectNotToBeCase,
-  expectToEqualCase: expectToEqualCase,
-  expectNotToEqualCase: expectNotToEqualCase,
-  expectToBeUndefinedCase: expectToBeUndefinedCase,
-  expectNotToBeUndefinedCase: expectNotToBeUndefinedCase,
-  getNodeName: getNodeName,
-  isDescribe: isDescribe,
-  isFunction: isFunction,
-  isTestCase: isTestCase,
-  getDocsUrl: getDocsUrl,
+  method,
+  method2,
+  argument,
+  argument2,
+  expectCase,
+  expectNotCase,
+  expectResolveCase,
+  expectRejectCase,
+  expectToBeCase,
+  expectNotToBeCase,
+  expectToEqualCase,
+  expectNotToEqualCase,
+  expectToBeUndefinedCase,
+  expectNotToBeUndefinedCase,
+  getNodeName,
+  isDescribe,
+  isFunction,
+  isTestCase,
+  getDocsUrl,
 };

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -68,7 +68,7 @@ module.exports = {
               if (node.type === 'ReturnStatement') {
                 context.report({
                   message: 'Unexpected return statement in describe callback',
-                  node: node,
+                  node,
                 });
               }
             });


### PR DESCRIPTION
This enables eslint rules `prefer-template` and `object-shorthand`. This improves readability, _in my opinion_ so I can understand if you do not want to merge it in.