### PR TITLE
fix(valid-describe): add check for concise body arrow functions

### DIFF
--- a/rules/__tests__/valid-describe.test.js
+++ b/rules/__tests__/valid-describe.test.js
@@ -122,6 +122,20 @@ ruleTester.run('valid-describe', rule, {
     },
     {
       code: `
+      describe('foo', () =>
+        test('bar', () => {})
+      )
+      `,
+      errors: [
+        {
+          message: 'Arrow function describe callback must have a block body',
+          line: 2,
+          column: 23,
+        },
+      ],
+    },
+    {
+      code: `
       describe('foo', function () {
         return Promise.resolve().then(() => {
           it('breaks', () => {

--- a/rules/__tests__/valid-describe.test.js
+++ b/rules/__tests__/valid-describe.test.js
@@ -34,6 +34,11 @@ ruleTester.run('valid-describe', rule, {
       })
     })
     `,
+    `
+    describe('foo', () =>
+      test('bar', () => {})
+    )
+    `,
   ],
   invalid: [
     {
@@ -119,20 +124,6 @@ ruleTester.run('valid-describe', rule, {
         });
       });`,
       errors: [{ message: 'No async describe callback', line: 6, column: 27 }],
-    },
-    {
-      code: `
-      describe('foo', () =>
-        test('bar', () => {})
-      )
-      `,
-      errors: [
-        {
-          message: 'Arrow function describe callback must have a block body',
-          line: 2,
-          column: 23,
-        },
-      ],
     },
     {
       code: `

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -10,10 +10,6 @@ const isString = node =>
   (node.type === 'Literal' && typeof node.value === 'string') ||
   node.type === 'TemplateLiteral';
 
-const isConciseBodyArrowFunction = node =>
-  node.type === 'ArrowFunctionExpression' &&
-  node.body.type === 'CallExpression';
-
 const hasParams = node => node.params.length > 0;
 
 const paramsLocation = params => {
@@ -80,21 +76,16 @@ module.exports = {
               loc: paramsLocation(callbackFunction.params),
             });
           }
-          if (isConciseBodyArrowFunction(callbackFunction)) {
-            return context.report({
-              message:
-                'Arrow function describe callback must have a block body',
-              node: callbackFunction,
+          if (callbackFunction.body.type === 'BlockStatement') {
+            callbackFunction.body.body.forEach(node => {
+              if (node.type === 'ReturnStatement') {
+                context.report({
+                  message: 'Unexpected return statement in describe callback',
+                  node,
+                });
+              }
             });
           }
-          callbackFunction.body.body.forEach(node => {
-            if (node.type === 'ReturnStatement') {
-              context.report({
-                message: 'Unexpected return statement in describe callback',
-                node,
-              });
-            }
-          });
         }
       },
     };

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -10,6 +10,10 @@ const isString = node =>
   (node.type === 'Literal' && typeof node.value === 'string') ||
   node.type === 'TemplateLiteral';
 
+const isConciseBodyArrowFunction = node =>
+  node.type === 'ArrowFunctionExpression' &&
+  node.body.type === 'CallExpression';
+
 const hasParams = node => node.params.length > 0;
 
 const paramsLocation = params => {
@@ -74,6 +78,13 @@ module.exports = {
             context.report({
               message: 'Unexpected argument(s) in describe callback',
               loc: paramsLocation(callbackFunction.params),
+            });
+          }
+          if (isConciseBodyArrowFunction(callbackFunction)) {
+            return context.report({
+              message:
+                'Arrow function describe callback must have a block body',
+              node: callbackFunction,
             });
           }
           callbackFunction.body.body.forEach(node => {


### PR DESCRIPTION
Fixes #105.

I've added a new condition for an arrow function with concise body. I'm not good at writing English, so the report message may not be look good to you. If so, please let me know and I'll fix it!