### PR TITLE
refactor(no-jest-import): use ESQuery syntax for selectors

### DIFF
--- a/rules/no-jest-import.js
+++ b/rules/no-jest-import.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const getDocsUrl = require('./util').getDocsUrl;
-const getNodeName = require('./util').getNodeName;
+
 const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
 
 module.exports = {
@@ -12,32 +12,20 @@ module.exports = {
   },
   create(context) {
     return {
-      ImportDeclaration(node) {
-        if (node.source.value === 'jest') {
-          context.report({
-            node,
-            message,
-          });
-        }
+      'ImportDeclaration[source.value="jest"]'(node) {
+        context.report({ node, message });
       },
-      CallExpression(node) {
-        const calleeName = getNodeName(node.callee);
-        if (
-          calleeName === 'require' &&
-          node.arguments[0] &&
-          node.arguments[0].value === 'jest'
-        ) {
-          context.report({
-            loc: {
-              end: {
-                column: node.arguments[0].loc.end.column,
-                line: node.arguments[0].loc.end.line,
-              },
-              start: node.arguments[0].loc.start,
+      'CallExpression[callee.name="require"][arguments.0.value="jest"]'(node) {
+        context.report({
+          loc: {
+            end: {
+              column: node.arguments[0].loc.end.column,
+              line: node.arguments[0].loc.end.line,
             },
-            message,
-          });
-        }
+            start: node.arguments[0].loc.start,
+          },
+          message,
+        });
       },
     };
   },

--- a/rules/no-jest-import.js
+++ b/rules/no-jest-import.js
@@ -17,13 +17,7 @@ module.exports = {
       },
       'CallExpression[callee.name="require"][arguments.0.value="jest"]'(node) {
         context.report({
-          loc: {
-            end: {
-              column: node.arguments[0].loc.end.column,
-              line: node.arguments[0].loc.end.line,
-            },
-            start: node.arguments[0].loc.start,
-          },
+          loc: node.arguments[0].loc,
           message,
         });
       },


### PR DESCRIPTION
ESLint visitor selectors support [ESQuery](https://github.com/estools/esquery) syntax, which is similar to a CSS style selector pattern. I'm opening this PR partly to show that it's capable to move some logic into these selectors (like `[callee.name="require"]`), but also to get some feedback if there is interest in introducing these into the codebase. Learned about them this weekend and wanted to share in the context of an ESLint plugin. 🤓 No worries on my end if this is merged or closed, more just want to start a discussion. 