### PR TITLE
fix(jest/no-identical-title): not reporting when using backticks

### DIFF
--- a/rules/__tests__/no-identical-title.test.js
+++ b/rules/__tests__/no-identical-title.test.js
@@ -12,6 +12,8 @@ ruleTester.run('no-identical-title', rule, {
       '   it("it", function() {});',
       '});',
     ].join('\n'),
+    ['describe();describe();'].join('\n'),
+    ['it();it();'].join('\n'),
     [
       'describe("describe1", function() {',
       '   it("it1", function() {});',

--- a/rules/__tests__/no-identical-title.test.js
+++ b/rules/__tests__/no-identical-title.test.js
@@ -81,6 +81,17 @@ ruleTester.run('no-identical-title', rule, {
       '    });',
       '});',
     ].join('\n'),
+    {
+      code: [
+        'describe("describe", () => {',
+        '    it(`testing ${someVar} with the same title`, () => {});',
+        '    it(`testing ${someVar} with the same title`, () => {});',
+        '});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
   ],
 
   invalid: [
@@ -209,6 +220,25 @@ ruleTester.run('no-identical-title', rule, {
             'Describe block title is used multiple times in the same describe block.',
           column: 1,
           line: 4,
+        },
+      ],
+    },
+    {
+      code: [
+        'describe("describe", () => {',
+        '    it(`testing backticks with the same title`, () => {});',
+        '    it(`testing backticks with the same title`, () => {});',
+        '});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+      errors: [
+        {
+          message:
+            'Test title is used multiple times in the same describe block.',
+          column: 5,
+          line: 3,
         },
       ],
     },

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -35,7 +35,10 @@ const handleDescribeBlockTitles = (context, titles, node, title) => {
 };
 
 const isFirstArgLiteral = node =>
-  node.arguments && node.arguments[0] && node.arguments[0].type === 'Literal';
+  node.arguments &&
+  node.arguments[0] &&
+  (node.arguments[0].type === 'Literal' ||
+    node.arguments[0].type === 'TemplateLiteral');
 
 module.exports = {
   meta: {
@@ -51,7 +54,14 @@ module.exports = {
         if (isDescribe(node)) {
           contexts.push(newDescribeContext());
         }
+        const [firstArgument] = node.arguments;
         if (!isFirstArgLiteral(node)) {
+          return;
+        }
+        if (
+          firstArgument.type === 'TemplateLiteral' &&
+          !!firstArgument.expressions.length
+        ) {
           return;
         }
 

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -41,7 +41,7 @@ const handleDescribeBlockTitles = (context, titles, node, title) => {
 };
 
 const isFirstArgValid = arg => {
-  if (!isString(arg)) {
+  if (!arg || !isString(arg)) {
     return false;
   }
   if (arg.type === 'TemplateLiteral' && hasExpressions(arg)) {

--- a/rules/util.js
+++ b/rules/util.js
@@ -134,7 +134,7 @@ const isString = node =>
   (node.type === 'Literal' && typeof node.value === 'string') ||
   node.type === 'TemplateLiteral';
 
-const hasExpressions = node => !!(node.expressions && node.expressions.length);
+const hasExpressions = node => node.expressions && node.expressions.length > 0;
 
 /**
  * Generates the URL to documentation for the given rule name. It uses the

--- a/rules/util.js
+++ b/rules/util.js
@@ -134,6 +134,8 @@ const isString = node =>
   (node.type === 'Literal' && typeof node.value === 'string') ||
   node.type === 'TemplateLiteral';
 
+const hasExpressions = node => !!(node.expressions && node.expressions.length);
+
 /**
  * Generates the URL to documentation for the given rule name. It uses the
  * package version to build the link to a tagged version of the
@@ -212,6 +214,7 @@ module.exports = {
   isFunction,
   isTestCase,
   isString,
+  hasExpressions,
   getDocsUrl,
   scopeHasLocalReference,
   composeFixers,


### PR DESCRIPTION
Currently `jest/no-identical-title` only checks against regular strings. As a result, this wouldn't get reported:

```
describe('an odd case where identical titles are not reported', () => {
    it(`this does not work as expected`, () => {
        //  ...test code here
    });
    it(`this does not work as expected`, () => {
        //  ...test code here
    });
});
```

This ticket fixes that by testing against `TemplateLiteral` nodes, but will never report if that node is using string interpolation (ie: has expressions, `${}` inside it).

Resolves #232