### PR TITLE
feat(rules): add prefer-strict-equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ for more information about extending configuration files.
 | [no-large-snapshots][]       | Disallow large snapshots                                          |                  |                     |
 | [no-test-prefixes][]         | Disallow using `f` & `x` prefixes to define focused/skipped tests |                  | ![fixable-green][]  |
 | [prefer-expect-assertions][] | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
+| [prefer-strict-equal][]      | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
 | [prefer-to-be-null][]        | Suggest using `toBeNull()`                                        |                  | ![fixable-green][]  |
 | [prefer-to-be-undefined][]   | Suggest using `toBeUndefined()`                                   |                  | ![fixable-green][]  |
 | [prefer-to-have-length][]    | Suggest using `toHaveLength()`                                    | ![recommended][] | ![fixable-green][]  |
@@ -115,6 +116,7 @@ for more information about extending configuration files.
 [no-large-snapshots]: docs/rules/no-large-snapshots.md
 [no-test-prefixes]: docs/rules/no-test-prefixes.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
+[prefer-strict-equal]: docs/rules/prefer-strict-equal.md
 [prefer-to-be-null]: docs/rules/prefer-to-be-null.md
 [prefer-to-be-undefined]: docs/rules/prefer-to-be-undefined.md
 [prefer-to-have-length]: docs/rules/prefer-to-have-length.md

--- a/docs/rules/prefer-strict-equal.md
+++ b/docs/rules/prefer-strict-equal.md
@@ -1,0 +1,25 @@
+# Suggest using `toStrictEqual()` ` (prefer-strict-equal)
+
+`toStrictEqual` not only checks that two objects contain the same data but also
+that they have the same shape. The believe is that imposing a stricter equality
+results in safer tests.
+
+## Rule details
+
+This rule triggers a warning if `toEqual()` is used to assert equality.
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following pattern is considered warning:
+
+```js
+expect({ a: 'a', b: undefined }).toEqual({ a: 'a' }); // true
+```
+
+The following pattern is not warning:
+
+```js
+expect({ a: 'a', b: undefined }).toStrictEqual({ a: 'a' }); // false
+```

--- a/docs/rules/prefer-strict-equal.md
+++ b/docs/rules/prefer-strict-equal.md
@@ -1,4 +1,4 @@
-# Suggest using `toStrictEqual()` ` (prefer-strict-equal)
+# Suggest using `toStrictEqual()` (prefer-strict-equal)
 
 `toStrictEqual` not only checks that two objects contain the same data but also
 that they have the same shape. The believe is that imposing a stricter equality

--- a/docs/rules/prefer-strict-equal.md
+++ b/docs/rules/prefer-strict-equal.md
@@ -1,14 +1,11 @@
 # Suggest using `toStrictEqual()` (prefer-strict-equal)
 
 `toStrictEqual` not only checks that two objects contain the same data but also
-that they have the same shape. The believe is that imposing a stricter equality
-results in safer tests.
+that they have the same structure. It is common to expect objects to not only have identical values but also to have identical keys. A stricter equality will catch cases where two objects do not have identical keys.
 
 ## Rule details
 
 This rule triggers a warning if `toEqual()` is used to assert equality.
-
-This rule is enabled by default.
 
 ### Default configuration
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const validExpect = require('./rules/valid-expect');
 const preferExpectAssertions = require('./rules/prefer-expect-assertions');
 const validExpectInPromise = require('./rules/valid-expect-in-promise');
 const preferInlineSnapshots = require('./rules/prefer-inline-snapshots');
+const preferStrictEqual = require('./rules/prefer-strict-equal');
 
 const snapshotProcessor = require('./processors/snapshot-processor');
 
@@ -83,5 +84,6 @@ module.exports = {
     'prefer-expect-assertions': preferExpectAssertions,
     'valid-expect-in-promise': validExpectInPromise,
     'prefer-inline-snapshots': preferInlineSnapshots,
+    'prefer-strict-equal': preferStrictEqual,
   },
 };

--- a/rules/__tests__/prefer-strict-equal.test.js
+++ b/rules/__tests__/prefer-strict-equal.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../prefer-strict-equal');
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-strict-equal', rule, {
+  valid: ['expect(something).toStrictEqual(somethingElse);'],
+  invalid: [
+    {
+      code: 'expect(something).toEqual(somethingElse);',
+      errors: [
+        {
+          message: 'Use toStrictEqual() instead',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(something).toStrictEqual(somethingElse);',
+    },
+  ],
+});

--- a/rules/prefer-strict-equal.js
+++ b/rules/prefer-strict-equal.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const getDocsUrl = require('./util').getDocsUrl;
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const propertyName = node.callee.property && node.callee.property.name;
+        if (propertyName === 'toEqual') {
+          context.report({
+            fix(fixer) {
+              return [fixer.replaceText(node.callee.property, 'toStrictEqual')];
+            },
+            message: 'Use toStrictEqual() instead',
+            node: node.callee.property,
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## This PR will 

Implement the `prefer-strict-equal` rule. This rule serves to encourage stricter equality checks on objects.

## Why?
The believe is that imposing stricter equality results in safer tests.