### PR TITLE
refactor: require rule file in tests

### DIFF
--- a/rules/__tests__/consistent-test-it.test.js
+++ b/rules/__tests__/consistent-test-it.test.js
@@ -1,14 +1,15 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../consistent-test-it');
+
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,
   },
 });
 
-ruleTester.run('consistent-test-it with fn=test', rules['consistent-test-it'], {
+ruleTester.run('consistent-test-it with fn=test', rule, {
   valid: [
     {
       code: 'test("foo")',
@@ -73,7 +74,7 @@ ruleTester.run('consistent-test-it with fn=test', rules['consistent-test-it'], {
   ],
 });
 
-ruleTester.run('consistent-test-it with fn=it', rules['consistent-test-it'], {
+ruleTester.run('consistent-test-it with fn=it', rule, {
   valid: [
     {
       code: 'it("foo")',
@@ -136,135 +137,127 @@ ruleTester.run('consistent-test-it with fn=it', rules['consistent-test-it'], {
   ],
 });
 
-ruleTester.run(
-  'consistent-test-it with fn=test and withinDescribe=it ',
-  rules['consistent-test-it'],
-  {
-    valid: [
-      {
-        code: 'test("foo")',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-      },
-      {
-        code: 'test.only("foo")',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-      },
-      {
-        code: 'test.skip("foo")',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-      },
-      {
-        code: 'xtest("foo")',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-      },
-      {
-        code: '[1,2,3].forEach(() => { test("foo") })',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-      },
-    ],
-    invalid: [
-      {
-        code: 'describe("suite", () => { test("foo") })',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { it("foo") })',
-      },
-      {
-        code: 'describe("suite", () => { test.only("foo") })',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { it.only("foo") })',
-      },
-      {
-        code: 'describe("suite", () => { xtest("foo") })',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { xit("foo") })',
-      },
-      {
-        code: 'describe("suite", () => { test.skip("foo") })',
-        options: [{ fn: 'test', withinDescribe: 'it' }],
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { it.skip("foo") })',
-      },
-    ],
-  }
-);
+ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: 'test.only("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: 'test.skip("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: 'xtest("foo")',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+    {
+      code: '[1,2,3].forEach(() => { test("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { test.only("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it.only("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { xtest("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { xit("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { test.skip("foo") })',
+      options: [{ fn: 'test', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it.skip("foo") })',
+    },
+  ],
+});
 
-ruleTester.run(
-  'consistent-test-it with fn=it and withinDescribe=test ',
-  rules['consistent-test-it'],
-  {
-    valid: [
-      {
-        code: 'it("foo")',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-      },
-      {
-        code: 'it.only("foo")',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-      },
-      {
-        code: 'it.skip("foo")',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-      },
-      {
-        code: 'xit("foo")',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-      },
-      {
-        code: '[1,2,3].forEach(() => { it("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-      },
-    ],
-    invalid: [
-      {
-        code: 'describe("suite", () => { it("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-        errors: [
-          { message: "Prefer using 'test' instead of 'it' within describe" },
-        ],
-        output: 'describe("suite", () => { test("foo") })',
-      },
-      {
-        code: 'describe("suite", () => { it.only("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-        errors: [
-          { message: "Prefer using 'test' instead of 'it' within describe" },
-        ],
-        output: 'describe("suite", () => { test.only("foo") })',
-      },
-      {
-        code: 'describe("suite", () => { xit("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-        errors: [
-          { message: "Prefer using 'test' instead of 'it' within describe" },
-        ],
-        output: 'describe("suite", () => { xtest("foo") })',
-      },
-      {
-        code: 'describe("suite", () => { it.skip("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'test' }],
-        errors: [
-          { message: "Prefer using 'test' instead of 'it' within describe" },
-        ],
-        output: 'describe("suite", () => { test.skip("foo") })',
-      },
-    ],
-  }
-);
+ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
+  valid: [
+    {
+      code: 'it("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: 'it.only("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: 'it.skip("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: 'xit("foo")',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+    {
+      code: '[1,2,3].forEach(() => { it("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { it.only("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test.only("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { xit("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { xtest("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { it.skip("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test.skip("foo") })',
+    },
+  ],
+});
 
 ruleTester.run(
   'consistent-test-it with fn=test and withinDescribe=test ',
-  rules['consistent-test-it'],
+  rule,
   {
     valid: [
       {
@@ -295,122 +288,106 @@ ruleTester.run(
   }
 );
 
-ruleTester.run(
-  'consistent-test-it with fn=it and withinDescribe=it ',
-  rules['consistent-test-it'],
-  {
-    valid: [
-      {
-        code: 'describe("suite", () => { it("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'it' }],
-      },
-      {
-        code: 'it("foo")',
-        options: [{ fn: 'it', withinDescribe: 'it' }],
-      },
-    ],
-    invalid: [
-      {
-        code: 'describe("suite", () => { test("foo") })',
-        options: [{ fn: 'it', withinDescribe: 'it' }],
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { it("foo") })',
-      },
-      {
-        code: 'test("foo")',
-        options: [{ fn: 'it', withinDescribe: 'it' }],
-        errors: [{ message: "Prefer using 'it' instead of 'test'" }],
-        output: 'it("foo")',
-      },
-    ],
-  }
-);
+ruleTester.run('consistent-test-it with fn=it and withinDescribe=it ', rule, {
+  valid: [
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+    },
+    {
+      code: 'it("foo")',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+    {
+      code: 'test("foo")',
+      options: [{ fn: 'it', withinDescribe: 'it' }],
+      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      output: 'it("foo")',
+    },
+  ],
+});
 
-ruleTester.run(
-  'consistent-test-it defaults without config object',
-  rules['consistent-test-it'],
-  {
-    valid: [
-      {
-        code: 'test("foo")',
-      },
-    ],
-    invalid: [
-      {
-        code: 'describe("suite", () => { test("foo") })',
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { it("foo") })',
-      },
-    ],
-  }
-);
+ruleTester.run('consistent-test-it defaults without config object', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+    },
+  ],
+  invalid: [
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+  ],
+});
 
-ruleTester.run(
-  'consistent-test-it with withinDescribe=it',
-  rules['consistent-test-it'],
-  {
-    valid: [
-      {
-        code: 'test("foo")',
-        options: [{ withinDescribe: 'it' }],
-      },
-      {
-        code: 'describe("suite", () => { it("foo") })',
-        options: [{ withinDescribe: 'it' }],
-      },
-    ],
-    invalid: [
-      {
-        code: 'it("foo")',
-        options: [{ withinDescribe: 'it' }],
-        errors: [{ message: "Prefer using 'test' instead of 'it'" }],
-        output: 'test("foo")',
-      },
-      {
-        code: 'describe("suite", () => { test("foo") })',
-        options: [{ withinDescribe: 'it' }],
-        errors: [
-          { message: "Prefer using 'it' instead of 'test' within describe" },
-        ],
-        output: 'describe("suite", () => { it("foo") })',
-      },
-    ],
-  }
-);
+ruleTester.run('consistent-test-it with withinDescribe=it', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ withinDescribe: 'it' }],
+    },
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ withinDescribe: 'it' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'it("foo")',
+      options: [{ withinDescribe: 'it' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test("foo")',
+    },
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ withinDescribe: 'it' }],
+      errors: [
+        { message: "Prefer using 'it' instead of 'test' within describe" },
+      ],
+      output: 'describe("suite", () => { it("foo") })',
+    },
+  ],
+});
 
-ruleTester.run(
-  'consistent-test-it with withinDescribe=test',
-  rules['consistent-test-it'],
-  {
-    valid: [
-      {
-        code: 'test("foo")',
-        options: [{ withinDescribe: 'test' }],
-      },
-      {
-        code: 'describe("suite", () => { test("foo") })',
-        options: [{ withinDescribe: 'test' }],
-      },
-    ],
-    invalid: [
-      {
-        code: 'it("foo")',
-        options: [{ withinDescribe: 'test' }],
-        errors: [{ message: "Prefer using 'test' instead of 'it'" }],
-        output: 'test("foo")',
-      },
-      {
-        code: 'describe("suite", () => { it("foo") })',
-        options: [{ withinDescribe: 'test' }],
-        errors: [
-          { message: "Prefer using 'test' instead of 'it' within describe" },
-        ],
-        output: 'describe("suite", () => { test("foo") })',
-      },
-    ],
-  }
-);
+ruleTester.run('consistent-test-it with withinDescribe=test', rule, {
+  valid: [
+    {
+      code: 'test("foo")',
+      options: [{ withinDescribe: 'test' }],
+    },
+    {
+      code: 'describe("suite", () => { test("foo") })',
+      options: [{ withinDescribe: 'test' }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'it("foo")',
+      options: [{ withinDescribe: 'test' }],
+      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      output: 'test("foo")',
+    },
+    {
+      code: 'describe("suite", () => { it("foo") })',
+      options: [{ withinDescribe: 'test' }],
+      errors: [
+        { message: "Prefer using 'test' instead of 'it' within describe" },
+      ],
+      output: 'describe("suite", () => { test("foo") })',
+    },
+  ],
+});

--- a/rules/__tests__/lowercase-name.test.js
+++ b/rules/__tests__/lowercase-name.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../lowercase-name');
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -9,7 +9,7 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run('lowercase-name', rules['lowercase-name'], {
+ruleTester.run('lowercase-name', rule, {
   valid: [
     "it(' ', function () {})",
     'it(" ", function () {})',

--- a/rules/__tests__/no-disabled-tests.test.js
+++ b/rules/__tests__/no-disabled-tests.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../no-disabled-tests');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('no-disabled-tests', rules['no-disabled-tests'], {
+ruleTester.run('no-disabled-tests', rule, {
   valid: [
     'describe("foo", function () {})',
     'it("foo", function () {})',

--- a/rules/__tests__/no-focused-tests.test.js
+++ b/rules/__tests__/no-focused-tests.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../no-focused-tests');
 
 const ruleTester = new RuleTester();
 const expectedErrorMessage = 'Unexpected focused test.';
 
-ruleTester.run('no-focused-tests', rules['no-focused-tests'], {
+ruleTester.run('no-focused-tests', rule, {
   valid: [
     'describe()',
     'it()',

--- a/rules/__tests__/no-hooks.test.js
+++ b/rules/__tests__/no-hooks.test.js
@@ -1,14 +1,15 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../no-hooks');
+
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,
   },
 });
 
-ruleTester.run('no-hooks', rules['no-hooks'], {
+ruleTester.run('no-hooks', rule, {
   valid: [
     'test("foo")',
     'describe("foo", () => { it("bar") })',

--- a/rules/__tests__/no-identical-title.test.js
+++ b/rules/__tests__/no-identical-title.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../no-identical-title');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('no-identical-title', rules['no-identical-title'], {
+ruleTester.run('no-identical-title', rule, {
   valid: [
     [
       'describe("describe", function() {',

--- a/rules/__tests__/no-test-prefixes.test.js
+++ b/rules/__tests__/no-test-prefixes.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../no-test-prefixes');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('no-test-prefixes', rules['no-test-prefixes'], {
+ruleTester.run('no-test-prefixes', rule, {
   valid: [
     'describe("foo", function () {})',
     'it("foo", function () {})',

--- a/rules/__tests__/prefer-expect-assertions.test.js
+++ b/rules/__tests__/prefer-expect-assertions.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../prefer-expect-assertions');
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -12,7 +12,7 @@ const ruleTester = new RuleTester({
 const expectedMsg =
   'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';
 
-ruleTester.run('prefer-expect-assertions', rules['prefer-expect-assertions'], {
+ruleTester.run('prefer-expect-assertions', rule, {
   invalid: [
     {
       code: 'it("it1", () => {})',

--- a/rules/__tests__/prefer-to-be-null.test.js
+++ b/rules/__tests__/prefer-to-be-null.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../../').rules;
+const rule = require('../prefer-to-be-null');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('prefer_to_be_null', rules['prefer-to-be-null'], {
+ruleTester.run('prefer-to-be-null', rule, {
   valid: [
     'expect(null).toBeNull();',
     'expect(null).toEqual();',

--- a/rules/__tests__/prefer-to-be-undefined.test.js
+++ b/rules/__tests__/prefer-to-be-undefined.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../../').rules;
+const rule = require('../prefer-to-be-undefined');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('prefer_to_be_undefined', rules['prefer-to-be-undefined'], {
+ruleTester.run('prefer-to-be-undefined', rule, {
   valid: [
     'expect(undefined).toBeUndefined();',
     'expect(true).not.toBeUndefined();',

--- a/rules/__tests__/prefer-to-have-length.test.js
+++ b/rules/__tests__/prefer-to-have-length.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../prefer-to-have-length');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('prefer_to_have_length', rules['prefer-to-have-length'], {
+ruleTester.run('prefer-to-have-length', rule, {
   valid: [
     'expect(files).toHaveLength(1);',
     "expect(files.name).toBe('file');",

--- a/rules/__tests__/valid-describe.test.js
+++ b/rules/__tests__/valid-describe.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../valid-describe');
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -9,7 +9,7 @@ const ruleTester = new RuleTester({
   },
 });
 
-ruleTester.run('valid-describe', rules['valid-describe'], {
+ruleTester.run('valid-describe', rule, {
   valid: [
     'describe("foo", function() {})',
     'describe("foo", () => {})',

--- a/rules/__tests__/valid-expect-in-promise.test.js
+++ b/rules/__tests__/valid-expect-in-promise.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../valid-expect-in-promise');
 
 const ruleTester = new RuleTester({
   parserOptions: {
@@ -12,7 +12,7 @@ const ruleTester = new RuleTester({
 const expectedMsg =
   'Promise should be returned to test its fulfillment or rejection';
 
-ruleTester.run('valid-expect-in-promise', rules['valid-expect-in-promise'], {
+ruleTester.run('valid-expect-in-promise', rule, {
   invalid: [
     {
       code: `

--- a/rules/__tests__/valid-expect.test.js
+++ b/rules/__tests__/valid-expect.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const RuleTester = require('eslint').RuleTester;
-const rules = require('../..').rules;
+const rule = require('../valid-expect');
 
 const ruleTester = new RuleTester();
 
-ruleTester.run('valid-expect', rules['valid-expect'], {
+ruleTester.run('valid-expect', rule, {
   valid: [
     'expect("something").toEqual("else");',
     'expect(true).toBeDefined();',


### PR DESCRIPTION
This is a follow-up to the PR comment in #82 and https://github.com/jest-community/eslint-plugin-jest/pull/82#issuecomment-366438570.

The goal of this PR is that moving forward, when you modify one rule and run `yarn test --watch`, the Jest test runner will only test and lint the modified file instead of all rules (since we were previously requiring all rules in each test).