### PR TITLE
fix(no-disabled-tests): stop picking up all funcs that start it/test

### DIFF
--- a/rules/__tests__/no-disabled-tests.test.js
+++ b/rules/__tests__/no-disabled-tests.test.js
@@ -21,6 +21,8 @@ ruleTester.run('no-disabled-tests', rule, {
     'var calledSkip = it.skip; calledSkip.call(it)',
     '({ f: function () {} }).f()',
     '(a || b).f()',
+    'itHappensToStartWithIt()',
+    'testSomething()',
     [
       'import { pending } from "actions"',
       '',

--- a/rules/__tests__/prefer-expect-assertions.test.js
+++ b/rules/__tests__/prefer-expect-assertions.test.js
@@ -87,5 +87,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
       '\n\t\t\texpect(someValue).toBe(true)\n' +
       '\t\t\t})',
     'test("it1")',
+    'itHappensToStartWithIt("foo", function() {})',
+    'testSomething("bar", function() {})',
   ],
 });

--- a/rules/no-disabled-tests.js
+++ b/rules/no-disabled-tests.js
@@ -44,10 +44,10 @@ module.exports = {
       'CallExpression[callee.name="describe"]'() {
         suiteDepth++;
       },
-      'CallExpression[callee.name=/^it|test$/]'() {
+      'CallExpression[callee.name=/^(it|test)$/]'() {
         testDepth++;
       },
-      'CallExpression[callee.name=/^it|test$/][arguments.length<2]'(node) {
+      'CallExpression[callee.name=/^(it|test)$/][arguments.length<2]'(node) {
         context.report({
           message: 'Test is missing function argument',
           node,

--- a/rules/prefer-expect-assertions.js
+++ b/rules/prefer-expect-assertions.js
@@ -54,7 +54,7 @@ module.exports = {
   },
   create(context) {
     return {
-      'CallExpression[callee.name=/^it|test$/][arguments.1.body.body]'(node) {
+      'CallExpression[callee.name=/^(it|test)$/][arguments.1.body.body]'(node) {
         const testFuncBody = node.arguments[1].body.body;
 
         if (!isFirstLineExprStmt(testFuncBody)) {


### PR DESCRIPTION
A bug in the regex means that this version picks up functions it shouldn't and warns that they don't have two arguments. For example, these lines in our codebase fail:

```
const dummyItem = itemBuilder({ // fails here
```

```
const showOutOfStockBadge = itemEntirelyOutOfStock(this.props.item);
```

Commit includes a test that was failing and the fix which is just to wrap brackets around the match in the regex.