### PR TITLE
chore: add parseExpect() util function

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "eslint-plugin-eslint-plugin": "^1.4.0",
     "eslint-plugin-node": "^6.0.0",
     "eslint-plugin-prettier": "^2.3.1",
+    "espree": "^3.5.4",
+    "estraverse": "^4.2.0",
     "husky": "^0.14.3",
     "jest": "^22.0.4",
     "jest-runner-eslint": "^0.4.0",

--- a/rules/__tests__/parse-expect.test.js
+++ b/rules/__tests__/parse-expect.test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const espree = require('espree');
+const estraverse = require('estraverse');
+const parseExpect = require('../parse-expect');
+
+const CASES = {
+  notExpect(parsed) {
+    expect(parsed).toBeNull();
+  },
+  'expect()'(parsed) {
+    expect(parsed).toMatchObject({
+      arguments: [],
+      properties: [],
+      matcher: undefined,
+      matcherArguments: [],
+    });
+  },
+  'expect().toBe'(parsed) {
+    expect(parsed).toMatchObject({
+      arguments: [],
+      properties: [Identifier('toBe')],
+      matcher: undefined,
+      matcherArguments: [],
+    });
+  },
+  'expect().toBe()'(parsed) {
+    expect(parsed).toMatchObject({
+      arguments: [],
+      properties: [],
+      matcher: Identifier('toBe'),
+      matcherArguments: [],
+    });
+  },
+  'expect(Promise.resolve(2)).not.resolves.toEqual(3)'(parsed) {
+    expect(parsed).toMatchObject({
+      arguments: [
+        CallExpression(Identifier('Promise'), Identifier('resolve'), [
+          Literal(2),
+        ]),
+      ],
+      properties: [Identifier('not'), Identifier('resolves')],
+      matcher: Identifier('toEqual'),
+      matcherArguments: [Literal(3)],
+    });
+  },
+  'expect().a.b.c.d.e.f()'(parsed) {
+    expect(parsed).toMatchObject({
+      arguments: [],
+      properties: [
+        Identifier('a'),
+        Identifier('b'),
+        Identifier('c'),
+        Identifier('d'),
+        Identifier('e'),
+      ],
+      matcher: Identifier('f'),
+      matcherArguments: [],
+    });
+  },
+};
+
+Object.keys(CASES).forEach(code => {
+  test(code, () => {
+    const assertion = CASES[code];
+    const node = findExpect(code);
+    assertion(parseExpect(node));
+  });
+});
+
+function findExpect(code) {
+  let callExpression = null;
+
+  const ast = espree.parse(code);
+  estraverse.traverse(ast, {
+    enter(node, parent) {
+      node.parent = parent;
+      if (
+        !callExpression &&
+        node.type === 'CallExpression' &&
+        node.callee.name === 'expect'
+      ) {
+        callExpression = node;
+      }
+    },
+  });
+
+  return callExpression;
+}
+
+function Identifier(name) {
+  return {
+    type: 'Identifier',
+    name,
+  };
+}
+
+function Literal(value) {
+  return {
+    type: 'Literal',
+    value,
+  };
+}
+
+function CallExpression(object, property, args) {
+  return {
+    type: 'CallExpression',
+    callee: {
+      object,
+      property,
+    },
+    arguments: args || [],
+  };
+}

--- a/rules/parse-expect.js
+++ b/rules/parse-expect.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = function parseExpect(node) {
+  if (node && node.type === 'CallExpression' && node.callee.name === 'expect') {
+    const properties = [];
+    let matcherArguments = [];
+    let matcher = undefined;
+    let parent = node.parent;
+    while (parent) {
+      if (parent.type === 'MemberExpression') {
+        const grandParentType = parent.parent && parent.parent.type;
+        switch (grandParentType) {
+          case 'CallExpression': {
+            matcher = parent.property;
+            matcherArguments = matcherArguments.concat(parent.parent.arguments);
+            break;
+          }
+          case 'MemberExpression':
+          case 'ExpressionStatement': {
+            properties.push(parent.property);
+            break;
+          }
+        }
+      }
+      parent = parent.parent;
+    }
+    return {
+      arguments: node.arguments,
+      properties,
+      matcher,
+      matcherArguments,
+    };
+  }
+  return null;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1873,7 +1873,7 @@ eslint@^4.10.0, eslint@^4.5.0:
     table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.5.2:
+espree@^3.5.2, espree@^3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:


### PR DESCRIPTION
This is related to #73. I was curious to see what a `parseExpect()` function looked like and to get some feedback on it. Right now it looks like:

```ts
type ParsedExpect = {
  /* The argument nodes passed to `expect()`. */
  arguments: Node[],
  /* The properties chained onto `expect()`, like `.not` or `.resolves`. */
  properties: Node[],
  /* The matcher function called on `expect()`, like `.toBe()`, or undefined if missing. */
  matcher: Node | undefined,
  /* The argument nodes passed to the matcher function. */
  matcherArguments: Node[],
}

/* If a CallExpression node is passed in, return a ParsedExpect object, otherwise null. */
function parseExpect(node: Node | null): ParsedExpect | null
```

I can see helper functions being built on top of this parsing function, like:

```ts
/* The property names chained onto an `expect()` call. */
function expectPropertyNames(expect: ParsedExpect | null): string[] {
  return expect
    ? expect.properties.map(property => property.name)
    : []
}
```

I can also see this helping simplify some of the logic in the `valid-expect` rule (and the WIP #78).

Thoughts on this as a starting point? I haven't integrated this function into any of the rules, but I'd be happy to explore that refactoring in this PR if we'd like to see what this API looks like when it's used.