### PR TITLE
fix(rules): improve no-identical-title error message

### DIFF
--- a/rules/__tests__/no-identical-title.test.js
+++ b/rules/__tests__/no-identical-title.test.js
@@ -93,7 +93,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test title is used multiple times in the same test suite.',
+          message:
+            'Test title is used multiple times in the same describe block.',
           column: 4,
           line: 3,
         },
@@ -105,7 +106,8 @@ ruleTester.run('no-identical-title', rule, {
       ),
       errors: [
         {
-          message: 'Test title is used multiple times in the same test suite.',
+          message:
+            'Test title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -118,7 +120,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test title is used multiple times in the same test suite.',
+          message:
+            'Test title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -130,7 +133,8 @@ ruleTester.run('no-identical-title', rule, {
       ),
       errors: [
         {
-          message: 'Test title is used multiple times in the same test suite.',
+          message:
+            'Test title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -143,7 +147,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test title is used multiple times in the same test suite.',
+          message:
+            'Test title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -156,7 +161,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test suite title is used multiple times.',
+          message:
+            'Describe block title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -169,7 +175,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test suite title is used multiple times.',
+          message:
+            'Describe block title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -182,7 +189,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test suite title is used multiple times.',
+          message:
+            'Describe block title is used multiple times in the same describe block.',
           column: 1,
           line: 2,
         },
@@ -197,7 +205,8 @@ ruleTester.run('no-identical-title', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'Test suite title is used multiple times.',
+          message:
+            'Describe block title is used multiple times in the same describe block.',
           column: 1,
           line: 4,
         },

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -13,7 +13,8 @@ const handleTestCaseTitles = (context, titles, node, title) => {
   if (isTestCase(node)) {
     if (titles.indexOf(title) !== -1) {
       context.report({
-        message: 'Test title is used multiple times in the same test suite.',
+        message:
+          'Test title is used multiple times in the same describe block.',
         node,
       });
     }
@@ -21,13 +22,14 @@ const handleTestCaseTitles = (context, titles, node, title) => {
   }
 };
 
-const handleTestSuiteTitles = (context, titles, node, title) => {
+const handleDescribeBlockTitles = (context, titles, node, title) => {
   if (!isDescribe(node)) {
     return;
   }
   if (titles.indexOf(title) !== -1) {
     context.report({
-      message: 'Test suite title is used multiple times.',
+      message:
+        'Describe block title is used multiple times in the same describe block.',
       node,
     });
   }
@@ -57,7 +59,7 @@ module.exports = {
 
         const title = node.arguments[0].value;
         handleTestCaseTitles(context, currentLayer.testTitles, node, title);
-        handleTestSuiteTitles(
+        handleDescribeBlockTitles(
           context,
           currentLayer.describeTitles,
           node,


### PR DESCRIPTION
This is a PR to improve the error message of `no-identical-title` rule, after the issue #107