### PR TITLE
Prepare for update to ESLint v5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
 - 8
 - node
 - 6
-- 4
 before_install:
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
 - export PATH="$HOME/.yarn/bin:$PATH"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">= 4"
+    "node": ">=6"
   },
   "peerDependencies": {
     "eslint": ">=5"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": ">= 4"
   },
   "peerDependencies": {
-    "eslint": ">=3.6"
+    "eslint": ">=5"
   },
   "scripts": {
     "lint": "eslint . --ignore-pattern '!.eslintrc.js'",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@commitlint/cli": "^6.0.1",
     "@commitlint/config-conventional": "^6.0.2",
-    "eslint": "^4.10.0",
+    "eslint": "^5.1.0",
     "eslint-config-prettier": "^2.7.0",
     "eslint-plugin-eslint-plugin": "^1.4.0",
     "eslint-plugin-node": "^6.0.0",

--- a/rules/__tests__/consistent-test-it.test.js
+++ b/rules/__tests__/consistent-test-it.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../consistent-test-it');
 
 const ruleTester = new RuleTester({

--- a/rules/__tests__/lowercase-name.test.js
+++ b/rules/__tests__/lowercase-name.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../lowercase-name');
 
 const ruleTester = new RuleTester({

--- a/rules/__tests__/no-disabled-tests.test.js
+++ b/rules/__tests__/no-disabled-tests.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../no-disabled-tests');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/no-focused-tests.test.js
+++ b/rules/__tests__/no-focused-tests.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../no-focused-tests');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/no-hooks.test.js
+++ b/rules/__tests__/no-hooks.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../no-hooks');
 
 const ruleTester = new RuleTester({

--- a/rules/__tests__/no-identical-title.test.js
+++ b/rules/__tests__/no-identical-title.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../no-identical-title');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/no-jasmine-globals.test.js
+++ b/rules/__tests__/no-jasmine-globals.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../no-jasmine-globals');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/no-jest-import.test.js
+++ b/rules/__tests__/no-jest-import.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const rule = require('../no-jest-import.js');
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const ruleTester = new RuleTester();
 const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
 

--- a/rules/__tests__/no-test-prefixes.test.js
+++ b/rules/__tests__/no-test-prefixes.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../no-test-prefixes');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/prefer-expect-assertions.test.js
+++ b/rules/__tests__/prefer-expect-assertions.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../prefer-expect-assertions');
 
 const ruleTester = new RuleTester({

--- a/rules/__tests__/prefer-to-be-null.test.js
+++ b/rules/__tests__/prefer-to-be-null.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../prefer-to-be-null');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/prefer-to-be-undefined.test.js
+++ b/rules/__tests__/prefer-to-be-undefined.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../prefer-to-be-undefined');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/prefer-to-have-length.test.js
+++ b/rules/__tests__/prefer-to-have-length.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../prefer-to-have-length');
 
 const ruleTester = new RuleTester();

--- a/rules/__tests__/valid-describe.test.js
+++ b/rules/__tests__/valid-describe.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../valid-describe');
 
 const ruleTester = new RuleTester({

--- a/rules/__tests__/valid-expect-in-promise.test.js
+++ b/rules/__tests__/valid-expect-in-promise.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../valid-expect-in-promise');
 
 const ruleTester = new RuleTester({

--- a/rules/__tests__/valid-expect.test.js
+++ b/rules/__tests__/valid-expect.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const RuleTester = require('eslint').RuleTester;
+const { RuleTester } = require('eslint');
 const rule = require('../valid-expect');
 
 const ruleTester = new RuleTester();

--- a/rules/consistent-test-it.js
+++ b/rules/consistent-test-it.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const getNodeName = require('./util').getNodeName;
-const isTestCase = require('./util').isTestCase;
-const isDescribe = require('./util').isDescribe;
+const { getDocsUrl, getNodeName, isTestCase, isDescribe } = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/lowercase-name.js
+++ b/rules/lowercase-name.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 const isItTestOrDescribeFunction = node => {
   return (

--- a/rules/no-disabled-tests.js
+++ b/rules/no-disabled-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 function getName(node) {
   function joinNames(a, b) {

--- a/rules/no-focused-tests.js
+++ b/rules/no-focused-tests.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 const testFunctions = Object.assign(Object.create(null), {
   describe: true,

--- a/rules/no-hooks.js
+++ b/rules/no-hooks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const isDescribe = require('./util').isDescribe;
-const isTestCase = require('./util').isTestCase;
+const { getDocsUrl, isDescribe, isTestCase } = require('./util');
 
 const newDescribeContext = () => ({
   describeTitles: [],

--- a/rules/no-jasmine-globals.js
+++ b/rules/no-jasmine-globals.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const getNodeName = require('./util').getNodeName;
+const { getDocsUrl, getNodeName } = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/no-jest-import.js
+++ b/rules/no-jest-import.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const getNodeName = require('./util').getNodeName;
+const { getDocsUrl, getNodeName } = require('./util');
+
 const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
 
 module.exports = {

--- a/rules/no-large-snapshots.js
+++ b/rules/no-large-snapshots.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/no-test-prefixes.js
+++ b/rules/no-test-prefixes.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const getNodeName = require('./util').getNodeName;
-const isTestCase = require('./util').isTestCase;
-const isDescribe = require('./util').isDescribe;
+const { getDocsUrl, getNodeName, isTestCase, isDescribe } = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/prefer-expect-assertions.js
+++ b/rules/prefer-expect-assertions.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 const ruleMsg =
   'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';

--- a/rules/prefer-to-be-null.js
+++ b/rules/prefer-to-be-null.js
@@ -1,14 +1,16 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const argument = require('./util').argument;
-const argument2 = require('./util').argument2;
-const expectToBeCase = require('./util').expectToBeCase;
-const expectToEqualCase = require('./util').expectToEqualCase;
-const expectNotToEqualCase = require('./util').expectNotToEqualCase;
-const expectNotToBeCase = require('./util').expectNotToBeCase;
-const method = require('./util').method;
-const method2 = require('./util').method2;
+const {
+  getDocsUrl,
+  argument,
+  argument2,
+  expectToBeCase,
+  expectToEqualCase,
+  expectNotToEqualCase,
+  expectNotToBeCase,
+  method,
+  method2,
+} = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/prefer-to-be-undefined.js
+++ b/rules/prefer-to-be-undefined.js
@@ -1,13 +1,15 @@
 'use strict';
-const argument = require('./util').argument;
-const argument2 = require('./util').argument2;
-const expectToBeCase = require('./util').expectToBeCase;
-const expectNotToBeCase = require('./util').expectNotToBeCase;
-const expectToEqualCase = require('./util').expectToEqualCase;
-const expectNotToEqualCase = require('./util').expectNotToEqualCase;
-const getDocsUrl = require('./util').getDocsUrl;
-const method = require('./util').method;
-const method2 = require('./util').method2;
+const {
+  argument,
+  argument2,
+  expectToBeCase,
+  expectNotToBeCase,
+  expectToEqualCase,
+  expectNotToEqualCase,
+  getDocsUrl,
+  method,
+  method2,
+} = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/prefer-to-have-length.js
+++ b/rules/prefer-to-have-length.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const expectCase = require('./util').expectCase;
-const expectNotCase = require('./util').expectNotCase;
-const expectResolveCase = require('./util').expectResolveCase;
-const expectRejectCase = require('./util').expectRejectCase;
-const method = require('./util').method;
+const {
+  getDocsUrl,
+  expectCase,
+  expectNotCase,
+  expectResolveCase,
+  expectRejectCase,
+  method,
+} = require('./util');
 
 module.exports = {
   meta: {

--- a/rules/valid-describe.js
+++ b/rules/valid-describe.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const isDescribe = require('./util').isDescribe;
-const isFunction = require('./util').isFunction;
+const { getDocsUrl, isDescribe, isFunction } = require('./util');
 
 const isAsync = node => node.async;
 

--- a/rules/valid-expect-in-promise.js
+++ b/rules/valid-expect-in-promise.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const getDocsUrl = require('./util').getDocsUrl;
-const isFunction = require('./util').isFunction;
+const { getDocsUrl, isFunction } = require('./util');
 
 const reportMsg =
   'Promise should be returned to test its fulfillment or rejection';

--- a/rules/valid-expect.js
+++ b/rules/valid-expect.js
@@ -5,7 +5,7 @@
  * MIT license, Tom Vincent.
  */
 
-const getDocsUrl = require('./util').getDocsUrl;
+const { getDocsUrl } = require('./util');
 
 const expectProperties = ['not', 'resolves', 'rejects'];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,6 +257,12 @@ acorn-jsx@^3.0.0:
   dependencies:
     acorn "^3.0.4"
 
+acorn-jsx@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-4.1.1.tgz#e8e41e48ea2fe0c896740610ab6a4ffd8add225e"
+  dependencies:
+    acorn "^5.0.3"
+
 acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
@@ -264,6 +270,10 @@ acorn@^3.0.4:
 acorn@^5.0.0, acorn@^5.3.0, acorn@^5.5.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+acorn@^5.0.3, acorn@^5.6.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
 
 agent-base@4, agent-base@^4.1.0:
   version "4.2.0"
@@ -282,6 +292,10 @@ ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
 
+ajv-keywords@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -297,6 +311,15 @@ ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
     fast-deep-equal "^1.0.0"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
+
+ajv@^6.0.1, ajv@^6.5.0:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.2.tgz#678495f9b82f7cca6be248dd92f59bff5e1f4360"
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.1"
 
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
@@ -1500,6 +1523,16 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1741,6 +1774,16 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.10.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
 es-abstract@^1.5.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
@@ -1827,11 +1870,22 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.10.0, eslint@^4.5.0:
+eslint@^4.5.0:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.18.2.tgz#0f81267ad1012e7d2051e186a9004cc2267b8d45"
   dependencies:
@@ -1873,12 +1927,63 @@ eslint@^4.10.0, eslint@^4.5.0:
     table "4.0.2"
     text-table "~0.2.0"
 
+eslint@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.1.0.tgz#2ed611f1ce163c0fb99e1e0cda5af8f662dff645"
+  dependencies:
+    ajv "^6.5.0"
+    babel-code-frame "^6.26.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^5.2.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.11.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.1.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.0"
+    string.prototype.matchall "^2.0.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
+
 espree@^3.5.2:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
+
+espree@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.0.0.tgz#253998f20a0f82db5d866385799d912a83a36634"
+  dependencies:
+    acorn "^5.6.0"
+    acorn-jsx "^4.1.1"
 
 esprima@^3.1.3:
   version "3.1.3"
@@ -1895,6 +2000,12 @@ esprima@~3.0.0:
 esquery@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esquery@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
     estraverse "^4.0.0"
 
@@ -2010,6 +2121,14 @@ external-editor@^2.0.4:
     iconv-lite "^0.4.17"
     tmp "^0.0.33"
 
+external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -2036,6 +2155,10 @@ extsprintf@1.3.0, extsprintf@^1.2.0:
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
 fast-diff@^1.1.1:
   version "1.1.2"
@@ -2354,6 +2477,10 @@ globals@^11.0.1:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
 
+globals@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
+
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2486,6 +2613,10 @@ has-flag@^3.0.0:
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
+
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -2688,6 +2819,24 @@ inquirer@^3.0.6:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -2950,7 +3099,7 @@ is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
 
-is-resolvable@^1.0.0:
+is-resolvable@^1.0.0, is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -3374,6 +3523,13 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
+js-yaml@^3.11.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
@@ -3435,6 +3591,10 @@ json-parse-better-errors@^1.0.1:
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -3998,6 +4158,10 @@ nerf-dart@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/nerf-dart/-/nerf-dart-1.0.0.tgz#e6dab7febf5ad816ea81cf5c629c5a0ebde72c1a"
 
+nice-try@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
+
 node-emoji@^1.4.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
@@ -4346,7 +4510,7 @@ path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -4634,6 +4798,16 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexp.prototype.flags@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz#6b30724e306a27833eeb171b66ac8890ba37e41c"
+  dependencies:
+    define-properties "^1.1.2"
+
+regexpp@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -4867,6 +5041,12 @@ rx-lite@*, rx-lite@^4.0.8:
 rxjs@^5.4.2:
   version "5.5.6"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
+  dependencies:
+    symbol-observable "1.0.1"
+
+rxjs@^5.5.2:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
   dependencies:
     symbol-observable "1.0.1"
 
@@ -5209,6 +5389,16 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.matchall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-2.0.0.tgz#2af8fe3d2d6dc53ca2a59bd376b089c3c152b3c8"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.10.0"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    regexp.prototype.flags "^1.2.0"
+
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
@@ -5263,7 +5453,7 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -5301,6 +5491,17 @@ table@4.0.2:
   dependencies:
     ajv "^5.2.3"
     ajv-keywords "^2.1.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
+
+table@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
+  dependencies:
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
     chalk "^2.1.0"
     lodash "^4.17.4"
     slice-ansi "1.0.0"
@@ -5347,7 +5548,7 @@ text-extensions@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.7.0.tgz#faaaba2625ed746d568a23e4d0aacd9bf08a8b39"
 
-text-table@~0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -5538,6 +5739,12 @@ update-notifier@^2.3.0:
     latest-version "^3.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
+
+uri-js@^4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
 
 urix@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
This PR targets the `next` branch as discussed in https://github.com/jest-community/eslint-plugin-jest/pull/125#issuecomment-403375120 and takes care of some initial work for the next major version of eslint-plugin-jest.

This PR:

* updates the dev and peer dependency to ESLint >=5
* updates the supported Node engine to v6 (in both package.json and .travis.yml)
* refactors to use object destructuring when requiring functions from './util.js' and 'eslint'

Each commit could be applied as-is to the `next` branch using GitHub's **Rebase and merge** feature, but I will let you determine what the proper merging strategy is for this PR into the `next` branch. 👍 

![image](https://user-images.githubusercontent.com/2344137/42435948-2a9895d2-830d-11e8-9b44-dbcb24e5ef3b.png)
