### PR TITLE
feat(config): added shareable configuration plugin:jest/all

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ If you want to enable all rules instead of only some you can do so by adding the
 }
 ```
 
+While the `recommended` and `style` configurations only change in major versions
+the `all` configuration may change in any release and is thus unsuited for
+installations requiring long-term consistency.
+
 ## Rules
 
 | Rule                         | Description                                                       | Recommended      | Fixable             |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ See
 [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files)
 for more information about extending configuration files.
 
+### All
+
+If you want to enable all rules instead of only some you can do so by adding the
+`all` configuration to your `.eslintrc` config file:
+
+```json
+{
+  "extends": ["plugin:jest/all"]
+}
+```
+
 ## Rules
 
 | Rule                         | Description                                                       | Recommended      | Fixable             |

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,22 @@ const rules = fs
     (acc, curr) => Object.assign(acc, { [curr]: require(`./rules/${curr}`) }),
     {},
   );
+let allRules = {};
+Object.keys(rules).forEach(function(key) {
+  allRules[`jest/${key}`] = 'error';
+});
 
 const snapshotProcessor = require('./processors/snapshot-processor');
 
 module.exports = {
   configs: {
+    all: {
+      plugins: ['jest'],
+      env: {
+        'jest/globals': true,
+      },
+      rules: allRules,
+    },
     recommended: {
       plugins: ['jest'],
       env: {


### PR DESCRIPTION
This pull request creates an "all" shareable configuration that enables all rules similar to [eslint-plugin-react](https://github.com/yannickcr/eslint-plugin-react) among others. It is a useful starting point for beginners who want to see everything the plugin is capable of before enabling selected rules, and can also make custom configurations less verbose.

I haven't previously contributed to this repository before, so please let me know if I missed anything that should have been included!