### PR TITLE
feat: adds no jest import rule

### DIFF
--- a/docs/rules/no-jest-import.md
+++ b/docs/rules/no-jest-import.md
@@ -1,0 +1,20 @@
+# Disallow importing Jest(no-jest-import)
+
+The jest object is automatically in scope within every test file. The methods in
+the jest object help create mocks and let you control Jest's overall behavior.
+It is therefore completely unnecessary to import in Jest, as Jest doesn't export
+anything in the first place.
+
+### Rule details
+
+This rule reports on any importing of Jest.
+
+To name a few: *var jest = require('jest'); *const jest = require('jest');
+*import jest from 'jest'; *import {jest as test} from 'jest';
+
+There is no correct usage of this code, other than to not import Jest it in the
+first place.
+
+## Further Reading
+
+\*[The Jest Object](https://facebook.github.io/jest/docs/en/jest-object.html)

--- a/docs/rules/no-jest-import.md
+++ b/docs/rules/no-jest-import.md
@@ -1,18 +1,18 @@
 # Disallow importing Jest(no-jest-import)
 
-The jest object is automatically in scope within every test file. The methods in
-the jest object help create mocks and let you control Jest's overall behavior.
-It is therefore completely unnecessary to import in Jest, as Jest doesn't export
-anything in the first place.
+The `jest` object is automatically in scope within every test file. The methods
+in the `jest` object help create mocks and let you control Jest's overall
+behavior. It is therefore completely unnecessary to import in `jest`, as Jest
+doesn't export anything in the first place.
 
 ### Rule details
 
 This rule reports on any importing of Jest.
 
-To name a few: *var jest = require('jest'); *const jest = require('jest');
-*import jest from 'jest'; *import {jest as test} from 'jest';
+To name a few: `var jest = require('jest');` `const jest = require('jest');`
+`import jest from 'jest';` `import {jest as test} from 'jest';`
 
-There is no correct usage of this code, other than to not import Jest it in the
+There is no correct usage of this code, other than to not import `jest` in the
 first place.
 
 ## Further Reading

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ module.exports = {
         'jest/no-disabled-tests': 'warn',
         'jest/no-focused-tests': 'error',
         'jest/no-identical-title': 'error',
-        'jest/no-jest-import': 'error',
         'jest/prefer-to-have-length': 'warn',
         'jest/valid-expect': 'error',
       },

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const noDisabledTests = require('./rules/no-disabled-tests');
 const noFocusedTests = require('./rules/no-focused-tests');
 const noHooks = require('./rules/no-hooks');
 const noIdenticalTitle = require('./rules/no-identical-title');
+const noJestImport = require('./rules/no-jest-import');
 const noLargeSnapshots = require('./rules/no-large-snapshots');
 const noTestPrefixes = require('./rules/no-test-prefixes');
 const preferToBeNull = require('./rules/prefer-to-be-null');
@@ -29,6 +30,7 @@ module.exports = {
         'jest/no-disabled-tests': 'warn',
         'jest/no-focused-tests': 'error',
         'jest/no-identical-title': 'error',
+        'jest/no-jest-import': 'error',
         'jest/prefer-to-have-length': 'warn',
         'jest/valid-expect': 'error',
       },
@@ -67,6 +69,7 @@ module.exports = {
     'no-focused-tests': noFocusedTests,
     'no-hooks': noHooks,
     'no-identical-title': noIdenticalTitle,
+    'no-jest-import': noJestImport,
     'no-large-snapshots': noLargeSnapshots,
     'no-test-prefixes': noTestPrefixes,
     'prefer-to-be-null': preferToBeNull,

--- a/rules/__tests__/no-jest-import.test.js
+++ b/rules/__tests__/no-jest-import.test.js
@@ -3,6 +3,7 @@
 const rule = require('../no-jest-import.js');
 const RuleTester = require('eslint').RuleTester;
 const ruleTester = new RuleTester();
+const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
 
 ruleTester.run('no-jest-import', rule, {
   valid: [
@@ -20,7 +21,7 @@ ruleTester.run('no-jest-import', rule, {
         {
           endColumn: 15,
           column: 9,
-          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          message,
         },
       ],
     },
@@ -31,7 +32,7 @@ ruleTester.run('no-jest-import', rule, {
         {
           endColumn: 24,
           column: 1,
-          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          message,
         },
       ],
     },
@@ -41,7 +42,7 @@ ruleTester.run('no-jest-import', rule, {
         {
           endColumn: 26,
           column: 20,
-          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          message,
         },
       ],
     },
@@ -52,7 +53,7 @@ ruleTester.run('no-jest-import', rule, {
         {
           endColumn: 34,
           column: 1,
-          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          message,
         },
       ],
     },
@@ -63,7 +64,7 @@ ruleTester.run('no-jest-import', rule, {
         {
           endColumn: 28,
           column: 22,
-          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          message,
         },
       ],
     },

--- a/rules/__tests__/no-jest-import.test.js
+++ b/rules/__tests__/no-jest-import.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const rule = require('../no-jest-import.js');
+const RuleTester = require('eslint').RuleTester;
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-jest-import', rule, {
+  valid: [
+    {
+      code: 'import something from "something"',
+      parserOptions: { sourceType: 'module' },
+    },
+    'require("somethingElse")',
+    'entirelyDifferent(fn)',
+  ],
+  invalid: [
+    {
+      code: 'require("jest")',
+      errors: [
+        {
+          endColumn: 15,
+          column: 9,
+          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+        },
+      ],
+    },
+    {
+      code: 'import jest from "jest"',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 24,
+          column: 1,
+          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+        },
+      ],
+    },
+    {
+      code: 'var jest = require("jest")',
+      errors: [
+        {
+          endColumn: 26,
+          column: 20,
+          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+        },
+      ],
+    },
+    {
+      code: 'import {jest as test} from "jest"',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 34,
+          column: 1,
+          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+        },
+      ],
+    },
+    {
+      code: 'const jest = require("jest")',
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 28,
+          column: 22,
+          message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+        },
+      ],
+    },
+  ],
+});

--- a/rules/no-jest-import.js
+++ b/rules/no-jest-import.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const getDocsUrl = require('./util').getDocsUrl;
+const getNodeName = require('./util').getNodeName;
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'jest') {
+          context.report({
+            node,
+            message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          });
+        }
+      },
+      CallExpression(node) {
+        const calleeName = getNodeName(node.callee);
+        if (calleeName === 'require' && node.arguments[0].value === 'jest') {
+          context.report({
+            loc: {
+              end: {
+                column: node.arguments[0].loc.end.column,
+                line: node.arguments[0].loc.end.line,
+              },
+              start: node.arguments[0].loc.start,
+            },
+            message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+          });
+        }
+      },
+    };
+  },
+};

--- a/rules/no-jest-import.js
+++ b/rules/no-jest-import.js
@@ -2,6 +2,7 @@
 
 const getDocsUrl = require('./util').getDocsUrl;
 const getNodeName = require('./util').getNodeName;
+const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
 
 module.exports = {
   meta: {
@@ -15,7 +16,7 @@ module.exports = {
         if (node.source.value === 'jest') {
           context.report({
             node,
-            message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+            message,
           });
         }
       },
@@ -30,7 +31,7 @@ module.exports = {
               },
               start: node.arguments[0].loc.start,
             },
-            message: `Jest is automatically in scope. Do not import Jest, as it doesn't export anything.`,
+            message,
           });
         }
       },


### PR DESCRIPTION
Closes #90.

Adds the eslint rule 'no-jest-import', disallowing any import from Jest.

Adds tests and documentation for rule.