### PR TITLE
Fix: no-alias-methods supports .resolves & .rejects

### DIFF
--- a/rules/__tests__/no-alias-methods.test.js
+++ b/rules/__tests__/no-alias-methods.test.js
@@ -177,5 +177,17 @@ ruleTester.run('no-alias-methods', rule, {
       ],
       output: 'expect(a).rejects.toThrow()',
     },
+    {
+      code: 'expect(a).not.toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 15,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).not.toThrow()',
+    },
   ],
 });

--- a/rules/__tests__/no-alias-methods.test.js
+++ b/rules/__tests__/no-alias-methods.test.js
@@ -153,5 +153,29 @@ ruleTester.run('no-alias-methods', rule, {
       ],
       output: 'expect(a).toThrow()',
     },
+    {
+      code: 'expect(a).resolves.toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 20,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).resolves.toThrow()',
+    },
+    {
+      code: 'expect(a).rejects.toThrowError()',
+      errors: [
+        {
+          message:
+            'Replace toThrowError() with its canonical name of toThrow()',
+          column: 19,
+          line: 1,
+        },
+      ],
+      output: 'expect(a).rejects.toThrow()',
+    },
   ],
 });

--- a/rules/no-alias-methods.js
+++ b/rules/no-alias-methods.js
@@ -33,7 +33,11 @@ module.exports = {
         }
 
         let targetNode = method(node);
-        if (targetNode.name === 'resolves' || targetNode.name === 'rejects') {
+        if (
+          targetNode.name === 'resolves' ||
+          targetNode.name === 'rejects' ||
+          targetNode.name === 'not'
+        ) {
           targetNode = method(node.parent);
         }
 

--- a/rules/no-alias-methods.js
+++ b/rules/no-alias-methods.js
@@ -32,9 +32,15 @@ module.exports = {
           return;
         }
 
-        // Check if the method used matches any of ours.
-        const propertyName = method(node) && method(node).name;
-        const methodItem = methodNames.find(item => item[1] === propertyName);
+        let targetNode = method(node);
+        if (targetNode.name === 'resolves' || targetNode.name === 'rejects') {
+          targetNode = method(node.parent);
+        }
+
+        // Check if the method used matches any of ours
+        const methodItem = methodNames.find(
+          item => item[1] === targetNode.name
+        );
 
         if (methodItem) {
           context.report({
@@ -43,9 +49,9 @@ module.exports = {
               replace: methodItem[1],
               canonical: methodItem[0],
             },
-            node: method(node),
+            node: targetNode,
             fix(fixer) {
-              return [fixer.replaceText(method(node), methodItem[0])];
+              return [fixer.replaceText(targetNode, methodItem[0])];
             },
           });
         }


### PR DESCRIPTION
The autofix for `no-alias-methods` didn't catch everything it could've in our internal repo. Specifically `.resolves` & `.rejects` were missed.

This PR assumes that the full list of `methodNames` can be prefixed with `.resolves` and `.rejects`.

There may be other helpers I've overlooked that could be added here. For now, I erred on the side of caution.