### PR TITLE
fix(no-mocks-import): do not crash on dynamic `require`

### DIFF
--- a/rules/__tests__/no-mocks-import.test.js
+++ b/rules/__tests__/no-mocks-import.test.js
@@ -18,6 +18,7 @@ ruleTester.run('no-mocks-import', rule, {
     'require("./x__mocks__")',
     'require("./x__mocks__/x")',
     'require()',
+    'var path = "./__mocks__.js"; require(path)',
     'entirelyDifferent(fn)',
   ],
   invalid: [

--- a/rules/no-mocks-import.js
+++ b/rules/no-mocks-import.js
@@ -22,7 +22,11 @@ module.exports = {
         }
       },
       'CallExpression[callee.name="require"]'(node) {
-        if (node.arguments.length && isMockPath(node.arguments[0].value)) {
+        if (
+          node.arguments.length &&
+          node.arguments[0].value &&
+          isMockPath(node.arguments[0].value)
+        ) {
           context.report({
             loc: node.arguments[0].loc,
             message,


### PR DESCRIPTION
Close #249 

Co-authored-by: Martin Zlámal <mrtnzlml@gmail.com>