### PR TITLE
fix(jest/no-identical-title): don't show an error for different template literals

### DIFF
--- a/rules/__tests__/no-identical-title.test.js
+++ b/rules/__tests__/no-identical-title.test.js
@@ -94,6 +94,21 @@ ruleTester.run('no-identical-title', rule, {
         es6: true,
       },
     },
+    {
+      code: ['it(`it1`, () => {});', 'it(`it2`, () => {});'].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
+    {
+      code: [
+        'describe(`describe1`, () => {});',
+        'describe(`describe2`, () => {});',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
   ],
 
   invalid: [

--- a/rules/no-identical-title.js
+++ b/rules/no-identical-title.js
@@ -50,6 +50,14 @@ const isFirstArgValid = arg => {
   return true;
 };
 
+const getArgValue = arg => {
+  if (arg.type === 'TemplateLiteral') {
+    return arg.quasis[0].value.raw;
+  }
+
+  return arg.value;
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -68,7 +76,7 @@ module.exports = {
         if (!isFirstArgValid(firstArgument)) {
           return;
         }
-        const title = node.arguments[0].value;
+        const title = getArgValue(firstArgument);
         handleTestCaseTitles(context, currentLayer.testTitles, node, title);
         handleDescribeBlockTitles(
           context,


### PR DESCRIPTION
### Summary

Hey, since the recent release (with #237), two different template literals with no expressions will show a lint error. This happens because we try to get their value in a way that doesn't work for template literals and get `undefined` ([see here](https://github.com/jest-community/eslint-plugin-jest/blob/master/rules/no-identical-title.js#L71)).

This PR handles this use-case and adds a test to it (which would fail the last release).

Thanks 🙏 
