### PR TITLE
prefer-strict-equal: Only run if `expect` is used

### DIFF
--- a/rules/__tests__/prefer-strict-equal.test.js
+++ b/rules/__tests__/prefer-strict-equal.test.js
@@ -6,7 +6,10 @@ const rule = require('../prefer-strict-equal');
 const ruleTester = new RuleTester();
 
 ruleTester.run('prefer-strict-equal', rule, {
-  valid: ['expect(something).toStrictEqual(somethingElse);'],
+  valid: [
+    'expect(something).toStrictEqual(somethingElse);',
+    "a().toEqual('b')",
+  ],
   invalid: [
     {
       code: 'expect(something).toEqual(somethingElse);',

--- a/rules/prefer-strict-equal.js
+++ b/rules/prefer-strict-equal.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const expectCase = require('./util').expectCase;
 const getDocsUrl = require('./util').getDocsUrl;
+const method = require('./util').method;
 
 module.exports = {
   meta: {
@@ -12,14 +14,19 @@ module.exports = {
   create(context) {
     return {
       CallExpression(node) {
-        const propertyName = node.callee.property && node.callee.property.name;
+        if (!expectCase(node)) {
+          return;
+        }
+
+        const propertyName = method(node) && method(node).name;
+
         if (propertyName === 'toEqual') {
           context.report({
             fix(fixer) {
-              return [fixer.replaceText(node.callee.property, 'toStrictEqual')];
+              return [fixer.replaceText(method(node), 'toStrictEqual')];
             },
             message: 'Use toStrictEqual() instead',
-            node: node.callee.property,
+            node: method(node),
           });
         }
       },


### PR DESCRIPTION
Only run the rule `prefer-strict-equal` on `CallExpression`s where `expect` is used.