### PR TITLE
feat(rules): add `no-jasmine-globals`

### DIFF
--- a/docs/rules/no-jasmine-globals.md
+++ b/docs/rules/no-jasmine-globals.md
@@ -1,0 +1,59 @@
+# Disallow Jasmine globals
+
+`jest` uses `jasmine` as a test runner. A side effect of this is that both a
+`jasmine` object, and some jasmine-specific globals, are exposed to the test
+environment. Most functionality offered by Jasmine has been ported to Jest, and
+the Jasmine globals will stop working in the future. Developers should therefor
+migrate to Jest's documented API instead of relying on the undocumented Jasmine
+API.
+
+### Rule details
+
+This rule reports on any usage of Jasmine globals which is not ported to Jest,
+and suggests alternative from Jest's own API.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;
+
+test('my test', () => {
+  pending();
+});
+
+test('my test', () => {
+  fail();
+});
+
+test('my test', () => {
+  spyOn(some, 'object');
+});
+
+test('my test', () => {
+  jasmine.createSpy();
+});
+
+test('my test', () => {
+  expect('foo').toEqual(jasmine.anything());
+});
+```
+
+The following patterns would not be considered warnings:
+
+```js
+jest.setTimeout(5000);
+
+test('my test', () => {
+  spyOn(some, 'object');
+});
+
+test('my test', () => {
+  jest.fn();
+});
+
+test('my test', () => {
+  expect('foo').toEqual(expect.anything());
+});
+```

--- a/docs/rules/no-jasmine-globals.md
+++ b/docs/rules/no-jasmine-globals.md
@@ -46,7 +46,7 @@ The following patterns would not be considered warnings:
 jest.setTimeout(5000);
 
 test('my test', () => {
-  spyOn(some, 'object');
+  jest.spyOn(some, 'object');
 });
 
 test('my test', () => {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const noDisabledTests = require('./rules/no-disabled-tests');
 const noFocusedTests = require('./rules/no-focused-tests');
 const noHooks = require('./rules/no-hooks');
 const noIdenticalTitle = require('./rules/no-identical-title');
+const noJasmineGlobals = require('./rules/no-jasmine-globals');
 const noJestImport = require('./rules/no-jest-import');
 const noLargeSnapshots = require('./rules/no-large-snapshots');
 const noTestPrefixes = require('./rules/no-test-prefixes');
@@ -69,6 +70,7 @@ module.exports = {
     'no-focused-tests': noFocusedTests,
     'no-hooks': noHooks,
     'no-identical-title': noIdenticalTitle,
+    'no-jasmine-globals': noJasmineGlobals,
     'no-jest-import': noJestImport,
     'no-large-snapshots': noLargeSnapshots,
     'no-test-prefixes': noTestPrefixes,

--- a/rules/__tests__/no-jasmine-globals.test.js
+++ b/rules/__tests__/no-jasmine-globals.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../no-jasmine-globals');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-jasmine-globals', rule, {
+  valid: [
+    'jest.spyOn()',
+    'jest.fn()',
+    'expect.extend()',
+    'expect.any()',
+    'it("foo", function () {})',
+    'test("foo", function () {})',
+    'foo()',
+  ],
+  invalid: [
+    {
+      code: 'spyOn(some, "object")',
+      errors: [
+        {
+          message: 'Avoid using global `spyOn`, prefer `jest.spyOn`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'spyOnProperty(some, "object")',
+      errors: [
+        {
+          message: 'Avoid using global `spyOnProperty`, prefer `jest.spyOn`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'fail()',
+      errors: [
+        {
+          message:
+            'Avoid global `fail`, prefer throwing an error, or the `done` callback',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'pending()',
+      errors: [
+        {
+          message: 'Avoid global `pending`, prefer explicitly skipping a test',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;',
+      errors: [
+        {
+          message: 'Avoid using global `jasmine`',
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'jest.setTimeout(5000);',
+    },
+    {
+      code: 'jasmine.addMatchers(matchers)',
+      errors: [
+        {
+          message: 'Avoid using `jasmine.addMatchers`, prefer `expect.extend`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.createSpy()',
+      errors: [
+        {
+          message: 'Avoid using `jasmine.createSpy`, prefer `jest.fn`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.any()',
+      errors: [
+        {
+          message: 'Avoid using `jasmine.any`, prefer `expect.any`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.anything()',
+      errors: [
+        {
+          message: 'Avoid using `jasmine.anything`, prefer `expect.anything`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.arrayContaining()',
+      errors: [
+        {
+          message:
+            'Avoid using `jasmine.arrayContaining`, prefer `expect.arrayContaining`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.objectContaining()',
+      errors: [
+        {
+          message:
+            'Avoid using `jasmine.objectContaining`, prefer `expect.objectContaining`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.stringMatching()',
+      errors: [
+        {
+          message:
+            'Avoid using `jasmine.stringMatching`, prefer `expect.stringMatching`',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.getEnv()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.empty()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.falsy()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.truthy()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.arrayWithExactContents()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.clock()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});

--- a/rules/__tests__/no-jasmine-globals.test.js
+++ b/rules/__tests__/no-jasmine-globals.test.js
@@ -20,7 +20,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'spyOn(some, "object")',
       errors: [
         {
-          message: 'Avoid using global `spyOn`, prefer `jest.spyOn`',
+          message: 'Illegal usage of global `spyOn`, prefer `jest.spyOn`',
           column: 1,
           line: 1,
         },
@@ -30,7 +30,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'spyOnProperty(some, "object")',
       errors: [
         {
-          message: 'Avoid using global `spyOnProperty`, prefer `jest.spyOn`',
+          message:
+            'Illegal usage of global `spyOnProperty`, prefer `jest.spyOn`',
           column: 1,
           line: 1,
         },
@@ -41,7 +42,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       errors: [
         {
           message:
-            'Avoid global `fail`, prefer throwing an error, or the `done` callback',
+            'Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback',
           column: 1,
           line: 1,
         },
@@ -51,7 +52,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'pending()',
       errors: [
         {
-          message: 'Avoid global `pending`, prefer explicitly skipping a test',
+          message:
+            'Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`',
           column: 1,
           line: 1,
         },
@@ -61,7 +63,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -72,7 +74,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.addMatchers(matchers)',
       errors: [
         {
-          message: 'Avoid using `jasmine.addMatchers`, prefer `expect.extend`',
+          message:
+            'Illegal usage of `jasmine.addMatchers`, prefer `expect.extend`',
           column: 1,
           line: 1,
         },
@@ -82,7 +85,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.createSpy()',
       errors: [
         {
-          message: 'Avoid using `jasmine.createSpy`, prefer `jest.fn`',
+          message: 'Illegal usage of `jasmine.createSpy`, prefer `jest.fn`',
           column: 1,
           line: 1,
         },
@@ -92,7 +95,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.any()',
       errors: [
         {
-          message: 'Avoid using `jasmine.any`, prefer `expect.any`',
+          message: 'Illegal usage of `jasmine.any`, prefer `expect.any`',
           column: 1,
           line: 1,
         },
@@ -103,7 +106,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.anything()',
       errors: [
         {
-          message: 'Avoid using `jasmine.anything`, prefer `expect.anything`',
+          message:
+            'Illegal usage of `jasmine.anything`, prefer `expect.anything`',
           column: 1,
           line: 1,
         },
@@ -115,7 +119,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       errors: [
         {
           message:
-            'Avoid using `jasmine.arrayContaining`, prefer `expect.arrayContaining`',
+            'Illegal usage of `jasmine.arrayContaining`, prefer `expect.arrayContaining`',
           column: 1,
           line: 1,
         },
@@ -127,7 +131,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       errors: [
         {
           message:
-            'Avoid using `jasmine.objectContaining`, prefer `expect.objectContaining`',
+            'Illegal usage of `jasmine.objectContaining`, prefer `expect.objectContaining`',
           column: 1,
           line: 1,
         },
@@ -139,7 +143,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       errors: [
         {
           message:
-            'Avoid using `jasmine.stringMatching`, prefer `expect.stringMatching`',
+            'Illegal usage of `jasmine.stringMatching`, prefer `expect.stringMatching`',
           column: 1,
           line: 1,
         },
@@ -150,7 +154,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.getEnv()',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -160,7 +164,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.empty()',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -170,7 +174,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.falsy()',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -180,7 +184,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.truthy()',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -190,7 +194,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.arrayWithExactContents()',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -200,7 +204,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.clock()',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },
@@ -210,7 +214,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 42',
       errors: [
         {
-          message: 'Avoid using jasmine global',
+          message: 'Illegal usage of jasmine global',
           column: 1,
           line: 1,
         },

--- a/rules/__tests__/no-jasmine-globals.test.js
+++ b/rules/__tests__/no-jasmine-globals.test.js
@@ -61,7 +61,7 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;',
       errors: [
         {
-          message: 'Avoid using global `jasmine`',
+          message: 'Avoid using jasmine global',
           column: 1,
           line: 1,
         },
@@ -97,6 +97,7 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
+      output: 'expect.any()',
     },
     {
       code: 'jasmine.anything()',
@@ -107,6 +108,7 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
+      output: 'expect.anything()',
     },
     {
       code: 'jasmine.arrayContaining()',
@@ -118,6 +120,7 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
+      output: 'expect.arrayContaining()',
     },
     {
       code: 'jasmine.objectContaining()',
@@ -129,6 +132,7 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
+      output: 'expect.objectContaining()',
     },
     {
       code: 'jasmine.stringMatching()',
@@ -140,6 +144,7 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
+      output: 'expect.stringMatching()',
     },
     {
       code: 'jasmine.getEnv()',
@@ -193,6 +198,16 @@ ruleTester.run('no-jasmine-globals', rule, {
     },
     {
       code: 'jasmine.clock()',
+      errors: [
+        {
+          message: 'Avoid using jasmine global',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 42',
       errors: [
         {
           message: 'Avoid using jasmine global',

--- a/rules/no-jasmine-globals.js
+++ b/rules/no-jasmine-globals.js
@@ -3,11 +3,6 @@
 const getDocsUrl = require('./util').getDocsUrl;
 const getNodeName = require('./util').getNodeName;
 
-/*
-fail
-pending
-*/
-
 module.exports = {
   meta: {
     docs: {

--- a/rules/no-jasmine-globals.js
+++ b/rules/no-jasmine-globals.js
@@ -57,6 +57,9 @@ module.exports = {
             functionName === 'stringMatching'
           ) {
             context.report({
+              fix(fixer) {
+                return [fixer.replaceText(node.callee.object, 'expect')];
+              },
               node,
               message: `Avoid using \`${calleeName}\`, prefer \`expect.${functionName}\``,
             });
@@ -87,29 +90,27 @@ module.exports = {
       },
       MemberExpression(node) {
         if (node.object.name === 'jasmine') {
-          if (node.property.type === 'Identifier') {
-            if (node.parent.type === 'AssignmentExpression') {
-              if (node.property.name === 'DEFAULT_TIMEOUT_INTERVAL') {
-                context.report({
-                  fix(fixer) {
-                    return [
-                      fixer.replaceText(
-                        node.parent,
-                        `jest.setTimeout(${node.parent.right.value})`
-                      ),
-                    ];
-                  },
-                  node,
-                  message: 'Avoid using global `jasmine`',
-                });
-                return;
-              }
-
+          if (node.parent.type === 'AssignmentExpression') {
+            if (node.property.name === 'DEFAULT_TIMEOUT_INTERVAL') {
               context.report({
+                fix(fixer) {
+                  return [
+                    fixer.replaceText(
+                      node.parent,
+                      `jest.setTimeout(${node.parent.right.value})`
+                    ),
+                  ];
+                },
                 node,
-                message: 'Avoid using global `jasmine`',
+                message: 'Avoid using jasmine global',
               });
+              return;
             }
+
+            context.report({
+              node,
+              message: 'Avoid using jasmine global',
+            });
           }
         }
       },

--- a/rules/no-jasmine-globals.js
+++ b/rules/no-jasmine-globals.js
@@ -1,0 +1,118 @@
+'use strict';
+
+const getDocsUrl = require('./util').getDocsUrl;
+const getNodeName = require('./util').getNodeName;
+
+/*
+fail
+pending
+*/
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const calleeName = getNodeName(node.callee);
+
+        if (calleeName === 'spyOn' || calleeName === 'spyOnProperty') {
+          context.report({
+            node,
+            message: `Avoid using global \`${calleeName}\`, prefer \`jest.spyOn\``,
+          });
+          return;
+        }
+
+        if (calleeName === 'fail') {
+          context.report({
+            node,
+            message:
+              'Avoid global `fail`, prefer throwing an error, or the `done` callback',
+          });
+          return;
+        }
+
+        if (calleeName === 'pending') {
+          context.report({
+            node,
+            message:
+              'Avoid global `pending`, prefer explicitly skipping a test',
+          });
+          return;
+        }
+
+        if (calleeName.startsWith('jasmine.')) {
+          const functionName = calleeName.replace('jasmine.', '');
+
+          if (
+            functionName === 'any' ||
+            functionName === 'anything' ||
+            functionName === 'arrayContaining' ||
+            functionName === 'objectContaining' ||
+            functionName === 'stringMatching'
+          ) {
+            context.report({
+              node,
+              message: `Avoid using \`${calleeName}\`, prefer \`expect.${functionName}\``,
+            });
+            return;
+          }
+
+          if (functionName === 'addMatchers') {
+            context.report({
+              node,
+              message: `Avoid using \`${calleeName}\`, prefer \`expect.extend\``,
+            });
+            return;
+          }
+
+          if (functionName === 'createSpy') {
+            context.report({
+              node,
+              message: `Avoid using \`${calleeName}\`, prefer \`jest.fn\``,
+            });
+            return;
+          }
+
+          context.report({
+            node,
+            message: 'Avoid using jasmine global',
+          });
+        }
+      },
+      MemberExpression(node) {
+        if (node.object.name === 'jasmine') {
+          if (node.property.type === 'Identifier') {
+            if (node.parent.type === 'AssignmentExpression') {
+              if (node.property.name === 'DEFAULT_TIMEOUT_INTERVAL') {
+                context.report({
+                  fix(fixer) {
+                    return [
+                      fixer.replaceText(
+                        node.parent,
+                        `jest.setTimeout(${node.parent.right.value})`
+                      ),
+                    ];
+                  },
+                  node,
+                  message: 'Avoid using global `jasmine`',
+                });
+                return;
+              }
+
+              context.report({
+                node,
+                message: 'Avoid using global `jasmine`',
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};

--- a/rules/no-jasmine-globals.js
+++ b/rules/no-jasmine-globals.js
@@ -18,7 +18,7 @@ module.exports = {
         if (calleeName === 'spyOn' || calleeName === 'spyOnProperty') {
           context.report({
             node,
-            message: `Avoid using global \`${calleeName}\`, prefer \`jest.spyOn\``,
+            message: `Illegal usage of global \`${calleeName}\`, prefer \`jest.spyOn\``,
           });
           return;
         }
@@ -27,7 +27,7 @@ module.exports = {
           context.report({
             node,
             message:
-              'Avoid global `fail`, prefer throwing an error, or the `done` callback',
+              'Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback',
           });
           return;
         }
@@ -36,7 +36,7 @@ module.exports = {
           context.report({
             node,
             message:
-              'Avoid global `pending`, prefer explicitly skipping a test',
+              'Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`',
           });
           return;
         }
@@ -56,7 +56,7 @@ module.exports = {
                 return [fixer.replaceText(node.callee.object, 'expect')];
               },
               node,
-              message: `Avoid using \`${calleeName}\`, prefer \`expect.${functionName}\``,
+              message: `Illegal usage of \`${calleeName}\`, prefer \`expect.${functionName}\``,
             });
             return;
           }
@@ -64,7 +64,7 @@ module.exports = {
           if (functionName === 'addMatchers') {
             context.report({
               node,
-              message: `Avoid using \`${calleeName}\`, prefer \`expect.extend\``,
+              message: `Illegal usage of \`${calleeName}\`, prefer \`expect.extend\``,
             });
             return;
           }
@@ -72,14 +72,14 @@ module.exports = {
           if (functionName === 'createSpy') {
             context.report({
               node,
-              message: `Avoid using \`${calleeName}\`, prefer \`jest.fn\``,
+              message: `Illegal usage of \`${calleeName}\`, prefer \`jest.fn\``,
             });
             return;
           }
 
           context.report({
             node,
-            message: 'Avoid using jasmine global',
+            message: 'Illegal usage of jasmine global',
           });
         }
       },
@@ -97,14 +97,14 @@ module.exports = {
                   ];
                 },
                 node,
-                message: 'Avoid using jasmine global',
+                message: 'Illegal usage of jasmine global',
               });
               return;
             }
 
             context.report({
               node,
-              message: 'Avoid using jasmine global',
+              message: 'Illegal usage of jasmine global',
             });
           }
         }


### PR DESCRIPTION
In preparation for jest-circus, warning users about Jasmine usage would be great.

Will probably add to recommended in next major (whenever eslint 5 comes out)

/cc @captbaritone