### PR TITLE
fix: use range instead of start/end properties

### DIFF
--- a/rules/lowercase-name.js
+++ b/rules/lowercase-name.js
@@ -78,8 +78,8 @@ module.exports = {
               const description = testDescription(node);
 
               const rangeIgnoringQuotes = [
-                firstArg.start + 1,
-                firstArg.end - 1,
+                firstArg.range[0] + 1,
+                firstArg.range[1] - 1,
               ];
               const newDescription =
                 description.substring(0, 1).toLowerCase() +

--- a/rules/prefer-spy-on.js
+++ b/rules/prefer-spy-on.js
@@ -53,11 +53,11 @@ module.exports = {
             return [
               fixer.insertTextBefore(node.left, `jest.spyOn(`),
               fixer.replaceTextRange(
-                [node.left.object.end, node.left.property.start],
+                [node.left.object.range[1], node.left.property.range[0]],
                 `, ${leftPropQuote}`
               ),
               fixer.replaceTextRange(
-                [node.left.property.end, jestFnCall.end],
+                [node.left.property.range[1], jestFnCall.range[1]],
                 `${leftPropQuote})${mockImplementation}`
               ),
             ];


### PR DESCRIPTION
This PR replaces usage of non standard fields `start`, `end` with `range`.

Properties `start`, `end` should not be used (they may be removed in feature)

currently those rules are crashing because of that if you decide to use ([@typescript-eslint/parser](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/parser)) 

see: https://eslint.org/docs/developer-guide/working-with-custom-parsers#all-nodes

fixes: https://github.com/typescript-eslint/typescript-eslint/issues/175