### PR TITLE
fix: move @typescript-eslint/experimental-utils to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "build": "babel --extensions .js,.ts src --out-dir lib",
     "typecheck": "tsc -p ."
   },
+  "dependencies": {
+    "@typescript-eslint/experimental-utils": "^1.9.1-alpha.3"
+  },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
     "@babel/core": "^7.4.4",
@@ -46,7 +49,6 @@
     "@types/jest": "^24.0.12",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^1.9.1-alpha.3",
-    "@typescript-eslint/experimental-utils": "^1.9.1-alpha.3",
     "babel-jest": "^24.8.0",
     "eslint": "^5.1.0",
     "eslint-config-prettier": "^4.1.0",


### PR DESCRIPTION
From mobile, seems correct?