### PR TITLE
New rule: no-test-todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ for more information about extending configuration files.
 | [no-test-prefixes][]         | Disallow using `f` & `x` prefixes to define focused/skipped tests | ![recommended][] | ![fixable-green][]  |
 | [no-test-return-statement][] | Disallow explicitly returning from tests                          |                  |                     |
 | [no-truthy-falsy][]          | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
+| [no-test-todo][]             | Disallow using the .todo modifiers on tests                       |                  |                     |
 | [prefer-expect-assertions][] | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
 | [prefer-spy-on][]            | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
 | [prefer-strict-equal][]      | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
@@ -141,6 +142,7 @@ for more information about extending configuration files.
 [no-test-prefixes]: docs/rules/no-test-prefixes.md
 [no-test-return-statement]: docs/rules/no-test-return-statement.md
 [no-truthy-falsy]: docs/rules/no-truthy-falsy.md
+[no-test-todo]: docs/rules/no-test-todo.md
 [prefer-called-with]: docs/rules/prefer-called-with.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
 [prefer-spy-on]: docs/rules/prefer-spy-on.md

--- a/docs/rules/no-test-todo.md
+++ b/docs/rules/no-test-todo.md
@@ -1,0 +1,27 @@
+# Disallow unfinished tests (no-test-todo)
+
+Jest allows you to plan tests by only providing the test description
+([Jest Documentation](https://jestjs.io/docs/en/api#testtodoname)).  
+This rule can be used to ensure that none of these unfinished tests will be
+committed or to be reminded of unfinished tests by setting the rule severity to
+warn.
+
+## Rule details
+
+This rule triggers a warning if you add the modifier `.todo` to `test` or `it`.
+
+```js
+// valid:
+it('test description', () => {});
+
+test('test description', () => {});
+
+it.skip('test description', () => {});
+
+it.only('test description', () => {});
+
+// invalid:
+it.todo('test description');
+
+test.todo('test description');
+```

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const noJestImport = require('./rules/no-jest-import');
 const noLargeSnapshots = require('./rules/no-large-snapshots');
 const noTestPrefixes = require('./rules/no-test-prefixes');
 const noTestReturnStatement = require('./rules/no-test-return-statement');
+const noTestTodo = require('./rules/no-test-todo');
 const preferSpyOn = require('./rules/prefer-spy-on');
 const preferToBeNull = require('./rules/prefer-to-be-null');
 const preferToBeUndefined = require('./rules/prefer-to-be-undefined');
@@ -101,6 +102,7 @@ module.exports = {
     'no-large-snapshots': noLargeSnapshots,
     'no-test-prefixes': noTestPrefixes,
     'no-test-return-statement': noTestReturnStatement,
+    'no-test-todo': noTestTodo,
     'prefer-spy-on': preferSpyOn,
     'prefer-to-be-null': preferToBeNull,
     'prefer-to-be-undefined': preferToBeUndefined,

--- a/rules/__tests__/no-test-todo.test.js
+++ b/rules/__tests__/no-test-todo.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-test-todo');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-test-todo', rule, {
+  valid: [
+    'it("test description", () => {})',
+    'test("test description", () => {})',
+    'test.only("test description", () => {})',
+    'test.skip("test description", () => {})',
+  ],
+
+  invalid: [
+    {
+      code: 'it.todo("test description")',
+      errors: [{ messageId: 'no-test-todo' }],
+    },
+    {
+      code: 'test.todo("test description")',
+      errors: [{ messageId: 'no-test-todo' }],
+    },
+  ],
+});

--- a/rules/no-test-todo.js
+++ b/rules/no-test-todo.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { getDocsUrl, getNodeName } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    messages: {
+      'no-test-todo': 'Unexpected test modifier .todo',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const functionName = getNodeName(node.callee);
+
+        if (functionName === 'test.todo' || functionName === 'it.todo') {
+          context.report({ messageId: 'no-test-todo', node });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Hi,
I decided to contribute the additional rules of my local fork.
Most of them are inspired by other eslint plugins (ava, mocha and jasmine), as well as jest errors.
This rule warns if test.todo() is used ([reference](https://github.com/avajs/eslint-plugin-ava/blob/master/docs/rules/no-todo-test.md)).


The other rules are:
- no-empty-test-file:             Disallow test files without a single test block
- no-empty-test-suites:           Disallow empty test suites (describe)
- no-global-tests:                Disallow tests outside of test suites
- no-global-setup:                Disallow hooks in global scope
- no-nested-tests:                Disallow tests inside of other tests                  
- no-test-todo-implementation:    Disallow tests with a .todo modifier to have an implementation
- require-single-top-level-suite: Require a single top level describe block
- require-newline-before-expect:  Requires a newline before expect() call(s)
- test-suite-spacing:             Specify the spacing between test suites
- declaration-spacing:            Specify the spacing between declaration (before, after, it, ...) inside test suites (differentiates between hooks, "hook groups" and test blocks)
- declaration-order:              Specify the order of the declarations (default: beforeAll, afterAll, beforeEach, afterEach, test)

I try to create PRs for the remaining rules over the course of this week.  
If any of these rules is not wanted, please tell me.

Any feedback is appreciated.