### PR TITLE
Assert that async `expect`s are awaited or returned - Closes #54, #254

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -20,7 +20,7 @@ or when a matcher function was not called, e.g.:
 expect(true).toBeDefined;
 ```
 
-or when an async assertion was not awaited or returned, e.g.:
+or when an async assertion was not `await`ed or returned, e.g.:
 
 ```js
 expect(Promise.resolve('Hi!')).resolves.toBe('Hi!');
@@ -76,8 +76,8 @@ test('test2', () => expect(Promise.resolve(2)).resolves.toBe(2));
 
 ### `allowPromiseMethods`
 
-When set to true, disables triggers on async assertions that were used inside a
-Promise method.
+When set to true, disables triggering warnings on async assertions that were
+used inside a Promise method, even if not immediately `await`ed or returned.
 
 Examples of **correct** code for the { "allowPromiseMethods": **true** } option:
 

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -38,10 +38,6 @@ This rule is enabled by default.
       type: 'boolean',
       default: false,
     },
-    allowPromiseMethods: {
-      type: 'boolean',
-      default: false,
-    },
   },
   additionalProperties: false,
 }
@@ -74,43 +70,6 @@ test('test1', async () => {
 test('test2', () => expect(Promise.resolve(2)).resolves.toBe(2));
 ```
 
-### `allowPromiseMethods`
-
-When set to true, disables triggering warnings on async assertions that were
-used inside a Promise method, even if not immediately `await`ed or returned.
-
-Examples of **correct** code for the { "allowPromiseMethods": **true** } option:
-
-```js
-// allowPromiseMethods: true
-test('test1', () => {
-  Promise.all([
-    expect(Promise.resolve(1)).resolves.toBeDefined(),
-    expect(Promise.resolve(2)).resolves.toBeDefined(),
-  ]);
-});
-```
-
-Examples of **correct** code for the { "allowPromiseMethods": **false** }
-option:
-
-```js
-// allowPromiseMethods: false
-test('test1', async () => {
-  await Promise.all([
-    expect(Promise.resolve(1)).resolves.toBeDefined(),
-    expect(Promise.resolve(2)).resolves.toBeDefined(),
-  ]);
-});
-
-test('test2', () => {
-  return Promise.all([
-    expect(Promise.resolve(1)).resolves.toBeDefined(),
-    expect(Promise.resolve(2)).resolves.toBeDefined(),
-  ]);
-});
-```
-
 ### Default configuration
 
 The following patterns are considered warnings:
@@ -124,6 +83,10 @@ expect(true).toBeDefined;
 expect(Promise.resolve('hello')).resolves;
 expect(Promise.resolve('hello')).resolves.toEqual('hello');
 Promise.resolve(expect(Promise.resolve('hello')).resolves.toEqual('hello'));
+Promise.all([
+  expect(Promise.resolve('hello')).resolves.toEqual('hello'),
+  expect(Promise.resolve('hi')).resolves.toEqual('hi'),
+]);
 ```
 
 The following patterns are not warnings:
@@ -135,5 +98,9 @@ expect(true).toBeDefined();
 await expect(Promise.resolve('hello')).resolves.toEqual('hello');
 await Promise.resolve(
   expect(Promise.resolve('hello')).resolves.toEqual('hello'),
+);
+await Promise.all(
+  expect(Promise.resolve('hello')).resolves.toEqual('hello'),
+  expect(Promise.resolve('hi')).resolves.toEqual('hi'),
 );
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,10 @@ module.exports = {
         'jest/no-jasmine-globals': 'warn',
         'jest/no-test-prefixes': 'error',
         'jest/valid-describe': 'error',
-        'jest/valid-expect': ['error', { alwaysAwait: false }],
+        'jest/valid-expect': [
+          'error',
+          { alwaysAwait: true, ignoreInPromise: true },
+        ],
         'jest/valid-expect-in-promise': 'error',
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = {
         'jest/no-jasmine-globals': 'warn',
         'jest/no-test-prefixes': 'error',
         'jest/valid-describe': 'error',
-        'jest/valid-expect': ['error'],
+        'jest/valid-expect': 'error',
         'jest/valid-expect-in-promise': 'error',
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = {
         'jest/no-jasmine-globals': 'warn',
         'jest/no-test-prefixes': 'error',
         'jest/valid-describe': 'error',
-        'jest/valid-expect': ['error', { alwaysAwait: true }],
+        'jest/valid-expect': ['error', { alwaysAwait: false }],
         'jest/valid-expect-in-promise': 'error',
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = {
         'jest/no-jasmine-globals': 'warn',
         'jest/no-test-prefixes': 'error',
         'jest/valid-describe': 'error',
-        'jest/valid-expect': 'error',
+        'jest/valid-expect': ['error', { alwaysAwait: true }],
         'jest/valid-expect-in-promise': 'error',
       },
     },

--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,7 @@ module.exports = {
         'jest/no-jasmine-globals': 'warn',
         'jest/no-test-prefixes': 'error',
         'jest/valid-describe': 'error',
-        'jest/valid-expect': [
-          'error',
-          { alwaysAwait: true, ignoreInPromise: true },
-        ],
+        'jest/valid-expect': ['error'],
         'jest/valid-expect-in-promise': 'error',
       },
     },

--- a/src/rules/__tests__/no-alias-methods.test.js
+++ b/src/rules/__tests__/no-alias-methods.test.js
@@ -19,6 +19,7 @@ ruleTester.run('no-alias-methods', rule, {
     'expect(a).toHaveNthReturnedWith()',
     'expect(a).toThrow()',
     'expect(a).rejects;',
+    'expect(a);',
   ],
 
   invalid: [

--- a/src/rules/__tests__/no-truthy-falsy.test.js
+++ b/src/rules/__tests__/no-truthy-falsy.test.js
@@ -15,6 +15,7 @@ ruleTester.run('no-truthy-falsy', rule, {
     'expect("anything").not.toEqual(true);',
     'expect(Promise.resolve({})).resolves.toBe(true);',
     'expect(Promise.reject({})).rejects.toBe(true);',
+    'expect(a);',
   ],
 
   invalid: [

--- a/src/rules/__tests__/prefer-called-with.test.js
+++ b/src/rules/__tests__/prefer-called-with.test.js
@@ -17,6 +17,7 @@ ruleTester.run('prefer-called-with', rule, {
     'expect(fn).not.toHaveBeenCalledWith();',
     'expect(fn).toBeCalledTimes(0);',
     'expect(fn).toHaveBeenCalledTimes(0);',
+    'expect(fn);',
   ],
 
   invalid: [

--- a/src/rules/__tests__/prefer-strict-equal.test.js
+++ b/src/rules/__tests__/prefer-strict-equal.test.js
@@ -9,6 +9,7 @@ ruleTester.run('prefer-strict-equal', rule, {
   valid: [
     'expect(something).toStrictEqual(somethingElse);',
     "a().toEqual('b')",
+    'expect(a);',
   ],
   invalid: [
     {

--- a/src/rules/__tests__/prefer-to-contain.test.js
+++ b/src/rules/__tests__/prefer-to-contain.test.js
@@ -25,6 +25,7 @@ ruleTester.run('prefer-to-contain', rule, {
     `expect(a.test(b)).resolves.toEqual(true)`,
     `expect(a.test(b)).resolves.not.toEqual(true)`,
     `expect(a).not.toContain(b)`,
+    'expect(a);',
   ],
   invalid: [
     {

--- a/src/rules/__tests__/prefer-to-have-length.test.js
+++ b/src/rules/__tests__/prefer-to-have-length.test.js
@@ -12,6 +12,7 @@ ruleTester.run('prefer-to-have-length', rule, {
     'expect(result).toBe(true);',
     `expect(user.getUserName(5)).resolves.toEqual('Paul')`,
     `expect(user.getUserName(5)).rejects.toEqual('Paul')`,
+    'expect(a);',
   ],
 
   invalid: [

--- a/src/rules/__tests__/require-tothrow-message.test.js
+++ b/src/rules/__tests__/require-tothrow-message.test.js
@@ -27,6 +27,7 @@ ruleTester.run('require-tothrow-message', rule, {
 
     // Allow no message for `not`.
     "expect(() => { throw new Error('a'); }).not.toThrow();",
+    'expect(a);',
   ],
 
   invalid: [

--- a/src/rules/__tests__/valid-expect.test.js
+++ b/src/rules/__tests__/valid-expect.test.js
@@ -79,12 +79,12 @@ ruleTester.run('valid-expect', rule, {
     {
       code:
         'test("valid-expect", () => { Promise.all([expect(Promise.reject(2)).not.rejects.toBeDefined(), expect(Promise.reject(2)).not.rejects.toBeDefined()]); });',
-      options: [{ ignoreInPromise: true }],
+      options: [{ allowPromiseMethods: true }],
     },
     {
       code:
         'test("valid-expect", () => { Promise.resolve(expect(Promise.reject(2)).not.rejects.toBeDefined()); });',
-      options: [{ ignoreInPromise: true }],
+      options: [{ allowPromiseMethods: true }],
     },
   ],
 
@@ -387,7 +387,7 @@ ruleTester.run('valid-expect', rule, {
       code: `test("valid-expect", () => { 
           Promise.resolve(expect(Promise.resolve(2)).not.resolves.toBeDefined()); 
         });`,
-      options: [{ ignoreInPromise: false }],
+      options: [{ allowPromiseMethods: false }],
       errors: [
         {
           line: 2,
@@ -431,7 +431,7 @@ ruleTester.run('valid-expect', rule, {
       code: `test("valid-expect", () => { 
           Promise.resolve(expect(Promise.resolve(2)).not.resolves.toBeDefined()); 
         });`,
-      options: [{ alwaysAwait: true, ignoreInPromise: false }],
+      options: [{ alwaysAwait: true, allowPromiseMethods: false }],
       errors: [
         {
           line: 2,

--- a/src/rules/__tests__/valid-expect.test.js
+++ b/src/rules/__tests__/valid-expect.test.js
@@ -479,5 +479,41 @@ ruleTester.run('valid-expect', rule, {
         },
       ],
     },
+    //
+    {
+      code: `test("valid-expect", () => { 
+          const assertions = [
+            expect(Promise.resolve(2)).not.resolves.toBeDefined(),
+            expect(Promise.resolve(3)).not.resolves.toBeDefined(),
+          ]
+        });`,
+      errors: [
+        {
+          line: 3,
+          column: 13,
+          endLine: 3,
+          endColumn: 66,
+          message: 'Async assertions must be awaited or returned.',
+        },
+        {
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 66,
+          message: 'Async assertions must be awaited or returned.',
+        },
+      ],
+    },
+    // Code coverage for line 29
+    {
+      code: 'expect(Promise.resolve(2)).resolves.toBe;',
+      errors: [
+        {
+          column: 37,
+          endColumn: 41,
+          message: '"toBe" was not called.',
+        },
+      ],
+    },
   ],
 });

--- a/src/rules/__tests__/valid-expect.test.js
+++ b/src/rules/__tests__/valid-expect.test.js
@@ -76,16 +76,6 @@ ruleTester.run('valid-expect', rule, {
     'test("valid-expect", async () => { await Promise.race([expect(Promise.reject(2)).not.rejects.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
     'test("valid-expect", async () => { await Promise.allSettled([expect(Promise.reject(2)).not.rejects.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
     'test("valid-expect", async () => { await Promise.any([expect(Promise.reject(2)).not.rejects.toBeDefined(), expect(Promise.reject(2)).rejects.not.toBeDefined()]); });',
-    {
-      code:
-        'test("valid-expect", () => { Promise.all([expect(Promise.reject(2)).not.rejects.toBeDefined(), expect(Promise.reject(2)).not.rejects.toBeDefined()]); });',
-      options: [{ allowPromiseMethods: true }],
-    },
-    {
-      code:
-        'test("valid-expect", () => { Promise.resolve(expect(Promise.reject(2)).not.rejects.toBeDefined()); });',
-      options: [{ allowPromiseMethods: true }],
-    },
   ],
 
   invalid: [
@@ -387,7 +377,6 @@ ruleTester.run('valid-expect', rule, {
       code: `test("valid-expect", () => { 
           Promise.resolve(expect(Promise.resolve(2)).not.resolves.toBeDefined()); 
         });`,
-      options: [{ allowPromiseMethods: false }],
       errors: [
         {
           line: 2,
@@ -431,7 +420,7 @@ ruleTester.run('valid-expect', rule, {
       code: `test("valid-expect", () => { 
           Promise.resolve(expect(Promise.resolve(2)).not.resolves.toBeDefined()); 
         });`,
-      options: [{ alwaysAwait: true, allowPromiseMethods: false }],
+      options: [{ alwaysAwait: true }],
       errors: [
         {
           line: 2,

--- a/src/rules/__tests__/valid-expect.test.js
+++ b/src/rules/__tests__/valid-expect.test.js
@@ -55,7 +55,11 @@ ruleTester.run('valid-expect', rule, {
         'test("valid-expect", function () { return Promise.resolve(expect(Promise.resolve(2)).not.rejects.toBeDefined()); });',
       options: [{ alwaysAwait: false }],
     },
-
+    {
+      code:
+        'test("valid-expect", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
+      options: [{ alwaysAwait: true }],
+    },
     'test("valid-expect", () => expect(Promise.resolve(2)).resolves.toBeDefined());',
     'test("valid-expect", () => expect(Promise.reject(2)).rejects.toBeDefined());',
     'test("valid-expect", () => expect(Promise.reject(2)).not.resolves.toBeDefined());',
@@ -383,6 +387,7 @@ ruleTester.run('valid-expect', rule, {
       code: `test("valid-expect", () => { 
           Promise.resolve(expect(Promise.resolve(2)).not.resolves.toBeDefined()); 
         });`,
+      options: [{ ignoreInPromise: false }],
       errors: [
         {
           line: 2,
@@ -426,7 +431,7 @@ ruleTester.run('valid-expect', rule, {
       code: `test("valid-expect", () => { 
           Promise.resolve(expect(Promise.resolve(2)).not.resolves.toBeDefined()); 
         });`,
-      options: [{ alwaysAwait: true }],
+      options: [{ alwaysAwait: true, ignoreInPromise: false }],
       errors: [
         {
           line: 2,

--- a/src/rules/__tests__/valid-expect.test.js
+++ b/src/rules/__tests__/valid-expect.test.js
@@ -262,18 +262,19 @@ ruleTester.run('valid-expect', rule, {
           expect(Promise.resolve(2)).not.resolves.toBeDefined(); 
           return expect(Promise.resolve(1)).rejects.toBeDefined(); 
         });`,
+      options: [{ alwaysAwait: true }],
       errors: [
         {
           line: 2,
           column: 11,
           endColumn: 64,
-          message: 'Async assertions must be awaited or returned.',
+          message: 'Async assertions must be awaited.',
         },
         {
           line: 3,
           column: 18,
           endColumn: 66,
-          message: 'Async assertions must be awaited or returned.',
+          message: 'Async assertions must be awaited.',
         },
       ],
     },
@@ -297,12 +298,13 @@ ruleTester.run('valid-expect', rule, {
           await expect(Promise.resolve(2)).not.resolves.toBeDefined(); 
           return expect(Promise.resolve(1)).rejects.toBeDefined(); 
         });`,
+      options: [{ alwaysAwait: true }],
       errors: [
         {
           line: 3,
           column: 18,
           endColumn: 66,
-          message: 'Async assertions must be awaited or returned.',
+          message: 'Async assertions must be awaited.',
         },
       ],
     },

--- a/src/rules/no-alias-methods.js
+++ b/src/rules/no-alias-methods.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { expectCase, getDocsUrl, method } = require('./util');
+const { expectCaseWithParent, getDocsUrl, method } = require('./util');
 
 module.exports = {
   meta: {
@@ -32,7 +32,7 @@ module.exports = {
 
     return {
       CallExpression(node) {
-        if (!expectCase(node)) {
+        if (!expectCaseWithParent(node)) {
           return;
         }
 

--- a/src/rules/no-truthy-falsy.js
+++ b/src/rules/no-truthy-falsy.js
@@ -4,8 +4,8 @@ const {
   getDocsUrl,
   expectCase,
   expectNotCase,
-  expectResolveCase,
-  expectRejectCase,
+  expectResolvesCase,
+  expectRejectsCase,
   method,
 } = require('./util');
 
@@ -25,8 +25,8 @@ module.exports = {
         if (
           expectCase(node) ||
           expectNotCase(node) ||
-          expectResolveCase(node) ||
-          expectRejectCase(node)
+          expectResolvesCase(node) ||
+          expectRejectsCase(node)
         ) {
           const targetNode =
             node.parent.parent.type === 'MemberExpression' ? node.parent : node;

--- a/src/rules/no-truthy-falsy.js
+++ b/src/rules/no-truthy-falsy.js
@@ -2,7 +2,7 @@
 
 const {
   getDocsUrl,
-  expectCase,
+  expectCaseWithParent,
   expectNotCase,
   expectResolvesCase,
   expectRejectsCase,
@@ -23,7 +23,7 @@ module.exports = {
     return {
       CallExpression(node) {
         if (
-          expectCase(node) ||
+          expectCaseWithParent(node) ||
           expectNotCase(node) ||
           expectResolvesCase(node) ||
           expectRejectsCase(node)

--- a/src/rules/prefer-called-with.js
+++ b/src/rules/prefer-called-with.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const { getDocsUrl, expectCase, expectNotCase, method } = require('./util');
+const {
+  getDocsUrl,
+  expectCaseWithParent,
+  expectNotCase,
+  method,
+} = require('./util');
 
 module.exports = {
   meta: {
@@ -16,7 +21,7 @@ module.exports = {
     return {
       CallExpression(node) {
         // Could check resolves/rejects here but not a likely idiom.
-        if (expectCase(node) && !expectNotCase(node)) {
+        if (expectCaseWithParent(node) && !expectNotCase(node)) {
           const methodNode = method(node);
           const { name } = methodNode;
           if (name === 'toBeCalled' || name === 'toHaveBeenCalled') {

--- a/src/rules/prefer-to-contain.js
+++ b/src/rules/prefer-to-contain.js
@@ -3,8 +3,8 @@
 const {
   getDocsUrl,
   expectCase,
-  expectResolveCase,
-  expectRejectCase,
+  expectResolvesCase,
+  expectRejectsCase,
   method,
   argument,
 } = require('./util');
@@ -93,7 +93,7 @@ module.exports = {
     return {
       CallExpression(node) {
         if (
-          !(expectResolveCase(node) || expectRejectCase(node)) &&
+          !(expectResolvesCase(node) || expectRejectsCase(node)) &&
           expectCase(node) &&
           (isEqualityNegation(node) || isValidEqualityCheck(node)) &&
           isValidIncludesMethod(node)

--- a/src/rules/prefer-to-contain.js
+++ b/src/rules/prefer-to-contain.js
@@ -2,7 +2,7 @@
 
 const {
   getDocsUrl,
-  expectCase,
+  expectCaseWithParent,
   expectResolvesCase,
   expectRejectsCase,
   method,
@@ -94,7 +94,7 @@ module.exports = {
       CallExpression(node) {
         if (
           !(expectResolvesCase(node) || expectRejectsCase(node)) &&
-          expectCase(node) &&
+          expectCaseWithParent(node) &&
           (isEqualityNegation(node) || isValidEqualityCheck(node)) &&
           isValidIncludesMethod(node)
         ) {

--- a/src/rules/prefer-to-have-length.js
+++ b/src/rules/prefer-to-have-length.js
@@ -2,7 +2,7 @@
 
 const {
   getDocsUrl,
-  expectCase,
+  expectCaseWithParent,
   expectNotCase,
   expectResolvesCase,
   expectRejectsCase,
@@ -29,7 +29,7 @@ module.exports = {
             expectResolvesCase(node) ||
             expectRejectsCase(node)
           ) &&
-          expectCase(node) &&
+          expectCaseWithParent(node) &&
           (method(node).name === 'toBe' || method(node).name === 'toEqual') &&
           node.arguments[0].property &&
           node.arguments[0].property.name === 'length'

--- a/src/rules/prefer-to-have-length.js
+++ b/src/rules/prefer-to-have-length.js
@@ -4,8 +4,8 @@ const {
   getDocsUrl,
   expectCase,
   expectNotCase,
-  expectResolveCase,
-  expectRejectCase,
+  expectResolvesCase,
+  expectRejectsCase,
   method,
 } = require('./util');
 
@@ -26,8 +26,8 @@ module.exports = {
         if (
           !(
             expectNotCase(node) ||
-            expectResolveCase(node) ||
-            expectRejectCase(node)
+            expectResolvesCase(node) ||
+            expectRejectsCase(node)
           ) &&
           expectCase(node) &&
           (method(node).name === 'toBe' || method(node).name === 'toEqual') &&

--- a/src/rules/require-tothrow-message.js
+++ b/src/rules/require-tothrow-message.js
@@ -1,4 +1,4 @@
-import { argument, expectCase, getDocsUrl, method } from './util';
+import { argument, expectCaseWithParent, getDocsUrl, method } from './util';
 
 export default {
   meta: {
@@ -13,7 +13,7 @@ export default {
   create(context) {
     return {
       CallExpression(node) {
-        if (!expectCase(node)) {
+        if (!expectCaseWithParent(node)) {
           return;
         }
 

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -5,7 +5,7 @@ const { version } = require('../../package.json');
 
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 
-const expectCase = node => node.callee.name === 'expect';
+const expectCase = node => node && node.callee && node.callee.name === 'expect';
 
 const expectNotCase = node =>
   expectCase(node) &&

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -5,30 +5,39 @@ const { version } = require('../../package.json');
 
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 
-const expectCase = node =>
-  node.callee.name === 'expect' &&
-  node.arguments.length === 1 &&
-  node.parent &&
-  node.parent.type === 'MemberExpression' &&
-  node.parent.parent;
+const expectCase = node => node.callee.name === 'expect';
 
 const expectNotCase = node =>
   expectCase(node) &&
   node.parent.parent.type === 'MemberExpression' &&
   methodName(node) === 'not';
 
-const expectResolveCase = node =>
+const expectResolvesCase = node =>
   expectCase(node) &&
   node.parent.parent.type === 'MemberExpression' &&
-  methodName(node) === 'resolve';
+  methodName(node) === 'resolves';
 
-const expectRejectCase = node =>
+const expectNotResolvesCase = node =>
+  expectNotCase(node) &&
+  node.parent.parent.type === 'MemberExpression' &&
+  methodName(node.parent) === 'resolves';
+
+const expectRejectsCase = node =>
   expectCase(node) &&
   node.parent.parent.type === 'MemberExpression' &&
-  methodName(node) === 'reject';
+  methodName(node) === 'rejects';
+
+const expectNotRejectsCase = node =>
+  expectNotCase(node) &&
+  node.parent.parent.type === 'MemberExpression' &&
+  methodName(node.parent) === 'rejects';
 
 const expectToBeCase = (node, arg) =>
-  !(expectNotCase(node) || expectResolveCase(node) || expectRejectCase(node)) &&
+  !(
+    expectNotCase(node) ||
+    expectResolvesCase(node) ||
+    expectRejectsCase(node)
+  ) &&
   expectCase(node) &&
   methodName(node) === 'toBe' &&
   argument(node) &&
@@ -47,7 +56,11 @@ const expectNotToBeCase = (node, arg) =>
     (argument2(node).name === 'undefined' && arg === undefined));
 
 const expectToEqualCase = (node, arg) =>
-  !(expectNotCase(node) || expectResolveCase(node) || expectRejectCase(node)) &&
+  !(
+    expectNotCase(node) ||
+    expectResolvesCase(node) ||
+    expectRejectsCase(node)
+  ) &&
   expectCase(node) &&
   methodName(node) === 'toEqual' &&
   argument(node) &&
@@ -226,8 +239,10 @@ module.exports = {
   argument2,
   expectCase,
   expectNotCase,
-  expectResolveCase,
-  expectRejectCase,
+  expectResolvesCase,
+  expectNotResolvesCase,
+  expectRejectsCase,
+  expectNotRejectsCase,
   expectToBeCase,
   expectNotToBeCase,
   expectToEqualCase,

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -7,6 +7,12 @@ const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 
 const expectCase = node => node && node.callee && node.callee.name === 'expect';
 
+const expectCaseWithParent = node =>
+  expectCase(node) &&
+  node.parent &&
+  node.parent.type === 'MemberExpression' &&
+  node.parent.parent;
+
 const expectNotCase = node =>
   expectCase(node) &&
   node.parent.parent.type === 'MemberExpression' &&
@@ -238,6 +244,7 @@ module.exports = {
   argument,
   argument2,
   expectCase,
+  expectCaseWithParent,
   expectNotCase,
   expectResolvesCase,
   expectNotResolvesCase,

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -90,6 +90,9 @@ module.exports = {
         '"{{ propertyName }}" is not a valid property of expect.',
       propertyWithoutMatcher: '"{{ propertyName }}" needs to call a matcher.',
       matcherOnPropertyNotCalled: '"{{ propertyName }}" was not called.',
+      asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}.',
+      promisesWithAsyncAssertionsMustBeAwaited:
+        'Promises which return async assertions must be awaited{{ orReturned }}.',
     },
     schema: [
       {
@@ -219,8 +222,8 @@ module.exports = {
             const allowReturn = !options[0] || !options[0].alwaysAwait;
             const isParentArrayExpression =
               parentNode.parent.type === 'ArrayExpression';
-            const messageReturn = allowReturn ? ' or returned' : '';
-            let message = `Async assertions must be awaited${messageReturn}.`;
+            const orReturned = allowReturn ? ' or returned' : '';
+            let messageId = 'asyncMustBeAwaited';
 
             // Promise.x([expect()]) || Promise.x(expect())
             if (promiseArgumentTypes.includes(parentNode.parent.type)) {
@@ -230,7 +233,7 @@ module.exports = {
 
               if (promiseNode) {
                 parentNode = promiseNode;
-                message = `Promises which return async assertions must be awaited${messageReturn}.`;
+                messageId = 'promisesWithAsyncAssertionsMustBeAwaited';
               }
             }
 
@@ -240,7 +243,10 @@ module.exports = {
             ) {
               context.report({
                 loc: parentNode.loc,
-                message,
+                data: {
+                  orReturned,
+                },
+                messageId,
                 node,
               });
 

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -23,15 +23,12 @@ const getParentCallExpressionNode = node => {
   return getParentCallExpressionNode(node.parent);
 };
 
-const checkIfValidReturn = (context, parentCallExpressionNode) => {
+const checkIfValidReturn = (parentCallExpressionNode, allowReturn = true) => {
   const validParentNodeTypes = ['ArrowFunctionExpression', 'AwaitExpression'];
-  const { options } = context;
-  if (!options[0] || !options[0].alwaysAwait) {
+  if (allowReturn) {
     validParentNodeTypes.push('ReturnStatement');
   }
-  return (
-    validParentNodeTypes.indexOf(parentCallExpressionNode.parent.type) > -1
-  );
+  return validParentNodeTypes.includes(parentCallExpressionNode.parent.type);
 };
 
 module.exports = {
@@ -157,10 +154,10 @@ module.exports = {
           expectNotRejectsCase(node)
         ) {
           const parentCallExpressionNode = getParentCallExpressionNode(node);
-          if (!checkIfValidReturn(context, parentCallExpressionNode)) {
-            const { options } = context;
-            const messageReturn =
-              !options[0] || !options[0].alwaysAwait ? ' or returned' : '';
+          const { options } = context;
+          const allowReturn = !options[0] || !options[0].alwaysAwait;
+          if (!checkIfValidReturn(parentCallExpressionNode, allowReturn)) {
+            const messageReturn = allowReturn ? ' or returned' : '';
 
             context.report({
               loc: parentCallExpressionNode.loc,

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -217,15 +217,16 @@ module.exports = {
           if (parentNode) {
             const { options } = context;
             const allowReturn = !options[0] || !options[0].alwaysAwait;
+            const isParentArrayExpression =
+              parentNode.parent.type === 'ArrayExpression';
             const messageReturn = allowReturn ? ' or returned' : '';
             let message = `Async assertions must be awaited${messageReturn}.`;
-            let isParentArrayExpression =
-              parentNode.parent.type === 'ArrayExpression';
-            let promiseNode = null;
 
             // Promise.x([expect()]) || Promise.x(expect())
             if (promiseArgumentTypes.includes(parentNode.parent.type)) {
-              promiseNode = getPromiseCallExpressionNode(parentNode.parent);
+              const promiseNode = getPromiseCallExpressionNode(
+                parentNode.parent,
+              );
 
               if (promiseNode) {
                 parentNode = promiseNode;

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -99,9 +99,9 @@ module.exports = {
             type: 'boolean',
             default: false,
           },
-          ignoreInPromise: {
+          allowPromiseMethods: {
             type: 'boolean',
-            default: true,
+            default: false,
           },
         },
         additionalProperties: false,
@@ -221,7 +221,8 @@ module.exports = {
           if (parentNode) {
             const { options } = context;
             const allowReturn = !options[0] || !options[0].alwaysAwait;
-            const ignoreInPromise = options[0] && options[0].ignoreInPromise;
+            const allowPromiseMethods =
+              options[0] && options[0].allowPromiseMethods;
             const messageReturn = allowReturn ? ' or returned' : '';
             let message = `Async assertions must be awaited${messageReturn}.`;
             let isParentArrayExpression =
@@ -232,7 +233,7 @@ module.exports = {
             if (promiseArgumentTypes.includes(parentNode.parent.type)) {
               promiseNode = getPromiseCallExpressionNode(parentNode.parent);
 
-              if (promiseNode && !ignoreInPromise) {
+              if (promiseNode && !allowPromiseMethods) {
                 parentNode = promiseNode;
                 message = `Promises which return async assertions must be awaited${messageReturn}.`;
               }
@@ -240,7 +241,7 @@ module.exports = {
 
             if (
               !checkIfValidReturn(parentNode.parent, allowReturn) &&
-              (!ignoreInPromise || !promiseNode) &&
+              (!allowPromiseMethods || !promiseNode) &&
               !promiseArrayExceptionExists(parentNode.loc)
             ) {
               context.report({

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -65,7 +65,7 @@ const getPromiseCallExpressionNode = node => {
   return null;
 };
 
-const checkIfValidReturn = (parentCallExpressionNode, allowReturn = true) => {
+const checkIfValidReturn = (parentCallExpressionNode, allowReturn) => {
   const validParentNodeTypes = ['ArrowFunctionExpression', 'AwaitExpression'];
   if (allowReturn) {
     validParentNodeTypes.push('ReturnStatement');

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -97,9 +97,11 @@ module.exports = {
         properties: {
           alwaysAwait: {
             type: 'boolean',
+            default: false,
           },
           ignoreInPromise: {
             type: 'boolean',
+            default: true,
           },
         },
         additionalProperties: false,

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -99,10 +99,6 @@ module.exports = {
             type: 'boolean',
             default: false,
           },
-          allowPromiseMethods: {
-            type: 'boolean',
-            default: false,
-          },
         },
         additionalProperties: false,
       },
@@ -221,8 +217,6 @@ module.exports = {
           if (parentNode) {
             const { options } = context;
             const allowReturn = !options[0] || !options[0].alwaysAwait;
-            const allowPromiseMethods =
-              options[0] && options[0].allowPromiseMethods;
             const messageReturn = allowReturn ? ' or returned' : '';
             let message = `Async assertions must be awaited${messageReturn}.`;
             let isParentArrayExpression =
@@ -233,7 +227,7 @@ module.exports = {
             if (promiseArgumentTypes.includes(parentNode.parent.type)) {
               promiseNode = getPromiseCallExpressionNode(parentNode.parent);
 
-              if (promiseNode && !allowPromiseMethods) {
+              if (promiseNode) {
                 parentNode = promiseNode;
                 message = `Promises which return async assertions must be awaited${messageReturn}.`;
               }
@@ -241,7 +235,6 @@ module.exports = {
 
             if (
               !checkIfValidReturn(parentNode.parent, allowReturn) &&
-              (!allowPromiseMethods || !promiseNode) &&
               !promiseArrayExceptionExists(parentNode.loc)
             ) {
               context.report({

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -163,8 +163,6 @@ module.exports = {
               !options[0] || !options[0].alwaysAwait ? ' or returned' : '';
 
             context.report({
-              // For some reason `endColumn` isn't set in tests if `loc` is not
-              // added
               loc: parentCallExpressionNode.loc,
               message: `Async assertions must be awaited${messageReturn}.`,
               node,


### PR DESCRIPTION
## Acceptance Criteria

- [x] Improve `valid-expect` rule
- [x] Add test coverage
- [x] Update docs
- [x] Enable `alwaysAwait` option in plugin config

closes #54,
closes #254