### PR TITLE
Add failing test for `no-mocks-import` dynamic requires

### DIFF
--- a/rules/__tests__/no-mocks-import.test.js
+++ b/rules/__tests__/no-mocks-import.test.js
@@ -18,6 +18,7 @@ ruleTester.run('no-mocks-import', rule, {
     'require("./x__mocks__")',
     'require("./x__mocks__/x")',
     'require()',
+    'var path = "./__mocks__.js"; require(path)',
     'entirelyDifferent(fn)',
   ],
   invalid: [


### PR DESCRIPTION
Hello, I tried the new `no-mocks-import` rule (https://github.com/jest-community/eslint-plugin-jest/pull/246) but it's failing on dynamic ~~imports~~ requires. I am adding at least this failing test since I am not sure how to fix it properly. Thank you for checking it! :)