### PR TITLE
feat(rules): various rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ for more information about extending configuration files.
 | [no-test-prefixes][]         | Disallow using `f` & `x` prefixes to define focused/skipped tests | ![recommended][] | ![fixable-green][]  |
 | [no-test-return-statement][] | Disallow explicitly returning from tests                          |                  |                     |
 | [no-truthy-falsy][]          | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
+| [no-test-todo][]             | Disallow using the .todo modifiers on tests                       |                  |                     |
 | [prefer-expect-assertions][] | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
 | [prefer-spy-on][]            | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
 | [prefer-strict-equal][]      | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
@@ -141,6 +142,7 @@ for more information about extending configuration files.
 [no-test-prefixes]: docs/rules/no-test-prefixes.md
 [no-test-return-statement]: docs/rules/no-test-return-statement.md
 [no-truthy-falsy]: docs/rules/no-truthy-falsy.md
+[no-test-todo]: docs/rules/no-test-todo.md
 [prefer-called-with]: docs/rules/prefer-called-with.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
 [prefer-spy-on]: docs/rules/prefer-spy-on.md

--- a/README.md
+++ b/README.md
@@ -89,38 +89,39 @@ for more information about extending configuration files.
 
 ## Rules
 
-| Rule                         | Description                                                       | Recommended      | Fixable             |
-| ---------------------------- | ----------------------------------------------------------------- | ---------------- | ------------------- |
-| [consistent-test-it][]       | Enforce consistent test or it keyword                             |                  | ![fixable-green][]  |
-| [expect-expect][]            | Enforce assertion to be made in a test body                       |                  |                     |
-| [lowercase-name][]           | Disallow capitalized test names                                   |                  | ![fixable-green][]  |
-| [no-alias-methods][]         | Disallow alias methods                                            | ![recommended][] | ![fixable-green][]  |
-| [no-disabled-tests][]        | Disallow disabled tests                                           | ![recommended][] |                     |
-| [no-focused-tests][]         | Disallow focused tests                                            | ![recommended][] |                     |
-| [no-hooks][]                 | Disallow setup and teardown hooks                                 |                  |                     |
-| [no-identical-title][]       | Disallow identical titles                                         | ![recommended][] |                     |
-| [no-jasmine-globals][]       | Disallow Jasmine globals                                          | ![recommended][] | ![fixable-yellow][] |
-| [no-jest-import][]           | Disallow importing `jest`                                         | ![recommended][] |                     |
-| [no-large-snapshots][]       | Disallow large snapshots                                          |                  |                     |
-| [no-test-callback][]         | Using a callback in asynchronous tests                            |                  | ![fixable-green][]  |
-| [no-test-prefixes][]         | Disallow using `f` & `x` prefixes to define focused/skipped tests | ![recommended][] | ![fixable-green][]  |
-| [no-test-return-statement][] | Disallow explicitly returning from tests                          |                  |                     |
-| [no-truthy-falsy][]          | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
-| [no-test-todo][]             | Disallow using the .todo modifiers on tests                       |                  |                     |
-| [prefer-expect-assertions][] | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
-| [prefer-spy-on][]            | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
-| [prefer-strict-equal][]      | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
-| [prefer-to-be-null][]        | Suggest using `toBeNull()`                                        |                  | ![fixable-green][]  |
-| [prefer-to-be-undefined][]   | Suggest using `toBeUndefined()`                                   |                  | ![fixable-green][]  |
-| [prefer-to-contain][]        | Suggest using `toContain()`                                       |                  | ![fixable-green][]  |
-| [prefer-to-have-length][]    | Suggest using `toHaveLength()`                                    |                  | ![fixable-green][]  |
-| [prefer-inline-snapshots][]  | Suggest using `toMatchInlineSnapshot()`                           |                  | ![fixable-green][]  |
-| [require-tothrow-message][]  | Require that `toThrow()` and `toThrowError` includes a message    |                  |                     |
-| [valid-describe][]           | Enforce valid `describe()` callback                               | ![recommended][] |                     |
-| [valid-expect-in-promise][]  | Enforce having return statement when testing with promises        | ![recommended][] |                     |
-| [valid-expect][]             | Enforce valid `expect()` usage                                    | ![recommended][] |                     |
-| [prefer-todo][]              | Suggest using `test.todo()`                                       |                  | ![fixable-green][]  |
-| [prefer-called-with][]       | Suggest using `toBeCalledWith()` OR `toHaveBeenCalledWith()`      |                  |                     |
+| Rule                            | Description                                                       | Recommended      | Fixable             |
+| ------------------------------- | ----------------------------------------------------------------- | ---------------- | ------------------- |
+| [consistent-test-it][]          | Enforce consistent test or it keyword                             |                  | ![fixable-green][]  |
+| [expect-expect][]               | Enforce assertion to be made in a test body                       |                  |                     |
+| [lowercase-name][]              | Disallow capitalized test names                                   |                  | ![fixable-green][]  |
+| [no-alias-methods][]            | Disallow alias methods                                            | ![recommended][] | ![fixable-green][]  |
+| [no-disabled-tests][]           | Disallow disabled tests                                           | ![recommended][] |                     |
+| [no-focused-tests][]            | Disallow focused tests                                            | ![recommended][] |                     |
+| [no-hooks][]                    | Disallow setup and teardown hooks                                 |                  |                     |
+| [no-identical-title][]          | Disallow identical titles                                         | ![recommended][] |                     |
+| [no-jasmine-globals][]          | Disallow Jasmine globals                                          | ![recommended][] | ![fixable-yellow][] |
+| [no-jest-import][]              | Disallow importing `jest`                                         | ![recommended][] |                     |
+| [no-large-snapshots][]          | Disallow large snapshots                                          |                  |                     |
+| [no-test-callback][]            | Using a callback in asynchronous tests                            |                  | ![fixable-green][]  |
+| [no-test-prefixes][]            | Disallow using `f` & `x` prefixes to define focused/skipped tests | ![recommended][] | ![fixable-green][]  |
+| [no-test-return-statement][]    | Disallow explicitly returning from tests                          |                  |                     |
+| [no-truthy-falsy][]             | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
+| [no-test-todo][]                | Disallow using the .todo modifiers on tests                       |                  |                     |
+| [no-test-todo-implementation][] | Disallow tests with .todo modifier to have an implementation      |                  |                     |  |
+| [prefer-expect-assertions][]    | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
+| [prefer-spy-on][]               | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
+| [prefer-strict-equal][]         | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
+| [prefer-to-be-null][]           | Suggest using `toBeNull()`                                        |                  | ![fixable-green][]  |
+| [prefer-to-be-undefined][]      | Suggest using `toBeUndefined()`                                   |                  | ![fixable-green][]  |
+| [prefer-to-contain][]           | Suggest using `toContain()`                                       |                  | ![fixable-green][]  |
+| [prefer-to-have-length][]       | Suggest using `toHaveLength()`                                    |                  | ![fixable-green][]  |
+| [prefer-inline-snapshots][]     | Suggest using `toMatchInlineSnapshot()`                           |                  | ![fixable-green][]  |
+| [require-tothrow-message][]     | Require that `toThrow()` and `toThrowError` includes a message    |                  |                     |
+| [valid-describe][]              | Enforce valid `describe()` callback                               | ![recommended][] |                     |
+| [valid-expect-in-promise][]     | Enforce having return statement when testing with promises        | ![recommended][] |                     |
+| [valid-expect][]                | Enforce valid `expect()` usage                                    | ![recommended][] |                     |
+| [prefer-todo][]                 | Suggest using `test.todo()`                                       |                  | ![fixable-green][]  |
+| [prefer-called-with][]          | Suggest using `toBeCalledWith()` OR `toHaveBeenCalledWith()`      |                  |                     |
 
 ## Credit
 
@@ -143,20 +144,21 @@ for more information about extending configuration files.
 [no-test-return-statement]: docs/rules/no-test-return-statement.md
 [no-truthy-falsy]: docs/rules/no-truthy-falsy.md
 [no-test-todo]: docs/rules/no-test-todo.md
+
+[no-test-todo-implementation] docs/rules/no-test-todo-implementation.md
 [prefer-called-with]: docs/rules/prefer-called-with.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
-[prefer-spy-on]: docs/rules/prefer-spy-on.md
-[prefer-strict-equal]: docs/rules/prefer-strict-equal.md
-[prefer-to-be-null]: docs/rules/prefer-to-be-null.md
-[prefer-to-be-undefined]: docs/rules/prefer-to-be-undefined.md
-[prefer-to-contain]: docs/rules/prefer-to-contain.md
-[prefer-to-have-length]: docs/rules/prefer-to-have-length.md
-[prefer-inline-snapshots]: docs/rules/prefer-inline-snapshots.md
-[require-tothrow-message]: docs/rules/require-tothrow-message.md
-[valid-describe]: docs/rules/valid-describe.md
-[valid-expect-in-promise]: docs/rules/valid-expect-in-promise.md
-[valid-expect]: docs/rules/valid-expect.md
-[prefer-todo]: docs/rules/prefer-todo.md
-[fixable-green]: https://img.shields.io/badge/-fixable-green.svg
-[fixable-yellow]: https://img.shields.io/badge/-fixable-yellow.svg
-[recommended]: https://img.shields.io/badge/-recommended-lightgrey.svg
+[prefer-spy-on]: docs/rules/prefer-spy-on.md [prefer-strict-equal]:
+docs/rules/prefer-strict-equal.md [prefer-to-be-null]:
+docs/rules/prefer-to-be-null.md [prefer-to-be-undefined]:
+docs/rules/prefer-to-be-undefined.md [prefer-to-contain]:
+docs/rules/prefer-to-contain.md [prefer-to-have-length]:
+docs/rules/prefer-to-have-length.md [prefer-inline-snapshots]:
+docs/rules/prefer-inline-snapshots.md [require-tothrow-message]:
+docs/rules/require-tothrow-message.md [valid-describe]:
+docs/rules/valid-describe.md [valid-expect-in-promise]:
+docs/rules/valid-expect-in-promise.md [valid-expect]: docs/rules/valid-expect.md
+[prefer-todo]: docs/rules/prefer-todo.md [fixable-green]:
+https://img.shields.io/badge/-fixable-green.svg [fixable-yellow]:
+https://img.shields.io/badge/-fixable-yellow.svg [recommended]:
+https://img.shields.io/badge/-recommended-lightgrey.svg

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ for more information about extending configuration files.
 | [no-test-return-statement][]    | Disallow explicitly returning from tests                          |                  |                     |
 | [no-truthy-falsy][]             | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
 | [no-test-todo][]                | Disallow using the .todo modifiers on tests                       |                  |                     |
-| [no-test-todo-implementation][] | Disallow tests with .todo modifier to have an implementation      |                  |                     |  |
+| [no-test-todo-implementation][] | Disallow tests with .todo modifier to have an implementation      |                  |                     |
 | [prefer-expect-assertions][]    | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
 | [prefer-spy-on][]               | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
 | [prefer-strict-equal][]         | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
@@ -144,21 +144,21 @@ for more information about extending configuration files.
 [no-test-return-statement]: docs/rules/no-test-return-statement.md
 [no-truthy-falsy]: docs/rules/no-truthy-falsy.md
 [no-test-todo]: docs/rules/no-test-todo.md
-
-[no-test-todo-implementation] docs/rules/no-test-todo-implementation.md
+[no-test-todo-implementation]: docs/rules/no-test-todo-implementation.md
 [prefer-called-with]: docs/rules/prefer-called-with.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
-[prefer-spy-on]: docs/rules/prefer-spy-on.md [prefer-strict-equal]:
-docs/rules/prefer-strict-equal.md [prefer-to-be-null]:
-docs/rules/prefer-to-be-null.md [prefer-to-be-undefined]:
-docs/rules/prefer-to-be-undefined.md [prefer-to-contain]:
-docs/rules/prefer-to-contain.md [prefer-to-have-length]:
-docs/rules/prefer-to-have-length.md [prefer-inline-snapshots]:
-docs/rules/prefer-inline-snapshots.md [require-tothrow-message]:
-docs/rules/require-tothrow-message.md [valid-describe]:
-docs/rules/valid-describe.md [valid-expect-in-promise]:
-docs/rules/valid-expect-in-promise.md [valid-expect]: docs/rules/valid-expect.md
-[prefer-todo]: docs/rules/prefer-todo.md [fixable-green]:
-https://img.shields.io/badge/-fixable-green.svg [fixable-yellow]:
-https://img.shields.io/badge/-fixable-yellow.svg [recommended]:
-https://img.shields.io/badge/-recommended-lightgrey.svg
+[prefer-spy-on]: docs/rules/prefer-spy-on.md
+[prefer-strict-equal]: docs/rules/prefer-strict-equal.md
+[prefer-to-be-null]: docs/rules/prefer-to-be-null.md
+[prefer-to-be-undefined]: docs/rules/prefer-to-be-undefined.md
+[prefer-to-contain]: docs/rules/prefer-to-contain.md
+[prefer-to-have-length]: docs/rules/prefer-to-have-length.md
+[prefer-inline-snapshots]: docs/rules/prefer-inline-snapshots.md
+[require-tothrow-message]: docs/rules/require-tothrow-message.md
+[valid-describe]: docs/rules/valid-describe.md
+[valid-expect-in-promise]: docs/rules/valid-expect-in-promise.md
+[valid-expect]: docs/rules/valid-expect.md
+[prefer-todo]: docs/rules/prefer-todo.md
+[fixable-green]: https://img.shields.io/badge/-fixable-green.svg
+[fixable-yellow]: https://img.shields.io/badge/-fixable-yellow.svg
+[recommended]: https://img.shields.io/badge/-recommended-lightgrey.svg

--- a/docs/rules/no-test-todo-implementation.md
+++ b/docs/rules/no-test-todo-implementation.md
@@ -1,0 +1,31 @@
+# Disallow tests with .todo modifier to have an implementation (no-test-todo-implementation)
+
+Jest allows you to plan tests by only providing the test description
+([Jest Documentation](https://jestjs.io/docs/en/api#testtodoname)).  
+If an implementation for the test is supplied by the second argument, jest will
+throw an error.
+
+## Rule details
+
+This rule triggers a warning if a test block with the modifier `.todo` has an
+implementation.
+
+```js
+// valid:
+it('test description', () => {});
+
+test('test description', () => {});
+
+it.skip('test description', () => {});
+
+it.only('test description', () => {});
+
+it.todo('test description');
+
+// invalid:
+it.todo('test description', () => {});
+
+test.todo('test description', () => {
+  expect(true).toBe(true);
+});
+```

--- a/docs/rules/no-test-todo.md
+++ b/docs/rules/no-test-todo.md
@@ -1,0 +1,27 @@
+# Disallow unfinished tests (no-test-todo)
+
+Jest allows you to plan tests by only providing the test description
+([Jest Documentation](https://jestjs.io/docs/en/api#testtodoname)).  
+This rule can be used to ensure that none of these unfinished tests will be
+committed or to be reminded of unfinished tests by setting the rule severity to
+warn.
+
+## Rule details
+
+This rule triggers a warning if you add the modifier `.todo` to `test` or `it`.
+
+```js
+// valid:
+it('test description', () => {});
+
+test('test description', () => {});
+
+it.skip('test description', () => {});
+
+it.only('test description', () => {});
+
+// invalid:
+it.todo('test description');
+
+test.todo('test description');
+```

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const noLargeSnapshots = require('./rules/no-large-snapshots');
 const noTestPrefixes = require('./rules/no-test-prefixes');
 const noTestReturnStatement = require('./rules/no-test-return-statement');
 const noTestTodo = require('./rules/no-test-todo');
+const noTestTodoImplementation = require('./rules/no-test-todo-implementation');
 const preferSpyOn = require('./rules/prefer-spy-on');
 const preferToBeNull = require('./rules/prefer-to-be-null');
 const preferToBeUndefined = require('./rules/prefer-to-be-undefined');
@@ -103,6 +104,7 @@ module.exports = {
     'no-test-prefixes': noTestPrefixes,
     'no-test-return-statement': noTestReturnStatement,
     'no-test-todo': noTestTodo,
+    'no-test-todo-implementation': noTestTodoImplementation,
     'prefer-spy-on': preferSpyOn,
     'prefer-to-be-null': preferToBeNull,
     'prefer-to-be-undefined': preferToBeUndefined,

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const noJestImport = require('./rules/no-jest-import');
 const noLargeSnapshots = require('./rules/no-large-snapshots');
 const noTestPrefixes = require('./rules/no-test-prefixes');
 const noTestReturnStatement = require('./rules/no-test-return-statement');
+const noTestTodo = require('./rules/no-test-todo');
 const preferSpyOn = require('./rules/prefer-spy-on');
 const preferToBeNull = require('./rules/prefer-to-be-null');
 const preferToBeUndefined = require('./rules/prefer-to-be-undefined');
@@ -101,6 +102,7 @@ module.exports = {
     'no-large-snapshots': noLargeSnapshots,
     'no-test-prefixes': noTestPrefixes,
     'no-test-return-statement': noTestReturnStatement,
+    'no-test-todo': noTestTodo,
     'prefer-spy-on': preferSpyOn,
     'prefer-to-be-null': preferToBeNull,
     'prefer-to-be-undefined': preferToBeUndefined,

--- a/rules/__tests__/no-test-todo-implementation.test.js
+++ b/rules/__tests__/no-test-todo-implementation.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-test-todo-implementation');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-test-todo-implementation', rule, {
+  valid: [
+    "it('test description', () => {});",
+    "test('test description', () => { });",
+    "it.skip('test description', () => { });",
+    "it.only('test description', () => { });",
+    "it.todo('test description');",
+  ],
+  invalid: [
+    {
+      code: "it.todo('test description', () => {})",
+      errors: [{ messageId: 'no-test-todo-implementation' }],
+    },
+    {
+      code: "it.todo('test description', () => { expect(true).toBe(true) });",
+      errors: [{ messageId: 'no-test-todo-implementation' }],
+    },
+  ],
+});

--- a/rules/__tests__/no-test-todo.test.js
+++ b/rules/__tests__/no-test-todo.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const rule = require('../no-test-todo');
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('no-test-todo', rule, {
+  valid: [
+    'it("test description", () => {})',
+    'test("test description", () => {})',
+    'test.only("test description", () => {})',
+    'test.skip("test description", () => {})',
+  ],
+
+  invalid: [
+    {
+      code: 'it.todo("test description")',
+      errors: [{ messageId: 'no-test-todo' }],
+    },
+    {
+      code: 'test.todo("test description")',
+      errors: [{ messageId: 'no-test-todo' }],
+    },
+  ],
+});

--- a/rules/no-test-todo-implementation.js
+++ b/rules/no-test-todo-implementation.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { getDocsUrl, getNodeName, isFunction } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    messages: {
+      'no-test-todo-implementation':
+        'Tests with .todo should not provide an implementation',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const functionName = getNodeName(node.callee);
+        const hasTodoModifier =
+          functionName === 'it.todo' || functionName === 'test.todo';
+        const hasImplementation =
+          node.arguments[1] && isFunction(node.arguments[1]);
+
+        if (hasTodoModifier && hasImplementation) {
+          context.report({
+            node,
+            messageId: 'no-test-todo-implementation',
+          });
+        }
+      },
+    };
+  },
+};

--- a/rules/no-test-todo.js
+++ b/rules/no-test-todo.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { getDocsUrl, getNodeName } = require('./util');
+
+module.exports = {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    messages: {
+      'no-test-todo': 'Unexpected test modifier .todo',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        const functionName = getNodeName(node.callee);
+
+        if (functionName === 'test.todo' || functionName === 'it.todo') {
+          context.report({ messageId: 'no-test-todo', node });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
I decided to contribute various eslint rules, which mostly are available on other eslint plugins or throw runtime errors in jest ([Original PR](https://github.com/jest-community/eslint-plugin-jest/pull/225)).


Current status:
- [x] no-test-todo:                   Disallow tests with .todo modifier
- [x] no-test-todo-implementation:    Disallow tests with a .todo modifier to have an implementation
- [ ] no-empty-test-file:             Disallow test files without a single test block
- [x] no-empty-test-suites:           Disallow empty test suites (describe)
- [x] no-global-tests:                Disallow tests outside of test suites
- [x] no-global-setup:                Disallow hooks in global scope
- [x] no-nested-tests:                Disallow tests inside of other tests
- [x] require-single-top-level-suite: Require a single top level describe block
- [ ] require-newline-before-expect:  Requires a newline before expect() call(s)
- [ ] test-suite-spacing:             Specify the spacing between test suites
- [ ] declaration-spacing:            Specify the spacing between declaration (before, after, it, ...) inside test suites (differentiates between hooks, "hook groups" and test blocks)
- [x] declaration-order:              Specify the order of the declarations (default: beforeAll, afterAll, beforeEach, afterEach, test)