### PR TITLE
Do not run `yarn build` during postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint": ">=5"
   },
   "scripts": {
-    "postinstall": "yarn build",
     "lint": "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts",
     "prettylint": "prettylint docs/**/*.md README.md package.json",
     "prepublishOnly": "yarn build",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": ">=5"
   },
   "scripts": {
+    "pretest": "yarn build",
     "lint": "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts",
     "prettylint": "prettylint docs/**/*.md README.md package.json",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Maybe I'm missing something, but running build during `postInstall` doesn't seem to be the right way to go.

This PR moves it into `pretest` instead.

Fixes #263