### PR TITLE
fix: no-large-snapshots to allow maxSize of 0

### DIFF
--- a/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`no-large-snapshots ExpressionStatement function should report if maxSize is zero 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "lineCount": 1,
+      "lineLimit": 0,
+    },
+    "message": "Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long",
+    "node": Object {
+      "loc": Object {
+        "end": Object {
+          "line": 2,
+        },
+        "start": Object {
+          "line": 1,
+        },
+      },
+    },
+  },
+]
+`;
+
 exports[`no-large-snapshots ExpressionStatement function should report if node has more lines of code than number given in sizeThreshold option 1`] = `
 Array [
   Object {

--- a/rules/__tests__/no-large-snapshots.test.js
+++ b/rules/__tests__/no-large-snapshots.test.js
@@ -74,6 +74,29 @@ describe('no-large-snapshots', () => {
       expect(mockReport.mock.calls[0]).toMatchSnapshot();
     });
 
+    it('should report if maxSize is zero', () => {
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [{ maxSize: 0 }],
+        report: mockReport,
+      };
+      const mockNode = {
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 2,
+          },
+        },
+      };
+      noLargeSnapshots(mockContext).ExpressionStatement(mockNode);
+
+      expect(mockReport).toHaveBeenCalledTimes(1);
+      expect(mockReport.mock.calls[0]).toMatchSnapshot();
+    });
+
     it('should not report if node has fewer lines of code than limit', () => {
       const mockReport = jest.fn();
       const mockContext = {

--- a/rules/no-large-snapshots.js
+++ b/rules/no-large-snapshots.js
@@ -11,7 +11,9 @@ module.exports = {
   create(context) {
     if (context.getFilename().endsWith('.snap')) {
       const lineLimit =
-        (context.options[0] && context.options[0].maxSize) || 50;
+        context.options[0] && Number.isFinite(context.options[0].maxSize)
+          ? context.options[0].maxSize
+          : 50;
 
       return {
         ExpressionStatement(node) {
@@ -22,7 +24,9 @@ module.exports = {
           if (lineCount > lineLimit) {
             context.report({
               message:
-                'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
+                lineLimit === 0
+                  ? 'Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long'
+                  : 'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
               data: { lineLimit, lineCount },
               node,
             });


### PR DESCRIPTION
**Problem:** Configuring the rule `jest/no-large-snapshots` with `[{ maxSize: 0 }]` sets the line limit to `50` instead of `0`.

**Solution:** Treat `0` as a requirement for no snapshot.