### PR TITLE
chore(package): update to prettier@1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ for more information about extending configuration files.
 
 ## Credit
 
-* [eslint-plugin-mocha](https://github.com/lo1tuma/eslint-plugin-mocha)
-* [eslint-plugin-jasmine](https://github.com/tlvince/eslint-plugin-jasmine)
+- [eslint-plugin-mocha](https://github.com/lo1tuma/eslint-plugin-mocha)
+- [eslint-plugin-jasmine](https://github.com/tlvince/eslint-plugin-jasmine)

--- a/docs/rules/consistent-test-it.md
+++ b/docs/rules/consistent-test-it.md
@@ -3,8 +3,8 @@
 Jest allows you to choose how you want to define your tests, using the `it` or
 the `test` keywords, with multiple permutations for each:
 
-* **it:** `it`, `xit`, `fit`, `it.only`, `it.skip`.
-* **test:** `test`, `xtest`, `test.only`, `test.skip`.
+- **it:** `it`, `xit`, `fit`, `it.only`, `it.skip`.
+- **test:** `test`, `xtest`, `test.only`, `test.skip`.
 
 This rule gives you control over the usage of these keywords in your codebase.
 

--- a/docs/rules/lowercase-name.md
+++ b/docs/rules/lowercase-name.md
@@ -40,9 +40,9 @@ it('adds 1 + 2 to equal 3', () => {
 This array option whitelists function names so that this rule does not report
 their usage as being incorrect. There are three possible values:
 
-* `"describe"`
-* `"test"`
-* `"it"`
+- `"describe"`
+- `"test"`
+- `"it"`
 
 By default, none of these options are enabled (the equivalent of
 `{ "ignore": [] }`).

--- a/docs/rules/no-disabled-tests.md
+++ b/docs/rules/no-disabled-tests.md
@@ -11,10 +11,10 @@ This rule raises a warning about disabled tests.
 
 There are a number of ways to disable tests in Jest:
 
-* by appending `.skip` to the test-suite or test-case
-* by prepending the test function name with `x`
-* by declaring a test with a name but no function body
-* by making a call to `pending()` anywhere within the test
+- by appending `.skip` to the test-suite or test-case
+- by prepending the test function name with `x`
+- by declaring a test with a name but no function body
+- by making a call to `pending()` anywhere within the test
 
 The following patterns are considered warnings:
 

--- a/docs/rules/no-hooks.md
+++ b/docs/rules/no-hooks.md
@@ -8,10 +8,10 @@ shared state between tests.
 
 This rule reports for the following function calls:
 
-* `beforeAll`
-* `beforeEach`
-* `afterAll`
-* `afterEach`
+- `beforeAll`
+- `beforeEach`
+- `afterAll`
+- `afterEach`
 
 Examples of **incorrect** code for this rule:
 
@@ -104,10 +104,10 @@ describe('foo', () => {
 This array option whitelists setup and teardown hooks so that this rule does not
 report their usage as being incorrect. There are four possible values:
 
-* `"beforeAll"`
-* `"beforeEach"`
-* `"afterAll"`
-* `"afterEach"`
+- `"beforeAll"`
+- `"beforeEach"`
+- `"afterAll"`
+- `"afterEach"`
 
 By default, none of these options are enabled (the equivalent of
 `{ "allow": [] }`).
@@ -171,5 +171,5 @@ safely disable this rule.
 
 ## Further Reading
 
-* [Jest docs - Setup and Teardown](https://facebook.github.io/jest/docs/en/setup-teardown.html)
-* [@jamiebuilds Twitter thread](https://twitter.com/jamiebuilds/status/954906997169664000)
+- [Jest docs - Setup and Teardown](https://facebook.github.io/jest/docs/en/setup-teardown.html)
+- [@jamiebuilds Twitter thread](https://twitter.com/jamiebuilds/status/954906997169664000)

--- a/docs/rules/no-test-prefixes.md
+++ b/docs/rules/no-test-prefixes.md
@@ -3,9 +3,9 @@
 Jest allows you to choose how you want to define focused and skipped tests, with
 multiple permutations for each:
 
-* **only & skip:** `it.only`, `test.only`, `describe.only`, `it.skip`,
+- **only & skip:** `it.only`, `test.only`, `describe.only`, `it.skip`,
   `test.skip`, `describe.skip`.
-* **'f' & 'x':** `fit`, `fdescribe`, `xit`, `xtest`, `xdescribe`.
+- **'f' & 'x':** `fit`, `fdescribe`, `xit`, `xtest`, `xdescribe`.
 
 This rule enforces usages from the **only & skip** list.
 

--- a/docs/rules/prefer-expect-assertions.md
+++ b/docs/rules/prefer-expect-assertions.md
@@ -7,7 +7,7 @@ Ensure every test to have either `expect.assertions(<number of assertions>)` OR
 
 This rule triggers a warning if,
 
-* `expect.assertions(<number of assertions>)` OR `expect.hasAssertions()` is not
+- `expect.assertions(<number of assertions>)` OR `expect.hasAssertions()` is not
   present as first statement in a test, e.g.:
 
 ```js
@@ -16,7 +16,7 @@ test('my test', () => {
 });
 ```
 
-* `expect.assertions(<number of assertions>)` is the first statement in a test
+- `expect.assertions(<number of assertions>)` is the first statement in a test
   where argument passed to `expect.assertions(<number of assertions>)` is not a
   valid number, e.g.:
 

--- a/docs/rules/valid-describe.md
+++ b/docs/rules/valid-describe.md
@@ -8,18 +8,18 @@ errors.
 This rule validates that the second parameter of a `describe()` function is a
 callback function. This callback function:
 
-* should not be
+- should not be
   [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)
-* should not contain any parameters
-* should not contain any `return` statements
+- should not contain any parameters
+- should not contain any `return` statements
 
 The following `describe` function aliases are also validated:
 
-* `describe`
-* `describe.only`
-* `describe.skip`
-* `fdescribe`
-* `xdescribe`
+- `describe`
+- `describe.only`
+- `describe.skip`
+- `fdescribe`
+- `xdescribe`
 
 The following patterns are considered warnings:
 

--- a/docs/rules/valid-expect-in-promise.md
+++ b/docs/rules/valid-expect-in-promise.md
@@ -7,8 +7,8 @@ promise
 
 This rule triggers a warning if,
 
-* test is having assertions in `then` or `catch` block of a promise
-* and that promise is not returned from the test
+- test is having assertions in `then` or `catch` block of a promise
+- and that promise is not returned from the test
 
 ### Default configuration
 

--- a/package.json
+++ b/package.json
@@ -4,13 +4,22 @@
   "description": "Eslint rules for Jest",
   "repository": "jest-community/eslint-plugin-jest",
   "license": "MIT",
-  "keywords": ["eslint", "eslintplugin", "eslint-plugin"],
+  "keywords": [
+    "eslint",
+    "eslintplugin",
+    "eslint-plugin"
+  ],
   "author": {
     "name": "Jonathan Kim",
     "email": "hello@jkimbo.com",
     "url": "jkimbo.com"
   },
-  "files": ["docs/", "rules/", "processors/", "index.js"],
+  "files": [
+    "docs/",
+    "rules/",
+    "processors/",
+    "index.js"
+  ],
   "engines": {
     "node": ">= 4"
   },
@@ -47,8 +56,14 @@
     "trailingComma": "es5"
   },
   "lint-staged": {
-    "*.js": ["eslint --fix", "git add"],
-    "*.{md,json}": ["prettier --write", "git add"]
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ],
+    "*.{md,json}": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "jest": {
     "coverageThreshold": {
@@ -67,11 +82,15 @@
       {
         "displayName": "lint",
         "runner": "jest-runner-eslint",
-        "testMatch": ["<rootDir>/**/*.js"]
+        "testMatch": [
+          "<rootDir>/**/*.js"
+        ]
       }
     ]
   },
   "commitlint": {
-    "extends": ["@commitlint/config-conventional"]
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,8 +4439,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.10.2:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.0.tgz#054de8d5fb1a4405c845d16183f58a2c301f6f16"
 
 pretty-format@^22.4.0:
   version "22.4.0"


### PR DESCRIPTION
https://prettier.io/blog/2018/05/23/1.13.0.html

This PR updates to the latest version of Prettier. I also ran `npx prettier '**/*.{md,js,json}' --write` to format all files using this new version of Prettier, if you are open to that change. Looks like the only changes are `package.json` formatting and changing `*` to `-` for Markdown lists, which are detailed in the [release blog post](https://prettier.io/blog/2018/05/23/1.13.0.html).