### PR TITLE
fix(util): add a test instead of throwing an error on getDocsUrl

### DIFF
--- a/__tests__/rules.test.js
+++ b/__tests__/rules.test.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const rules = require('../index').rules;
+
+describe('rules', () => {
+  it('should have a corresponding doc for each rule', () => {
+    Object.keys(rules).forEach(rule => {
+      const docPath = path.join(__dirname, '..', 'docs', 'rules', `${rule}.md`);
+
+      if (!fs.existsSync(docPath)) {
+        throw new Error(
+          `Could not find documentation file for rule "${rule}" in path "${docPath}"`
+        );
+      }
+    });
+  });
+});

--- a/rules/util.js
+++ b/rules/util.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
-const pkg = require('../package.json');
+const version = require('../package.json').version;
 
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 
@@ -123,18 +122,11 @@ const isFunction = node =>
  *
  * @param {string} filename - Name of the eslint rule
  * @returns {string} URL to the documentation for the given rule
- * @throws {Error} If the documentation file for the given rule is not present.
  */
 const getDocsUrl = filename => {
   const ruleName = path.basename(filename, '.js');
 
-  const docsFile = path.join(__dirname, `../docs/rules/${ruleName}.md`);
-  // istanbul ignore if
-  if (!fs.existsSync(docsFile)) {
-    throw new Error(`Could not find documentation file for rule "${ruleName}"`);
-  }
-
-  return `${REPO_URL}/blob/v${pkg.version}/docs/rules/${ruleName}.md`;
+  return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
 };
 
 module.exports = {


### PR DESCRIPTION
`getDocsUrl` is a function that runs on the plugin's users machine, it returns a doc url, which is located on the remote.

The error should have verified that there is a corresponding doc file on the file system, which should indicate that the link won't be broken.

That logic can be done by a dedicated test, and by that, won't break the users in case this file does not exist.

**note**: In the test, we are using the rule `key` (name) from the main `index.js`, while the `url` is built from the `__filename` which should be the same as the `key` but i don't think that we verify that somewhere.