### PR TITLE
feat(rules): add prefer-inline-snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ for more information about extending configuration files.
 | [prefer-to-be-null][]        | Suggest using `toBeNull()`                                        |                  | ![fixable-green][]  |
 | [prefer-to-be-undefined][]   | Suggest using `toBeUndefined()`                                   |                  | ![fixable-green][]  |
 | [prefer-to-have-length][]    | Suggest using `toHaveLength()`                                    | ![recommended][] | ![fixable-green][]  |
+| [prefer-inline-snapshots][]  | Suggest using `toMatchInlineSnapshot()`                           |                  | ![fixable-green][]  |
 | [valid-describe][]           | Enforce valid `describe()` callback                               |                  |                     |
 | [valid-expect-in-promise][]  | Enforce having return statement when testing with promises        |                  |                     |
 | [valid-expect][]             | Enforce valid `expect()` usage                                    | ![recommended][] |                     |

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ for more information about extending configuration files.
 [prefer-to-be-null]: docs/rules/prefer-to-be-null.md
 [prefer-to-be-undefined]: docs/rules/prefer-to-be-undefined.md
 [prefer-to-have-length]: docs/rules/prefer-to-have-length.md
+[prefer-inline-snapshots]: docs/rules/prefer-inline-snapshots.md
 [valid-describe]: docs/rules/valid-describe.md
 [valid-expect-in-promise]: docs/rules/valid-expect-in-promise.md
 [valid-expect]: docs/rules/valid-expect.md

--- a/docs/rules/prefer-inline-snapshots.md
+++ b/docs/rules/prefer-inline-snapshots.md
@@ -1,0 +1,30 @@
+# Suggest using inline snapshots (prefer-inline-snapshots)
+
+In order to make snapshot tests more managable and reviewable
+`toMatchInlineSnapshot()` and `toThrowErrorMatchingInlineSnapshot` should be
+used to write the snapshots inline in the test file.
+
+## Rule details
+
+This rule triggers a warning if `toMatchSnapshot()` or
+`toThrowErrorMatchingSnapshot` is used to capture a snapshot.
+
+The following pattern is considered warning:
+
+```js
+expect(obj).toMatchSnapshot();
+```
+
+```js
+expect(error).toThrowErrorMatchingSnapshot();
+```
+
+The following pattern is not warning:
+
+```js
+expect(obj).toMatchInlineSnapshot();
+```
+
+```js
+expect(error).toThrowErrorMatchingInlineSnapshot();
+```

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const validDescribe = require('./rules/valid-describe');
 const validExpect = require('./rules/valid-expect');
 const preferExpectAssertions = require('./rules/prefer-expect-assertions');
 const validExpectInPromise = require('./rules/valid-expect-in-promise');
+const preferInlineSnapshots = require('./rules/prefer-inline-snapshots');
 
 const snapshotProcessor = require('./processors/snapshot-processor');
 
@@ -81,5 +82,6 @@ module.exports = {
     'valid-expect': validExpect,
     'prefer-expect-assertions': preferExpectAssertions,
     'valid-expect-in-promise': validExpectInPromise,
+    'prefer-inline-snapshots': preferInlineSnapshots,
   },
 };

--- a/rules/__tests__/prefer-inline-snapshots.test.js
+++ b/rules/__tests__/prefer-inline-snapshots.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../prefer-inline-snapshots');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-inline-snapshots', rule, {
+  valid: [
+    'expect(something).toMatchInlineSnapshot();',
+    'expect(something).toThrowErrorMatchingInlineSnapshot();',
+  ],
+  invalid: [
+    {
+      code: 'expect(something).toMatchSnapshot();',
+      errors: [
+        {
+          message: 'Use toMatchInlineSnapshot() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(something).toMatchInlineSnapshot();',
+    },
+    {
+      code: 'expect(something).toThrowErrorMatchingSnapshot();',
+      errors: [
+        {
+          message: 'Use toThrowErrorMatchingInlineSnapshot() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(something).toThrowErrorMatchingInlineSnapshot();',
+    },
+  ],
+});

--- a/rules/prefer-inline-snapshots.js
+++ b/rules/prefer-inline-snapshots.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const getDocsUrl = require('./util').getDocsUrl;
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const propertyName = node.callee.property && node.callee.property.name;
+        if (propertyName === 'toMatchSnapshot') {
+          context.report({
+            fix(fixer) {
+              return [
+                fixer.replaceText(
+                  node.callee.property,
+                  'toMatchInlineSnapshot'
+                ),
+              ];
+            },
+            message: 'Use toMatchInlineSnapshot() instead',
+            node: node.callee.property,
+          });
+        } else if (propertyName === 'toThrowErrorMatchingSnapshot') {
+          context.report({
+            fix(fixer) {
+              return [
+                fixer.replaceText(
+                  node.callee.property,
+                  'toThrowErrorMatchingInlineSnapshot'
+                ),
+              ];
+            },
+            message: 'Use toThrowErrorMatchingInlineSnapshot() instead',
+            node: node.callee.property,
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## This PR will 

Implement the `prefer-inline-snapshots` rule. This rule serves to encourage interspersing snapshots inline in test file code over writing them to a separate `_snapshots_/*.snap` file.

## Why?
The believe is that the snapshot test is easier to comprehend when it can be seen as a whole. This is especially convenient during code-reviews.