### PR TITLE
fix(no-disabled-tests): fix false positives for pending() usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
   },
   env: {
     node: true,
+    es6: true,
   },
   rules: {
     eqeqeq: ['error', 'smart'],

--- a/rules/__tests__/no-disabled-tests.test.js
+++ b/rules/__tests__/no-disabled-tests.test.js
@@ -3,7 +3,11 @@
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../no-disabled-tests');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
 
 ruleTester.run('no-disabled-tests', rule, {
   valid: [
@@ -17,6 +21,35 @@ ruleTester.run('no-disabled-tests', rule, {
     'var calledSkip = it.skip; calledSkip.call(it)',
     '({ f: function () {} }).f()',
     '(a || b).f()',
+    [
+      'import { pending } from "actions"',
+      '',
+      'test("foo", () => {',
+      '  expect(pending()).toEqual({})',
+      '})',
+    ].join('\n'),
+    [
+      'const { pending } = require("actions")',
+      '',
+      'test("foo", () => {',
+      '  expect(pending()).toEqual({})',
+      '})',
+    ].join('\n'),
+    [
+      'test("foo", () => {',
+      '  const pending = getPending()',
+      '  expect(pending()).toEqual({})',
+      '})',
+    ].join('\n'),
+    [
+      'test("foo", () => {',
+      '  expect(pending()).toEqual({})',
+      '})',
+      '',
+      'function pending() {',
+      '  return {}',
+      '}',
+    ].join('\n'),
   ],
 
   invalid: [


### PR DESCRIPTION
Resolves #149 

This PR adds some failing test cases and fixes for false positive warnings of `pending()` in the no-disabled-tests rule.

I'll add some comments inline to help explain my solution - feedback welcome! 😺 