### PR TITLE
feat(rules): add expect-expect

### DIFF
--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -1,0 +1,30 @@
+# Enforce assertion to be made in a test body (expect-expect)
+
+Ensure that there is at least one `expect` call made in a test.
+
+## Rule details
+
+This rule triggers when there is no call made to `expect` in a test, to prevent
+users from forgetting to add assertions.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+it('should be a test', () => {
+  console.log('no assertion');
+});
+test('should assert something', () => {});
+```
+
+The following patterns are not warnings:
+
+```js
+it('should be a test', () => {
+  expect(true).toBeDefined();
+});
+it('should work with callbacks/async', () => {
+  somePromise().then(res => expect(res).toBe('passed'));
+});
+```

--- a/rules/__tests__/expect-expect.test.js
+++ b/rules/__tests__/expect-expect.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../expect-expect');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('expect-expect', rule, {
+  valid: [
+    'it("should pass", () => expect(true).toBeDefined())',
+    'test("should pass", () => expect(true).toBeDefined())',
+    'it("should pass", () => somePromise().then(() => expect(true).toBeDefined()))',
+  ],
+
+  invalid: [
+    {
+      code: 'it("should fail", () => {});',
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'test("should fail", () => {});',
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+    {
+      code: 'it("should fail", () => { somePromise.then(() => {}); });',
+      errors: [
+        {
+          message: 'Test has no assertions',
+          type: 'CallExpression',
+        },
+      ],
+    },
+  ],
+});

--- a/rules/expect-expect.js
+++ b/rules/expect-expect.js
@@ -1,0 +1,63 @@
+'use strict';
+
+/*
+ * This implementation is adapted from eslint-plugin-jasmine.
+ * MIT license, Remco Haszing.
+ */
+
+const getDocsUrl = require('./util').getDocsUrl;
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+  },
+  create(context) {
+    // variables should be defined here
+    const unchecked = [];
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+    const isExpectCall = node =>
+      // if we're not calling a function, ignore
+      node.type === 'CallExpression' &&
+      // if we're not calling expect, ignore
+      node.callee.name === 'expect';
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+    return {
+      // give me methods
+      CallExpression(node) {
+        // keep track of `it` calls
+        if (['it', 'test'].indexOf(node.callee.name) > -1) {
+          unchecked.push(node);
+          return;
+        }
+        if (!isExpectCall(node)) {
+          return;
+        }
+        // here, we do have a call to expect
+        // use `some` to return early (in case of nested `it`s
+        context.getAncestors().some(ancestor => {
+          const index = unchecked.indexOf(ancestor);
+          if (index !== -1) {
+            unchecked.splice(index, 1);
+            return true;
+          }
+          return false;
+        });
+      },
+      'Program:exit'() {
+        unchecked.forEach(node =>
+          context.report({
+            message: 'Test has no assertions',
+            node,
+          })
+        );
+      },
+    };
+  },
+};


### PR DESCRIPTION
This rule solves a common pain point at our company (and in a few issues on the main jest repo). We want to ensure that no-one has forgotten to add assertions to their tests. The standard way to do this is to use `expect.hasAssertions` or `expect.assertions`.

However, I added this lint rule to [our internal eslint plugin](https://github.com/TandaHQ/eslint-plugin-tanda/blob/master/lib/rules/expect-expect.js) and thought maybe it'd be beneficial to a wider audience.

The only case this doesn't cover (as I can see) is if you `throw` inside your test. And, of course, if you use a non-`expect`-based assertion library.