### PR TITLE
chore: use messageId in all rules

### DIFF
--- a/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -7,7 +7,7 @@ Array [
       "lineCount": 1,
       "lineLimit": 0,
     },
-    "message": "Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long",
+    "messageId": "noSnapshot",
     "node": Object {
       "loc": Object {
         "end": Object {
@@ -29,7 +29,7 @@ Array [
       "lineCount": 83,
       "lineLimit": 70,
     },
-    "message": "Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long",
+    "messageId": "tooLongSnapshots",
     "node": Object {
       "loc": Object {
         "end": Object {
@@ -51,7 +51,7 @@ Array [
       "lineCount": 52,
       "lineLimit": 50,
     },
-    "message": "Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long",
+    "messageId": "tooLongSnapshots",
     "node": Object {
       "loc": Object {
         "end": Object {

--- a/src/rules/__tests__/consistent-test-it.test.js
+++ b/src/rules/__tests__/consistent-test-it.test.js
@@ -36,38 +36,69 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
     {
       code: 'it("foo")',
       options: [{ fn: 'test' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'test("foo")',
     },
     {
       code: 'xit("foo")',
       options: [{ fn: 'test' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'xtest("foo")',
     },
     {
       code: 'fit("foo")',
       options: [{ fn: 'test' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'test.only("foo")',
     },
     {
       code: 'it.skip("foo")',
       options: [{ fn: 'test' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'test.skip("foo")',
     },
     {
       code: 'it.only("foo")',
       options: [{ fn: 'test' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'test.only("foo")',
     },
     {
       code: 'describe("suite", () => { it("foo") })',
       options: [{ fn: 'test' }],
       errors: [
-        { message: "Prefer using 'test' instead of 'it' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'test',
+            oppositeTestKeyword: 'it',
+          },
+        },
       ],
       output: 'describe("suite", () => { test("foo") })',
     },
@@ -105,32 +136,58 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
     {
       code: 'test("foo")',
       options: [{ fn: 'it' }],
-      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'it', oppositeTestKeyword: 'test' },
+        },
+      ],
       output: 'it("foo")',
     },
     {
       code: 'xtest("foo")',
       options: [{ fn: 'it' }],
-      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'it', oppositeTestKeyword: 'test' },
+        },
+      ],
       output: 'xit("foo")',
     },
     {
       code: 'test.skip("foo")',
       options: [{ fn: 'it' }],
-      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'it', oppositeTestKeyword: 'test' },
+        },
+      ],
       output: 'it.skip("foo")',
     },
     {
       code: 'test.only("foo")',
       options: [{ fn: 'it' }],
-      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'it', oppositeTestKeyword: 'test' },
+        },
+      ],
       output: 'it.only("foo")',
     },
     {
       code: 'describe("suite", () => { test("foo") })',
       options: [{ fn: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it("foo") })',
     },
@@ -165,7 +222,13 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
       code: 'describe("suite", () => { test("foo") })',
       options: [{ fn: 'test', withinDescribe: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it("foo") })',
     },
@@ -173,7 +236,13 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
       code: 'describe("suite", () => { test.only("foo") })',
       options: [{ fn: 'test', withinDescribe: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it.only("foo") })',
     },
@@ -181,7 +250,13 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
       code: 'describe("suite", () => { xtest("foo") })',
       options: [{ fn: 'test', withinDescribe: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { xit("foo") })',
     },
@@ -189,7 +264,13 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
       code: 'describe("suite", () => { test.skip("foo") })',
       options: [{ fn: 'test', withinDescribe: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it.skip("foo") })',
     },
@@ -224,7 +305,13 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
       code: 'describe("suite", () => { it("foo") })',
       options: [{ fn: 'it', withinDescribe: 'test' }],
       errors: [
-        { message: "Prefer using 'test' instead of 'it' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'test',
+            oppositeTestKeyword: 'it',
+          },
+        },
       ],
       output: 'describe("suite", () => { test("foo") })',
     },
@@ -232,7 +319,13 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
       code: 'describe("suite", () => { it.only("foo") })',
       options: [{ fn: 'it', withinDescribe: 'test' }],
       errors: [
-        { message: "Prefer using 'test' instead of 'it' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'test',
+            oppositeTestKeyword: 'it',
+          },
+        },
       ],
       output: 'describe("suite", () => { test.only("foo") })',
     },
@@ -240,7 +333,13 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
       code: 'describe("suite", () => { xit("foo") })',
       options: [{ fn: 'it', withinDescribe: 'test' }],
       errors: [
-        { message: "Prefer using 'test' instead of 'it' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'test',
+            oppositeTestKeyword: 'it',
+          },
+        },
       ],
       output: 'describe("suite", () => { xtest("foo") })',
     },
@@ -248,7 +347,13 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
       code: 'describe("suite", () => { it.skip("foo") })',
       options: [{ fn: 'it', withinDescribe: 'test' }],
       errors: [
-        { message: "Prefer using 'test' instead of 'it' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'test',
+            oppositeTestKeyword: 'it',
+          },
+        },
       ],
       output: 'describe("suite", () => { test.skip("foo") })',
     },
@@ -274,14 +379,25 @@ ruleTester.run(
         code: 'describe("suite", () => { it("foo") })',
         options: [{ fn: 'test', withinDescribe: 'test' }],
         errors: [
-          { message: "Prefer using 'test' instead of 'it' within describe" },
+          {
+            messageId: 'consistentMethodWithingDescribe',
+            data: {
+              testKeywordWithinDescribe: 'test',
+              oppositeTestKeyword: 'it',
+            },
+          },
         ],
         output: 'describe("suite", () => { test("foo") })',
       },
       {
         code: 'it("foo")',
         options: [{ fn: 'test', withinDescribe: 'test' }],
-        errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+        errors: [
+          {
+            messageId: 'consistentMethod',
+            data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+          },
+        ],
         output: 'test("foo")',
       },
     ],
@@ -304,14 +420,25 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=it ', rule, {
       code: 'describe("suite", () => { test("foo") })',
       options: [{ fn: 'it', withinDescribe: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it("foo") })',
     },
     {
       code: 'test("foo")',
       options: [{ fn: 'it', withinDescribe: 'it' }],
-      errors: [{ message: "Prefer using 'it' instead of 'test'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'it', oppositeTestKeyword: 'test' },
+        },
+      ],
       output: 'it("foo")',
     },
   ],
@@ -327,7 +454,13 @@ ruleTester.run('consistent-test-it defaults without config object', rule, {
     {
       code: 'describe("suite", () => { test("foo") })',
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it("foo") })',
     },
@@ -349,14 +482,25 @@ ruleTester.run('consistent-test-it with withinDescribe=it', rule, {
     {
       code: 'it("foo")',
       options: [{ withinDescribe: 'it' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'test("foo")',
     },
     {
       code: 'describe("suite", () => { test("foo") })',
       options: [{ withinDescribe: 'it' }],
       errors: [
-        { message: "Prefer using 'it' instead of 'test' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'it',
+            oppositeTestKeyword: 'test',
+          },
+        },
       ],
       output: 'describe("suite", () => { it("foo") })',
     },
@@ -378,14 +522,25 @@ ruleTester.run('consistent-test-it with withinDescribe=test', rule, {
     {
       code: 'it("foo")',
       options: [{ withinDescribe: 'test' }],
-      errors: [{ message: "Prefer using 'test' instead of 'it'" }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: { testKeyword: 'test', oppositeTestKeyword: 'it' },
+        },
+      ],
       output: 'test("foo")',
     },
     {
       code: 'describe("suite", () => { it("foo") })',
       options: [{ withinDescribe: 'test' }],
       errors: [
-        { message: "Prefer using 'test' instead of 'it' within describe" },
+        {
+          messageId: 'consistentMethodWithingDescribe',
+          data: {
+            testKeywordWithinDescribe: 'test',
+            oppositeTestKeyword: 'it',
+          },
+        },
       ],
       output: 'describe("suite", () => { test("foo") })',
     },

--- a/src/rules/__tests__/expect-expect.test.js
+++ b/src/rules/__tests__/expect-expect.test.js
@@ -38,7 +38,7 @@ ruleTester.run('expect-expect', rule, {
       code: 'it("should fail", () => {});',
       errors: [
         {
-          message: 'Test has no assertions',
+          messageId: 'noAssertions',
           type: 'CallExpression',
         },
       ],
@@ -47,7 +47,7 @@ ruleTester.run('expect-expect', rule, {
       code: 'test("should fail", () => {});',
       errors: [
         {
-          message: 'Test has no assertions',
+          messageId: 'noAssertions',
           type: 'CallExpression',
         },
       ],
@@ -56,7 +56,7 @@ ruleTester.run('expect-expect', rule, {
       code: 'it("should fail", () => { somePromise.then(() => {}); });',
       errors: [
         {
-          message: 'Test has no assertions',
+          messageId: 'noAssertions',
           type: 'CallExpression',
         },
       ],
@@ -66,7 +66,7 @@ ruleTester.run('expect-expect', rule, {
       options: [{ assertFunctionNames: ['expect'] }],
       errors: [
         {
-          message: 'Test has no assertions',
+          messageId: 'noAssertions',
           type: 'CallExpression',
         },
       ],
@@ -76,7 +76,7 @@ ruleTester.run('expect-expect', rule, {
       options: [{ assertFunctionNames: ['expect'] }],
       errors: [
         {
-          message: 'Test has no assertions',
+          messageId: 'noAssertions',
           type: 'CallExpression',
         },
       ],

--- a/src/rules/__tests__/lowercase-name.test.js
+++ b/src/rules/__tests__/lowercase-name.test.js
@@ -11,6 +11,8 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('lowercase-name', rule, {
   valid: [
+    'randomFunction()',
+    'foo.bar()',
     'it()',
     "it(' ', function () {})",
     'it(" ", function () {})',
@@ -22,6 +24,8 @@ ruleTester.run('lowercase-name', rule, {
     'it("123 foo", function () {})',
     'it(42, function () {})',
     'it(``)',
+    'it("")',
+    'it(42)',
     'test()',
     "test('foo', function () {})",
     'test("foo", function () {})',
@@ -30,6 +34,8 @@ ruleTester.run('lowercase-name', rule, {
     'test("123 foo", function () {})',
     'test("42", function () {})',
     'test(``)',
+    'test("")',
+    'test(42)',
     'describe()',
     "describe('foo', function () {})",
     'describe("foo", function () {})',
@@ -39,6 +45,8 @@ ruleTester.run('lowercase-name', rule, {
     'describe("42", function () {})',
     'describe(function () {})',
     'describe(``)',
+    'describe("")',
+    'describe(42)',
   ],
 
   invalid: [
@@ -47,7 +55,8 @@ ruleTester.run('lowercase-name', rule, {
       output: "it('foo', function () {})",
       errors: [
         {
-          message: '`it`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'it' },
           column: 1,
           line: 1,
         },
@@ -58,7 +67,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'it("foo", function () {})',
       errors: [
         {
-          message: '`it`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'it' },
           column: 1,
           line: 1,
         },
@@ -69,7 +79,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'it(`foo`, function () {})',
       errors: [
         {
-          message: '`it`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'it' },
           column: 1,
           line: 1,
         },
@@ -80,7 +91,8 @@ ruleTester.run('lowercase-name', rule, {
       output: "test('foo', function () {})",
       errors: [
         {
-          message: '`test`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'test' },
           column: 1,
           line: 1,
         },
@@ -91,7 +103,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'test("foo", function () {})',
       errors: [
         {
-          message: '`test`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'test' },
           column: 1,
           line: 1,
         },
@@ -102,7 +115,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'test(`foo`, function () {})',
       errors: [
         {
-          message: '`test`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'test' },
           column: 1,
           line: 1,
         },
@@ -113,7 +127,8 @@ ruleTester.run('lowercase-name', rule, {
       output: "describe('foo', function () {})",
       errors: [
         {
-          message: '`describe`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'describe' },
           column: 1,
           line: 1,
         },
@@ -124,7 +139,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'describe("foo", function () {})',
       errors: [
         {
-          message: '`describe`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'describe' },
           column: 1,
           line: 1,
         },
@@ -135,7 +151,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'describe(`foo`, function () {})',
       errors: [
         {
-          message: '`describe`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'describe' },
           column: 1,
           line: 1,
         },
@@ -146,7 +163,8 @@ ruleTester.run('lowercase-name', rule, {
       output: 'describe(`some longer description`, function () {})',
       errors: [
         {
-          message: '`describe`s should begin with lowercase',
+          messageId: 'unexpectedLowercase',
+          data: { method: 'describe' },
           column: 1,
           line: 1,
         },

--- a/src/rules/__tests__/no-alias-methods.test.js
+++ b/src/rules/__tests__/no-alias-methods.test.js
@@ -26,8 +26,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toBeCalled()',
       errors: [
         {
-          message:
-            'Replace toBeCalled() with its canonical name of toHaveBeenCalled()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toBeCalled', canonical: 'toHaveBeenCalled' },
           column: 11,
           line: 1,
         },
@@ -38,8 +38,11 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toBeCalledTimes()',
       errors: [
         {
-          message:
-            'Replace toBeCalledTimes() with its canonical name of toHaveBeenCalledTimes()',
+          messageId: 'replaceAlias',
+          data: {
+            replace: 'toBeCalledTimes',
+            canonical: 'toHaveBeenCalledTimes',
+          },
           column: 11,
           line: 1,
         },
@@ -50,8 +53,11 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toBeCalledWith()',
       errors: [
         {
-          message:
-            'Replace toBeCalledWith() with its canonical name of toHaveBeenCalledWith()',
+          messageId: 'replaceAlias',
+          data: {
+            replace: 'toBeCalledWith',
+            canonical: 'toHaveBeenCalledWith',
+          },
           column: 11,
           line: 1,
         },
@@ -62,8 +68,11 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).lastCalledWith()',
       errors: [
         {
-          message:
-            'Replace lastCalledWith() with its canonical name of toHaveBeenLastCalledWith()',
+          messageId: 'replaceAlias',
+          data: {
+            replace: 'lastCalledWith',
+            canonical: 'toHaveBeenLastCalledWith',
+          },
           column: 11,
           line: 1,
         },
@@ -74,8 +83,11 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).nthCalledWith()',
       errors: [
         {
-          message:
-            'Replace nthCalledWith() with its canonical name of toHaveBeenNthCalledWith()',
+          messageId: 'replaceAlias',
+          data: {
+            replace: 'nthCalledWith',
+            canonical: 'toHaveBeenNthCalledWith',
+          },
           column: 11,
           line: 1,
         },
@@ -86,8 +98,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toReturn()',
       errors: [
         {
-          message:
-            'Replace toReturn() with its canonical name of toHaveReturned()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toReturn', canonical: 'toHaveReturned' },
           column: 11,
           line: 1,
         },
@@ -98,8 +110,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toReturnTimes()',
       errors: [
         {
-          message:
-            'Replace toReturnTimes() with its canonical name of toHaveReturnedTimes()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toReturnTimes', canonical: 'toHaveReturnedTimes' },
           column: 11,
           line: 1,
         },
@@ -110,8 +122,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toReturnWith()',
       errors: [
         {
-          message:
-            'Replace toReturnWith() with its canonical name of toHaveReturnedWith()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toReturnWith', canonical: 'toHaveReturnedWith' },
           column: 11,
           line: 1,
         },
@@ -122,8 +134,11 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).lastReturnedWith()',
       errors: [
         {
-          message:
-            'Replace lastReturnedWith() with its canonical name of toHaveLastReturnedWith()',
+          messageId: 'replaceAlias',
+          data: {
+            replace: 'lastReturnedWith',
+            canonical: 'toHaveLastReturnedWith',
+          },
           column: 11,
           line: 1,
         },
@@ -134,8 +149,11 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).nthReturnedWith()',
       errors: [
         {
-          message:
-            'Replace nthReturnedWith() with its canonical name of toHaveNthReturnedWith()',
+          messageId: 'replaceAlias',
+          data: {
+            replace: 'nthReturnedWith',
+            canonical: 'toHaveNthReturnedWith',
+          },
           column: 11,
           line: 1,
         },
@@ -146,8 +164,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).toThrowError()',
       errors: [
         {
-          message:
-            'Replace toThrowError() with its canonical name of toThrow()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toThrowError', canonical: 'toThrow' },
           column: 11,
           line: 1,
         },
@@ -158,8 +176,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).resolves.toThrowError()',
       errors: [
         {
-          message:
-            'Replace toThrowError() with its canonical name of toThrow()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toThrowError', canonical: 'toThrow' },
           column: 20,
           line: 1,
         },
@@ -170,8 +188,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).rejects.toThrowError()',
       errors: [
         {
-          message:
-            'Replace toThrowError() with its canonical name of toThrow()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toThrowError', canonical: 'toThrow' },
           column: 19,
           line: 1,
         },
@@ -182,8 +200,8 @@ ruleTester.run('no-alias-methods', rule, {
       code: 'expect(a).not.toThrowError()',
       errors: [
         {
-          message:
-            'Replace toThrowError() with its canonical name of toThrow()',
+          messageId: 'replaceAlias',
+          data: { replace: 'toThrowError', canonical: 'toThrow' },
           column: 15,
           line: 1,
         },

--- a/src/rules/__tests__/no-commented-out-tests.test.js
+++ b/src/rules/__tests__/no-commented-out-tests.test.js
@@ -60,83 +60,57 @@ ruleTester.run('no-commented-out-tests', rule, {
   invalid: [
     {
       code: '// describe("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// describe["skip"]("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// describe[\'skip\']("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// it.skip("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// it.only("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// it["skip"]("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// test.skip("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// test["skip"]("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// xdescribe("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// xit("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// fit("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// xtest("foo", function () {})',
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: `// test(
              //   "foo", function () {}
              // )`,
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: `/* test
@@ -144,59 +118,27 @@ ruleTester.run('no-commented-out-tests', rule, {
                 "foo", function () {}
               )
               */`,
-      errors: [
-        { message: 'Some tests seem to be commented', column: 1, line: 1 },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// it("has title but no callback")',
-      errors: [
-        {
-          message: 'Some tests seem to be commented',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// it()',
-      errors: [
-        {
-          message: 'Some tests seem to be commented',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// test.someNewMethodThatMightBeAddedInTheFuture()',
-      errors: [
-        {
-          message: 'Some tests seem to be commented',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// test["someNewMethodThatMightBeAddedInTheFuture"]()',
-      errors: [
-        {
-          message: 'Some tests seem to be commented',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// test("has title but no callback")',
-      errors: [
-        {
-          message: 'Some tests seem to be commented',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: `
@@ -205,13 +147,7 @@ ruleTester.run('no-commented-out-tests', rule, {
       describe("has title but no callback", () => {}) 
       */
       bar()`,
-      errors: [
-        {
-          message: 'Some tests seem to be commented',
-          column: 7,
-          line: 3,
-        },
-      ],
+      errors: [{ messageId: 'commentedTests', column: 7, line: 3 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-disabled-tests.test.js
+++ b/src/rules/__tests__/no-disabled-tests.test.js
@@ -57,79 +57,59 @@ ruleTester.run('no-disabled-tests', rule, {
   invalid: [
     {
       code: 'describe.skip("foo", function () {})',
-      errors: [{ message: 'Skipped test suite', column: 1, line: 1 }],
+      errors: [{ messageId: 'skippedTestSuite', column: 1, line: 1 }],
     },
     {
       code: 'describe["skip"]("foo", function () {})',
-      errors: [{ message: 'Skipped test suite', column: 1, line: 1 }],
+      errors: [{ messageId: 'skippedTestSuite', column: 1, line: 1 }],
     },
     {
       code: 'it.skip("foo", function () {})',
-      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
       code: 'it["skip"]("foo", function () {})',
-      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
       code: 'test.skip("foo", function () {})',
-      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
       code: 'test["skip"]("foo", function () {})',
-      errors: [{ message: 'Skipped test', column: 1, line: 1 }],
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
       code: 'xdescribe("foo", function () {})',
-      errors: [{ message: 'Disabled test suite', column: 1, line: 1 }],
+      errors: [{ messageId: 'disabledSuite', column: 1, line: 1 }],
     },
     {
       code: 'xit("foo", function () {})',
-      errors: [{ message: 'Disabled test', column: 1, line: 1 }],
+      errors: [{ messageId: 'disabledTest', column: 1, line: 1 }],
     },
     {
       code: 'xtest("foo", function () {})',
-      errors: [{ message: 'Disabled test', column: 1, line: 1 }],
+      errors: [{ messageId: 'disabledTest', column: 1, line: 1 }],
     },
     {
       code: 'it("has title but no callback")',
-      errors: [
-        {
-          message: 'Test is missing function argument',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'missingFunction', column: 1, line: 1 }],
     },
     {
       code: 'test("has title but no callback")',
-      errors: [
-        {
-          message: 'Test is missing function argument',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'missingFunction', column: 1, line: 1 }],
     },
     {
       code: 'it("contains a call to pending", function () { pending() })',
-      errors: [
-        { message: 'Call to pending() within test', column: 48, line: 1 },
-      ],
+      errors: [{ messageId: 'pendingTest', column: 48, line: 1 }],
     },
     {
       code: 'pending();',
-      errors: [{ message: 'Call to pending()', column: 1, line: 1 }],
+      errors: [{ messageId: 'pending', column: 1, line: 1 }],
     },
     {
       code: 'describe("contains a call to pending", function () { pending() })',
-      errors: [
-        {
-          message: 'Call to pending() within test suite',
-          column: 54,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'pendingSuite', column: 54, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-empty-title.js
+++ b/src/rules/__tests__/no-empty-title.js
@@ -26,83 +26,35 @@ ruleTester.run('no-empty-title', rule, {
   invalid: [
     {
       code: 'describe("", function () {})',
-      errors: [
-        {
-          message: rule.errorMessages.describe,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'describe', column: 1, line: 1 }],
     },
     {
       code: ["describe('foo', () => {", "it('', () => {})", '})'].join('\n'),
-      errors: [
-        {
-          message: rule.errorMessages.test,
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'test', column: 1, line: 2 }],
     },
     {
       code: 'it("", function () {})',
-      errors: [
-        {
-          message: rule.errorMessages.test,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'test', column: 1, line: 1 }],
     },
     {
       code: 'test("", function () {})',
-      errors: [
-        {
-          message: rule.errorMessages.test,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'test', column: 1, line: 1 }],
     },
     {
       code: 'test(``, function () {})',
-      errors: [
-        {
-          message: rule.errorMessages.test,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'test', column: 1, line: 1 }],
     },
     {
       code: "xdescribe('', () => {})",
-      errors: [
-        {
-          message: rule.errorMessages.describe,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'describe', column: 1, line: 1 }],
     },
     {
       code: "xit('', () => {})",
-      errors: [
-        {
-          message: rule.errorMessages.test,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'test', column: 1, line: 1 }],
     },
     {
       code: "xtest('', () => {})",
-      errors: [
-        {
-          message: rule.errorMessages.test,
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'test', column: 1, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-focused-tests.test.js
+++ b/src/rules/__tests__/no-focused-tests.test.js
@@ -4,7 +4,6 @@ const { RuleTester } = require('eslint');
 const rule = require('../no-focused-tests');
 
 const ruleTester = new RuleTester();
-const expectedErrorMessage = 'Unexpected focused test.';
 
 ruleTester.run('no-focused-tests', rule, {
   valid: [
@@ -21,51 +20,51 @@ ruleTester.run('no-focused-tests', rule, {
   invalid: [
     {
       code: 'describe.only()',
-      errors: [{ message: expectedErrorMessage, column: 10, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 10, line: 1 }],
     },
     {
       code: 'describe.only.each()',
-      errors: [{ message: expectedErrorMessage, column: 10, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 10, line: 1 }],
     },
     {
       code: 'describe["only"]()',
-      errors: [{ message: expectedErrorMessage, column: 10, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 10, line: 1 }],
     },
     {
       code: 'it.only()',
-      errors: [{ message: expectedErrorMessage, column: 4, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 4, line: 1 }],
     },
     {
       code: 'it.only.each()',
-      errors: [{ message: expectedErrorMessage, column: 4, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 4, line: 1 }],
     },
     {
       code: 'it["only"]()',
-      errors: [{ message: expectedErrorMessage, column: 4, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 4, line: 1 }],
     },
     {
       code: 'test.only()',
-      errors: [{ message: expectedErrorMessage, column: 6, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 6, line: 1 }],
     },
     {
       code: 'test.only.each()',
-      errors: [{ message: expectedErrorMessage, column: 6, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 6, line: 1 }],
     },
     {
       code: 'test["only"]()',
-      errors: [{ message: expectedErrorMessage, column: 6, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 6, line: 1 }],
     },
     {
       code: 'fdescribe()',
-      errors: [{ message: expectedErrorMessage, column: 1, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 1, line: 1 }],
     },
     {
       code: 'fit()',
-      errors: [{ message: expectedErrorMessage, column: 1, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 1, line: 1 }],
     },
     {
       code: 'fit.each()',
-      errors: [{ message: expectedErrorMessage, column: 1, line: 1 }],
+      errors: [{ messageId: 'focusedTest', column: 1, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-hooks.test.js
+++ b/src/rules/__tests__/no-hooks.test.js
@@ -22,24 +22,32 @@ ruleTester.run('no-hooks', rule, {
   invalid: [
     {
       code: 'beforeAll(() => {})',
-      errors: [{ message: "Unexpected 'beforeAll' hook" }],
+      errors: [
+        { messageId: 'unexpectedHook', data: { hookName: 'beforeAll' } },
+      ],
     },
     {
       code: 'beforeEach(() => {})',
-      errors: [{ message: "Unexpected 'beforeEach' hook" }],
+      errors: [
+        { messageId: 'unexpectedHook', data: { hookName: 'beforeEach' } },
+      ],
     },
     {
       code: 'afterAll(() => {})',
-      errors: [{ message: "Unexpected 'afterAll' hook" }],
+      errors: [{ messageId: 'unexpectedHook', data: { hookName: 'afterAll' } }],
     },
     {
       code: 'afterEach(() => {})',
-      errors: [{ message: "Unexpected 'afterEach' hook" }],
+      errors: [
+        { messageId: 'unexpectedHook', data: { hookName: 'afterEach' } },
+      ],
     },
     {
       code: 'beforeEach(() => {}); afterEach(() => { jest.resetModules() });',
       options: [{ allow: ['afterEach'] }],
-      errors: [{ message: "Unexpected 'beforeEach' hook" }],
+      errors: [
+        { messageId: 'unexpectedHook', data: { hookName: 'beforeEach' } },
+      ],
     },
   ],
 });

--- a/src/rules/__tests__/no-identical-title.test.js
+++ b/src/rules/__tests__/no-identical-title.test.js
@@ -125,110 +125,54 @@ ruleTester.run('no-identical-title', rule, {
         '   it("it1", function() {});',
         '});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Test title is used multiple times in the same describe block.',
-          column: 4,
-          line: 3,
-        },
-      ],
+      errors: [{ messageId: 'multipleTestTitle', column: 4, line: 3 }],
     },
     {
       code: ['it("it1", function() {});', 'it("it1", function() {});'].join(
         '\n',
       ),
-      errors: [
-        {
-          message:
-            'Test title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleTestTitle', column: 1, line: 2 }],
     },
     {
       code: [
         'it.only("it1", function() {});',
         'it("it1", function() {});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Test title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleTestTitle', column: 1, line: 2 }],
     },
     {
       code: ['fit("it1", function() {});', 'it("it1", function() {});'].join(
         '\n',
       ),
-      errors: [
-        {
-          message:
-            'Test title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleTestTitle', column: 1, line: 2 }],
     },
     {
       code: [
         'it.only("it1", function() {});',
         'it.only("it1", function() {});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Test title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleTestTitle', column: 1, line: 2 }],
     },
     {
       code: [
         'describe("describe1", function() {});',
         'describe("describe1", function() {});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Describe block title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleDescribeTitle', column: 1, line: 2 }],
     },
     {
       code: [
         'describe("describe1", function() {});',
         'xdescribe("describe1", function() {});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Describe block title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleDescribeTitle', column: 1, line: 2 }],
     },
     {
       code: [
         'fdescribe("describe1", function() {});',
         'describe("describe1", function() {});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Describe block title is used multiple times in the same describe block.',
-          column: 1,
-          line: 2,
-        },
-      ],
+      errors: [{ messageId: 'multipleDescribeTitle', column: 1, line: 2 }],
     },
     {
       code: [
@@ -237,14 +181,7 @@ ruleTester.run('no-identical-title', rule, {
         '});',
         'describe("describe1", function() {});',
       ].join('\n'),
-      errors: [
-        {
-          message:
-            'Describe block title is used multiple times in the same describe block.',
-          column: 1,
-          line: 4,
-        },
-      ],
+      errors: [{ messageId: 'multipleDescribeTitle', column: 1, line: 4 }],
     },
     {
       code: [
@@ -256,14 +193,7 @@ ruleTester.run('no-identical-title', rule, {
       env: {
         es6: true,
       },
-      errors: [
-        {
-          message:
-            'Test title is used multiple times in the same describe block.',
-          column: 5,
-          line: 3,
-        },
-      ],
+      errors: [{ messageId: 'multipleTestTitle', column: 5, line: 3 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-jasmine-globals.test.js
+++ b/src/rules/__tests__/no-jasmine-globals.test.js
@@ -24,7 +24,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'spyOn(some, "object")',
       errors: [
         {
-          message: 'Illegal usage of global `spyOn`, prefer `jest.spyOn`',
+          messageId: 'illegalGlobal',
+          data: { global: 'spyOn', replacement: 'jest.spyOn' },
           column: 1,
           line: 1,
         },
@@ -34,8 +35,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'spyOnProperty(some, "object")',
       errors: [
         {
-          message:
-            'Illegal usage of global `spyOnProperty`, prefer `jest.spyOn`',
+          messageId: 'illegalGlobal',
+          data: { global: 'spyOnProperty', replacement: 'jest.spyOn' },
           column: 1,
           line: 1,
         },
@@ -43,43 +44,23 @@ ruleTester.run('no-jasmine-globals', rule, {
     },
     {
       code: 'fail()',
-      errors: [
-        {
-          message:
-            'Illegal usage of `fail`, prefer throwing an error, or the `done.fail` callback',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalFail', column: 1, line: 1 }],
     },
     {
       code: 'pending()',
-      errors: [
-        {
-          message:
-            'Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalPending', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
       output: 'jest.setTimeout(5000);',
     },
     {
       code: 'jasmine.addMatchers(matchers)',
       errors: [
         {
-          message:
-            'Illegal usage of `jasmine.addMatchers`, prefer `expect.extend`',
+          messageId: 'illegalMethod',
+          data: { method: 'jasmine.addMatchers', replacement: 'expect.extend' },
           column: 1,
           line: 1,
         },
@@ -89,7 +70,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.createSpy()',
       errors: [
         {
-          message: 'Illegal usage of `jasmine.createSpy`, prefer `jest.fn`',
+          messageId: 'illegalMethod',
+          data: { method: 'jasmine.createSpy', replacement: 'jest.fn' },
           column: 1,
           line: 1,
         },
@@ -99,7 +81,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.any()',
       errors: [
         {
-          message: 'Illegal usage of `jasmine.any`, prefer `expect.any`',
+          messageId: 'illegalMethod',
+          data: { method: 'jasmine.any', replacement: 'expect.any' },
           column: 1,
           line: 1,
         },
@@ -110,8 +93,8 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.anything()',
       errors: [
         {
-          message:
-            'Illegal usage of `jasmine.anything`, prefer `expect.anything`',
+          messageId: 'illegalMethod',
+          data: { method: 'jasmine.anything', replacement: 'expect.anything' },
           column: 1,
           line: 1,
         },
@@ -122,8 +105,11 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.arrayContaining()',
       errors: [
         {
-          message:
-            'Illegal usage of `jasmine.arrayContaining`, prefer `expect.arrayContaining`',
+          messageId: 'illegalMethod',
+          data: {
+            method: 'jasmine.arrayContaining',
+            replacement: 'expect.arrayContaining',
+          },
           column: 1,
           line: 1,
         },
@@ -134,8 +120,11 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.objectContaining()',
       errors: [
         {
-          message:
-            'Illegal usage of `jasmine.objectContaining`, prefer `expect.objectContaining`',
+          messageId: 'illegalMethod',
+          data: {
+            method: 'jasmine.objectContaining',
+            replacement: 'expect.objectContaining',
+          },
           column: 1,
           line: 1,
         },
@@ -146,8 +135,11 @@ ruleTester.run('no-jasmine-globals', rule, {
       code: 'jasmine.stringMatching()',
       errors: [
         {
-          message:
-            'Illegal usage of `jasmine.stringMatching`, prefer `expect.stringMatching`',
+          messageId: 'illegalMethod',
+          data: {
+            method: 'jasmine.stringMatching',
+            replacement: 'expect.stringMatching',
+          },
           column: 1,
           line: 1,
         },
@@ -156,73 +148,31 @@ ruleTester.run('no-jasmine-globals', rule, {
     },
     {
       code: 'jasmine.getEnv()',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.empty()',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.falsy()',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.truthy()',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.arrayWithExactContents()',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.clock()',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.MAX_PRETTY_PRINT_ARRAY_LENGTH = 42',
-      errors: [
-        {
-          message: 'Illegal usage of jasmine global',
-          column: 1,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-jest-import.test.js
+++ b/src/rules/__tests__/no-jest-import.test.js
@@ -3,7 +3,6 @@
 const rule = require('../no-jest-import.js');
 const { RuleTester } = require('eslint');
 const ruleTester = new RuleTester();
-const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
 
 ruleTester.run('no-jest-import', rule, {
   valid: [
@@ -18,56 +17,26 @@ ruleTester.run('no-jest-import', rule, {
   invalid: [
     {
       code: 'require("jest")',
-      errors: [
-        {
-          endColumn: 15,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 15, column: 9, messageId: 'unexpectedImport' }],
     },
     {
       code: 'import jest from "jest"',
       parserOptions: { sourceType: 'module' },
-      errors: [
-        {
-          endColumn: 24,
-          column: 1,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 24, column: 1, messageId: 'unexpectedImport' }],
     },
     {
       code: 'var jest = require("jest")',
-      errors: [
-        {
-          endColumn: 26,
-          column: 20,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 26, column: 20, messageId: 'unexpectedImport' }],
     },
     {
       code: 'import {jest as test} from "jest"',
       parserOptions: { sourceType: 'module' },
-      errors: [
-        {
-          endColumn: 34,
-          column: 1,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedImport' }],
     },
     {
       code: 'const jest = require("jest")',
       parserOptions: { sourceType: 'module' },
-      errors: [
-        {
-          endColumn: 28,
-          column: 22,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 28, column: 22, messageId: 'unexpectedImport' }],
     },
   ],
 });

--- a/src/rules/__tests__/no-large-snapshots.test.js
+++ b/src/rules/__tests__/no-large-snapshots.test.js
@@ -33,8 +33,8 @@ ruleTester.run('no-large-snapshots', rule, {
       )}\`);`,
       errors: [
         {
-          message:
-            'Expected Jest snapshot to be smaller than 50 lines but was 51 lines long',
+          messageId: 'tooLongSnapshots',
+          data: { lineLimit: 50, lineCount: 51 },
         },
       ],
     },
@@ -45,8 +45,8 @@ ruleTester.run('no-large-snapshots', rule, {
       )}\`);`,
       errors: [
         {
-          message:
-            'Expected Jest snapshot to be smaller than 50 lines but was 51 lines long',
+          messageId: 'tooLongSnapshots',
+          data: { lineLimit: 50, lineCount: 51 },
         },
       ],
     },

--- a/src/rules/__tests__/no-mocks-import.test.js
+++ b/src/rules/__tests__/no-mocks-import.test.js
@@ -3,7 +3,6 @@
 const rule = require('../no-mocks-import.js');
 const { RuleTester } = require('eslint');
 const ruleTester = new RuleTester();
-const message = `Mocks should not be manually imported from a __mocks__ directory. Instead use jest.mock and import from the original module path.`;
 
 ruleTester.run('no-mocks-import', rule, {
   valid: [
@@ -24,74 +23,32 @@ ruleTester.run('no-mocks-import', rule, {
   invalid: [
     {
       code: 'require("./__mocks__")',
-      errors: [
-        {
-          endColumn: 22,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 22, column: 9, messageId: 'noManualImport' }],
     },
     {
       code: 'require("./__mocks__/")',
-      errors: [
-        {
-          endColumn: 23,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 23, column: 9, messageId: 'noManualImport' }],
     },
     {
       code: 'require("./__mocks__/index")',
-      errors: [
-        {
-          endColumn: 28,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 28, column: 9, messageId: 'noManualImport' }],
     },
     {
       code: 'require("__mocks__")',
-      errors: [
-        {
-          endColumn: 20,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 20, column: 9, messageId: 'noManualImport' }],
     },
     {
       code: 'require("__mocks__/")',
-      errors: [
-        {
-          endColumn: 21,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 21, column: 9, messageId: 'noManualImport' }],
     },
     {
       code: 'require("__mocks__/index")',
-      errors: [
-        {
-          endColumn: 26,
-          column: 9,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 26, column: 9, messageId: 'noManualImport' }],
     },
     {
       code: 'import thing from "./__mocks__/index"',
       parserOptions: { sourceType: 'module' },
-      errors: [
-        {
-          endColumn: 38,
-          column: 1,
-          message,
-        },
-      ],
+      errors: [{ endColumn: 38, column: 1, messageId: 'noManualImport' }],
     },
   ],
 });

--- a/src/rules/__tests__/no-test-callback.test.js
+++ b/src/rules/__tests__/no-test-callback.test.js
@@ -20,106 +20,52 @@ ruleTester.run('no-test-callback', rule, {
   invalid: [
     {
       code: 'test("something", done => {done();})',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 19,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 19 }],
       output:
         'test("something", () => {return new Promise(done => {done();})})',
     },
     {
       code: 'test("something", (done) => {done();})',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 20,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 20 }],
       output:
         'test("something", () => {return new Promise((done) => {done();})})',
     },
     {
       code: 'test("something", done => done())',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 19,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 19 }],
       output: 'test("something", () => new Promise(done => done()))',
     },
     {
       code: 'test("something", (done) => done())',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 20,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 20 }],
       output: 'test("something", () => new Promise((done) => done()))',
     },
     {
       code: 'test("something", function(done) {done();})',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 28,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 28 }],
       output:
         'test("something", function() {return new Promise((done) => {done();})})',
     },
     {
       code: 'test("something", function (done) {done();})',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 29,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 29 }],
       output:
         'test("something", function () {return new Promise((done) => {done();})})',
     },
     {
       code: 'test("something", async done => {done();})',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 25,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 25 }],
       output:
         'test("something", async () => {await new Promise(done => {done();})})',
     },
     {
       code: 'test("something", async done => done())',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 25,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 25 }],
       output: 'test("something", async () => new Promise(done => done()))',
     },
     {
       code: 'test("something", async function (done) {done();})',
-      errors: [
-        {
-          message: 'Illegal usage of test callback',
-          line: 1,
-          column: 35,
-        },
-      ],
+      errors: [{ messageId: 'illegalTestCallback', line: 1, column: 35 }],
       output:
         'test("something", async function () {await new Promise((done) => {done();})})',
     },

--- a/src/rules/__tests__/no-test-prefixes.test.js
+++ b/src/rules/__tests__/no-test-prefixes.test.js
@@ -21,27 +21,62 @@ ruleTester.run('no-test-prefixes', rule, {
   invalid: [
     {
       code: 'fdescribe("foo", function () {})',
-      errors: [{ message: 'Use "describe.only" instead', column: 1, line: 1 }],
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'describe.only' },
+          column: 1,
+          line: 1,
+        },
+      ],
       output: 'describe.only("foo", function () {})',
     },
     {
       code: 'fit("foo", function () {})',
-      errors: [{ message: 'Use "it.only" instead', column: 1, line: 1 }],
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'it.only' },
+          column: 1,
+          line: 1,
+        },
+      ],
       output: 'it.only("foo", function () {})',
     },
     {
       code: 'xdescribe("foo", function () {})',
-      errors: [{ message: 'Use "describe.skip" instead', column: 1, line: 1 }],
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'describe.skip' },
+          column: 1,
+          line: 1,
+        },
+      ],
       output: 'describe.skip("foo", function () {})',
     },
     {
       code: 'xit("foo", function () {})',
-      errors: [{ message: 'Use "it.skip" instead', column: 1, line: 1 }],
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'it.skip' },
+          column: 1,
+          line: 1,
+        },
+      ],
       output: 'it.skip("foo", function () {})',
     },
     {
       code: 'xtest("foo", function () {})',
-      errors: [{ message: 'Use "test.skip" instead', column: 1, line: 1 }],
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'test.skip' },
+          column: 1,
+          line: 1,
+        },
+      ],
       output: 'test.skip("foo", function () {})',
     },
   ],

--- a/src/rules/__tests__/no-test-return-statement.test.js
+++ b/src/rules/__tests__/no-test-return-statement.test.js
@@ -29,13 +29,7 @@ ruleTester.run('no-test-prefixes', rule, {
         return expect(1).toBe(1);
       });
       `,
-      errors: [
-        {
-          message: 'Jest tests should not return a value.',
-          column: 9,
-          line: 3,
-        },
-      ],
+      errors: [{ messageId: 'noReturnValue', column: 9, line: 3 }],
     },
     {
       code: `
@@ -43,13 +37,7 @@ ruleTester.run('no-test-prefixes', rule, {
         return expect(1).toBe(1);
       });
       `,
-      errors: [
-        {
-          message: 'Jest tests should not return a value.',
-          column: 9,
-          line: 3,
-        },
-      ],
+      errors: [{ messageId: 'noReturnValue', column: 9, line: 3 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-truthy-falsy.test.js
+++ b/src/rules/__tests__/no-truthy-falsy.test.js
@@ -22,7 +22,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(true).toBeTruthy();',
       errors: [
         {
-          message: 'Avoid toBeTruthy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeTruthy' },
           column: 14,
           line: 1,
         },
@@ -32,7 +33,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(false).not.toBeTruthy();',
       errors: [
         {
-          message: 'Avoid toBeTruthy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeTruthy' },
           column: 19,
           line: 1,
         },
@@ -42,7 +44,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(Promise.resolve({})).resolves.toBeTruthy()',
       errors: [
         {
-          message: 'Avoid toBeTruthy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeTruthy' },
           column: 38,
           line: 1,
         },
@@ -52,7 +55,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(Promise.resolve({})).rejects.toBeTruthy()',
       errors: [
         {
-          message: 'Avoid toBeTruthy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeTruthy' },
           column: 37,
           line: 1,
         },
@@ -62,7 +66,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(false).toBeFalsy();',
       errors: [
         {
-          message: 'Avoid toBeFalsy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeFalsy' },
           column: 15,
           line: 1,
         },
@@ -72,7 +77,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(true).not.toBeFalsy();',
       errors: [
         {
-          message: 'Avoid toBeFalsy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeFalsy' },
           column: 18,
           line: 1,
         },
@@ -82,7 +88,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(Promise.resolve({})).resolves.toBeFalsy()',
       errors: [
         {
-          message: 'Avoid toBeFalsy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeFalsy' },
           column: 38,
           line: 1,
         },
@@ -92,7 +99,8 @@ ruleTester.run('no-truthy-falsy', rule, {
       code: 'expect(Promise.resolve({})).rejects.toBeFalsy()',
       errors: [
         {
-          message: 'Avoid toBeFalsy',
+          messageId: 'avoidMessage',
+          data: { methodName: 'toBeFalsy' },
           column: 37,
           line: 1,
         },

--- a/src/rules/__tests__/prefer-called-with.js
+++ b/src/rules/__tests__/prefer-called-with.js
@@ -24,7 +24,8 @@ ruleTester.run('prefer-called-with', rule, {
       code: 'expect(fn).toBeCalled();',
       errors: [
         {
-          message: 'Prefer toBeCalledWith(/* expected args */)',
+          messageId: 'preferCalledWith',
+          data: { name: 'toBeCalled' },
           column: 12,
           line: 1,
         },
@@ -34,7 +35,8 @@ ruleTester.run('prefer-called-with', rule, {
       code: 'expect(fn).toHaveBeenCalled();',
       errors: [
         {
-          message: 'Prefer toHaveBeenCalledWith(/* expected args */)',
+          messageId: 'preferCalledWith',
+          data: { name: 'toHaveBeenCalled' },
           column: 12,
           line: 1,
         },

--- a/src/rules/__tests__/prefer-expect-assertions.test.js
+++ b/src/rules/__tests__/prefer-expect-assertions.test.js
@@ -9,26 +9,15 @@ const ruleTester = new RuleTester({
   },
 });
 
-const expectedMsg =
-  'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';
-
 ruleTester.run('prefer-expect-assertions', rule, {
   invalid: [
     {
       code: 'it("it1", () => {})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
     {
       code: 'it("it1", () => { foo()})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
     {
       code:
@@ -36,43 +25,23 @@ ruleTester.run('prefer-expect-assertions', rule, {
         '\n\t\t\tsomeFunctionToDo();' +
         '\n\t\t\tsomeFunctionToDo2();\n' +
         '\t\t\t})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
     {
       code: 'it("it1", function() {var a = 2;})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
     {
       code: 'it("it1", function() {expect.assertions();})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
     {
       code: 'it("it1", function() {expect.assertions(1,2);})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
     {
       code: 'it("it1", function() {expect.assertions("1");})',
-      errors: [
-        {
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ messageId: 'haveExpectAssertions' }],
     },
   ],
 

--- a/src/rules/__tests__/prefer-inline-snapshots.test.js
+++ b/src/rules/__tests__/prefer-inline-snapshots.test.js
@@ -13,24 +13,12 @@ ruleTester.run('prefer-inline-snapshots', rule, {
   invalid: [
     {
       code: 'expect(something).toMatchSnapshot();',
-      errors: [
-        {
-          message: 'Use toMatchInlineSnapshot() instead',
-          column: 19,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'toMatch', column: 19, line: 1 }],
       output: 'expect(something).toMatchInlineSnapshot();',
     },
     {
       code: 'expect(something).toThrowErrorMatchingSnapshot();',
-      errors: [
-        {
-          message: 'Use toThrowErrorMatchingInlineSnapshot() instead',
-          column: 19,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'toMatchError', column: 19, line: 1 }],
       output: 'expect(something).toThrowErrorMatchingInlineSnapshot();',
     },
   ],

--- a/src/rules/__tests__/prefer-spy-on.test.js
+++ b/src/rules/__tests__/prefer-spy-on.test.js
@@ -24,84 +24,44 @@ ruleTester.run('prefer-spy-on', rule, {
   invalid: [
     {
       code: 'obj.a = jest.fn(); const test = 10;',
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output: "jest.spyOn(obj, 'a'); const test = 10;",
     },
     {
       code: "Date['now'] = jest['fn']()",
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output: "jest.spyOn(Date, 'now')",
     },
     {
       code: 'window[`${name}`] = jest[`fn`]()',
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output: 'jest.spyOn(window, `${name}`)',
     },
     {
       code: "obj['prop' + 1] = jest['fn']()",
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output: "jest.spyOn(obj, 'prop' + 1)",
     },
     {
       code: 'obj.one.two = jest.fn(); const test = 10;',
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output: "jest.spyOn(obj.one, 'two'); const test = 10;",
     },
     {
       code: 'obj.a = jest.fn(() => 10)',
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output: "jest.spyOn(obj, 'a').mockImplementation(() => 10)",
     },
     {
       code:
         "obj.a.b = jest.fn(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output:
         "jest.spyOn(obj.a, 'b').mockImplementation(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
     },
     {
       code: 'window.fetch = jest.fn(() => ({})).one.two().three().four',
-      errors: [
-        {
-          message: 'Use jest.spyOn() instead.',
-          type: 'AssignmentExpression',
-        },
-      ],
+      errors: [{ messageId: 'useJestSpyOn', type: 'AssignmentExpression' }],
       output:
         "jest.spyOn(window, 'fetch').mockImplementation(() => ({})).one.two().three().four",
     },

--- a/src/rules/__tests__/prefer-strict-equal.test.js
+++ b/src/rules/__tests__/prefer-strict-equal.test.js
@@ -13,13 +13,7 @@ ruleTester.run('prefer-strict-equal', rule, {
   invalid: [
     {
       code: 'expect(something).toEqual(somethingElse);',
-      errors: [
-        {
-          message: 'Use toStrictEqual() instead',
-          column: 19,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToStrictEqual', column: 19, line: 1 }],
       output: 'expect(something).toStrictEqual(somethingElse);',
     },
   ],

--- a/src/rules/__tests__/prefer-to-be-null.test.js
+++ b/src/rules/__tests__/prefer-to-be-null.test.js
@@ -24,46 +24,22 @@ ruleTester.run('prefer-to-be-null', rule, {
   invalid: [
     {
       code: 'expect(null).toBe(null);',
-      errors: [
-        {
-          message: 'Use toBeNull() instead',
-          column: 14,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
       output: 'expect(null).toBeNull();',
     },
     {
       code: 'expect(null).toEqual(null);',
-      errors: [
-        {
-          message: 'Use toBeNull() instead',
-          column: 14,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
       output: 'expect(null).toBeNull();',
     },
     {
       code: 'expect("a string").not.toBe(null);',
-      errors: [
-        {
-          message: 'Use toBeNull() instead',
-          column: 24,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
     },
     {
       code: 'expect("a string").not.toEqual(null);',
-      errors: [
-        {
-          message: 'Use toBeNull() instead',
-          column: 24,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
     },
   ],

--- a/src/rules/__tests__/prefer-to-be-undefined.test.js
+++ b/src/rules/__tests__/prefer-to-be-undefined.test.js
@@ -21,46 +21,22 @@ ruleTester.run('prefer-to-be-undefined', rule, {
   invalid: [
     {
       code: 'expect(undefined).toBe(undefined);',
-      errors: [
-        {
-          message: 'Use toBeUndefined() instead',
-          column: 19,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
       output: 'expect(undefined).toBeUndefined();',
     },
     {
       code: 'expect(undefined).toEqual(undefined);',
-      errors: [
-        {
-          message: 'Use toBeUndefined() instead',
-          column: 19,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
       output: 'expect(undefined).toBeUndefined();',
     },
     {
       code: 'expect("a string").not.toBe(undefined);',
-      errors: [
-        {
-          message: 'Use toBeUndefined() instead',
-          column: 24,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
     },
     {
       code: 'expect("a string").not.toEqual(undefined);',
-      errors: [
-        {
-          message: 'Use toBeUndefined() instead',
-          column: 24,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
     },
   ],

--- a/src/rules/__tests__/prefer-to-contain.test.js
+++ b/src/rules/__tests__/prefer-to-contain.test.js
@@ -29,178 +29,82 @@ ruleTester.run('prefer-to-contain', rule, {
   invalid: [
     {
       code: 'expect(a.includes(b)).toEqual(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).toEqual(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).not.toEqual(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).not.toEqual(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).toBe(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).toBe(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).not.toBe(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
     },
     {
       code: 'expect(a.includes(b)).not.toBe(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 23,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).toEqual(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 39,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).toContain(b.test(p));',
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).toEqual(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 39,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).not.toContain(b.test(p));',
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 39,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).not.toContain(b.test(p));',
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 39,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).toContain(b.test(p));',
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toBe(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 33,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toBe(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 33,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).not.toContain({a:1});',
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(true);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 33,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).not.toContain({a:1});',
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(false);',
-      errors: [
-        {
-          message: 'Use toContain() instead',
-          column: 33,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
     },
   ],

--- a/src/rules/__tests__/prefer-to-have-length.test.js
+++ b/src/rules/__tests__/prefer-to-have-length.test.js
@@ -17,24 +17,12 @@ ruleTester.run('prefer-to-have-length', rule, {
   invalid: [
     {
       code: 'expect(files.length).toBe(1);',
-      errors: [
-        {
-          message: 'Use toHaveLength() instead',
-          column: 22,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
       output: 'expect(files).toHaveLength(1);',
     },
     {
       code: 'expect(files.length).toEqual(1);',
-      errors: [
-        {
-          message: 'Use toHaveLength() instead',
-          column: 22,
-          line: 1,
-        },
-      ],
+      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
       output: 'expect(files).toHaveLength(1);',
     },
   ],

--- a/src/rules/__tests__/prefer-todo.test.js
+++ b/src/rules/__tests__/prefer-todo.test.js
@@ -23,36 +23,32 @@ ruleTester.run('prefer-todo', rule, {
   invalid: [
     {
       code: `test("i need to write this test");`,
-      errors: [
-        { message: 'Prefer todo test case over unimplemented test case' },
-      ],
+      errors: [{ messageId: 'todoOverUnimplemented' }],
       output: 'test.todo("i need to write this test");',
     },
     {
       code: 'test(`i need to write this test`);',
-      errors: [
-        { message: 'Prefer todo test case over unimplemented test case' },
-      ],
+      errors: [{ messageId: 'todoOverUnimplemented' }],
       output: 'test.todo(`i need to write this test`);',
     },
     {
       code: 'it("foo", function () {})',
-      errors: ['Prefer todo test case over empty test case'],
+      errors: [{ messageId: 'todoOverEmpty' }],
       output: 'it.todo("foo")',
     },
     {
       code: 'it("foo", () => {})',
-      errors: ['Prefer todo test case over empty test case'],
+      errors: [{ messageId: 'todoOverEmpty' }],
       output: 'it.todo("foo")',
     },
     {
       code: `test.skip("i need to write this test", () => {});`,
-      errors: ['Prefer todo test case over empty test case'],
+      errors: [{ messageId: 'todoOverEmpty' }],
       output: 'test.todo("i need to write this test");',
     },
     {
       code: `test.skip("i need to write this test", function() {});`,
-      errors: ['Prefer todo test case over empty test case'],
+      errors: [{ messageId: 'todoOverEmpty' }],
       output: 'test.todo("i need to write this test");',
     },
   ],

--- a/src/rules/__tests__/require-tothrow-message.test.js
+++ b/src/rules/__tests__/require-tothrow-message.test.js
@@ -34,7 +34,12 @@ ruleTester.run('require-tothrow-message', rule, {
     {
       code: "expect(() => { throw new Error('a'); }).toThrow();",
       errors: [
-        { message: 'Add an error message to toThrow()', column: 41, line: 1 },
+        {
+          messageId: 'requireRethrow',
+          data: { propertyName: 'toThrow' },
+          column: 41,
+          line: 1,
+        },
       ],
     },
     // Empty toThrowError
@@ -42,7 +47,8 @@ ruleTester.run('require-tothrow-message', rule, {
       code: "expect(() => { throw new Error('a'); }).toThrowError();",
       errors: [
         {
-          message: 'Add an error message to toThrowError()',
+          messageId: 'requireRethrow',
+          data: { propertyName: 'toThrowError' },
           column: 41,
           line: 1,
         },

--- a/src/rules/__tests__/valid-describe.test.js
+++ b/src/rules/__tests__/valid-describe.test.js
@@ -44,71 +44,47 @@ ruleTester.run('valid-describe', rule, {
     {
       code: 'describe(() => {})',
       errors: [
-        {
-          message: 'First argument must be name',
-          line: 1,
-          column: 10,
-        },
-        {
-          message: 'Describe requires name and callback arguments',
-          line: 1,
-          column: 10,
-        },
+        { messageId: 'firstArgumentMustBeName', line: 1, column: 10 },
+        { messageId: 'nameAndCallback', line: 1, column: 10 },
       ],
     },
     {
       code: 'describe("foo")',
-      errors: [
-        {
-          message: 'Describe requires name and callback arguments',
-          line: 1,
-          column: 10,
-        },
-      ],
+      errors: [{ messageId: 'nameAndCallback', line: 1, column: 10 }],
     },
     {
       code: 'describe("foo", "foo2")',
       errors: [
-        {
-          message: 'Second argument must be function',
-          line: 1,
-          column: 10,
-        },
+        { messageId: 'secondArgumentMustBeFunction', line: 1, column: 10 },
       ],
     },
     {
       code: 'describe()',
-      errors: [
-        {
-          message: 'Describe requires name and callback arguments',
-          line: 1,
-          column: 1,
-        },
-      ],
+      errors: [{ messageId: 'nameAndCallback', line: 1, column: 1 }],
     },
     {
       code: 'describe("foo", async () => {})',
-      errors: [{ message: 'No async describe callback', line: 1, column: 17 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 17 }],
     },
     {
       code: 'describe("foo", async function () {})',
-      errors: [{ message: 'No async describe callback', line: 1, column: 17 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 17 }],
     },
     {
       code: 'xdescribe("foo", async function () {})',
-      errors: [{ message: 'No async describe callback', line: 1, column: 18 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 18 }],
     },
     {
       code: 'fdescribe("foo", async function () {})',
-      errors: [{ message: 'No async describe callback', line: 1, column: 18 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 18 }],
     },
     {
       code: 'describe.only("foo", async function () {})',
-      errors: [{ message: 'No async describe callback', line: 1, column: 22 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 22 }],
     },
     {
       code: 'describe.skip("foo", async function () {})',
-      errors: [{ message: 'No async describe callback', line: 1, column: 22 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 22 }],
     },
     {
       code: `
@@ -123,7 +99,7 @@ ruleTester.run('valid-describe', rule, {
           });
         });
       });`,
-      errors: [{ message: 'No async describe callback', line: 6, column: 27 }],
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 6, column: 27 }],
     },
     {
       code: `
@@ -135,13 +111,7 @@ ruleTester.run('valid-describe', rule, {
         })
       })
       `,
-      errors: [
-        {
-          message: 'Unexpected return statement in describe callback',
-          line: 3,
-          column: 9,
-        },
-      ],
+      errors: [{ messageId: 'unexpectedReturnInDescribe', line: 3, column: 9 }],
     },
     {
       code: `
@@ -161,16 +131,8 @@ ruleTester.run('valid-describe', rule, {
       })
       `,
       errors: [
-        {
-          message: 'Unexpected return statement in describe callback',
-          line: 3,
-          column: 9,
-        },
-        {
-          message: 'Unexpected return statement in describe callback',
-          line: 9,
-          column: 11,
-        },
+        { messageId: 'unexpectedReturnInDescribe', line: 3, column: 9 },
+        { messageId: 'unexpectedReturnInDescribe', line: 9, column: 11 },
       ],
     },
     {
@@ -188,57 +150,33 @@ ruleTester.run('valid-describe', rule, {
       })
       `,
       errors: [
-        {
-          message: 'No async describe callback',
-          line: 2,
-          column: 23,
-        },
-        {
-          message: 'Unexpected return statement in describe callback',
-          line: 6,
-          column: 11,
-        },
+        { messageId: 'noAsyncDescribeCallback', line: 2, column: 23 },
+        { messageId: 'unexpectedReturnInDescribe', line: 6, column: 11 },
       ],
     },
     {
       code: 'describe("foo", done => {})',
       errors: [
-        {
-          message: 'Unexpected argument(s) in describe callback',
-          line: 1,
-          column: 17,
-        },
+        { messageId: 'unexpectedDescribeArgument', line: 1, column: 17 },
       ],
     },
     {
       code: 'describe("foo", function (done) {})',
       errors: [
-        {
-          message: 'Unexpected argument(s) in describe callback',
-          line: 1,
-          column: 27,
-        },
+        { messageId: 'unexpectedDescribeArgument', line: 1, column: 27 },
       ],
     },
     {
       code: 'describe("foo", function (one, two, three) {})',
       errors: [
-        {
-          message: 'Unexpected argument(s) in describe callback',
-          line: 1,
-          column: 27,
-        },
+        { messageId: 'unexpectedDescribeArgument', line: 1, column: 27 },
       ],
     },
     {
       code: 'describe("foo", async function (done) {})',
       errors: [
-        { message: 'No async describe callback', line: 1, column: 17 },
-        {
-          message: 'Unexpected argument(s) in describe callback',
-          line: 1,
-          column: 33,
-        },
+        { messageId: 'noAsyncDescribeCallback', line: 1, column: 17 },
+        { messageId: 'unexpectedDescribeArgument', line: 1, column: 33 },
       ],
     },
   ],

--- a/src/rules/__tests__/valid-expect-in-promise.test.js
+++ b/src/rules/__tests__/valid-expect-in-promise.test.js
@@ -9,9 +9,6 @@ const ruleTester = new RuleTester({
   },
 });
 
-const expectedMsg =
-  'Promise should be returned to test its fulfillment or rejection';
-
 ruleTester.run('valid-expect-in-promise', rule, {
   invalid: [
     {
@@ -22,13 +19,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
            });
          });
       `,
-      errors: [
-        {
-          column: 12,
-          endColumn: 15,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 12, endColumn: 15, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -38,13 +29,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
             });
         });
       `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 16,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 13, endColumn: 16, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -54,13 +39,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
             });
           });
       `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 16,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 13, endColumn: 16, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -71,13 +50,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
           }
         )
       `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 15,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 13, endColumn: 15, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -88,13 +61,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
           }
         )
       `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 15,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 13, endColumn: 15, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -106,13 +73,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
           })
         })
       `,
-      errors: [
-        {
-          column: 11,
-          endColumn: 13,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 11, endColumn: 13, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -123,13 +84,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
           })
         });
       `,
-      errors: [
-        {
-          column: 11,
-          endColumn: 13,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 11, endColumn: 13, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -137,13 +92,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
           Builder.getPromiseBuilder().get().build().then((data) => expect(data).toEqual('Hi'));
         });
       `,
-      errors: [
-        {
-          column: 11,
-          endColumn: 96,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 11, endColumn: 96, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -154,13 +103,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
             })
           });
       `,
-      errors: [
-        {
-          column: 13,
-          endColumn: 15,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 13, endColumn: 15, messageId: 'returnPromise' }],
     },
     {
       code: `
@@ -171,13 +114,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
            });
          });
       `,
-      errors: [
-        {
-          column: 18,
-          endColumn: 14,
-          message: expectedMsg,
-        },
-      ],
+      errors: [{ column: 18, endColumn: 14, messageId: 'returnPromise' }],
     },
   ],
 

--- a/src/rules/__tests__/valid-expect.test.js
+++ b/src/rules/__tests__/valid-expect.test.js
@@ -18,57 +18,25 @@ ruleTester.run('valid-expect', rule, {
   invalid: [
     {
       code: 'expect().toBe(true);',
-      errors: [
-        {
-          endColumn: 8,
-          column: 7,
-          message: 'No arguments were passed to expect().',
-        },
-      ],
+      errors: [{ endColumn: 8, column: 7, messageId: 'noArgs' }],
     },
     {
       code: 'expect().toEqual("something");',
-      errors: [
-        {
-          endColumn: 8,
-          column: 7,
-          message: 'No arguments were passed to expect().',
-        },
-      ],
+      errors: [{ endColumn: 8, column: 7, messageId: 'noArgs' }],
     },
     {
       code: 'expect("something", "else").toEqual("something");',
-      errors: [
-        {
-          endColumn: 26,
-          column: 21,
-          message: 'More than one argument was passed to expect().',
-        },
-      ],
+      errors: [{ endColumn: 26, column: 21, messageId: 'multipleArgs' }],
     },
     {
       code: 'expect("something");',
-      errors: [
-        {
-          endColumn: 20,
-          column: 1,
-          message: 'No assertion was called on expect().',
-        },
-      ],
+      errors: [{ endColumn: 20, column: 1, messageId: 'noAssertions' }],
     },
     {
       code: 'expect();',
       errors: [
-        {
-          endColumn: 9,
-          column: 1,
-          message: 'No assertion was called on expect().',
-        },
-        {
-          endColumn: 8,
-          column: 7,
-          message: 'No arguments were passed to expect().',
-        },
+        { endColumn: 9, column: 1, messageId: 'noAssertions' },
+        { endColumn: 8, column: 7, messageId: 'noArgs' },
       ],
     },
     {
@@ -77,7 +45,8 @@ ruleTester.run('valid-expect', rule, {
         {
           endColumn: 25,
           column: 14,
-          message: '"toBeDefined" was not called.',
+          messageId: 'matcherOnPropertyNotCalled',
+          data: { propertyName: 'toBeDefined' },
         },
       ],
     },
@@ -87,7 +56,8 @@ ruleTester.run('valid-expect', rule, {
         {
           endColumn: 29,
           column: 18,
-          message: '"toBeDefined" was not called.',
+          messageId: 'matcherOnPropertyNotCalled',
+          data: { propertyName: 'toBeDefined' },
         },
       ],
     },
@@ -97,7 +67,8 @@ ruleTester.run('valid-expect', rule, {
         {
           endColumn: 18,
           column: 14,
-          message: '"nope" is not a valid property of expect.',
+          messageId: 'invalidProperty',
+          data: { propertyName: 'nope' },
         },
       ],
     },
@@ -107,7 +78,8 @@ ruleTester.run('valid-expect', rule, {
         {
           endColumn: 22,
           column: 14,
-          message: '"resolves" needs to call a matcher.',
+          messageId: 'propertyWithoutMatcher',
+          data: { propertyName: 'resolves' },
         },
       ],
     },
@@ -117,7 +89,8 @@ ruleTester.run('valid-expect', rule, {
         {
           endColumn: 21,
           column: 14,
-          message: '"rejects" needs to call a matcher.',
+          messageId: 'propertyWithoutMatcher',
+          data: { propertyName: 'rejects' },
         },
       ],
     },
@@ -127,7 +100,8 @@ ruleTester.run('valid-expect', rule, {
         {
           endColumn: 17,
           column: 14,
-          message: '"not" needs to call a matcher.',
+          messageId: 'propertyWithoutMatcher',
+          data: { propertyName: 'not' },
         },
       ],
     },

--- a/src/rules/consistent-test-it.js
+++ b/src/rules/consistent-test-it.js
@@ -8,6 +8,12 @@ module.exports = {
       url: getDocsUrl(__filename),
     },
     fixable: 'code',
+    messages: {
+      consistentMethod:
+        "Prefer using '{{ testKeyword }}' instead of '{{ oppositeTestKeyword }}'",
+      consistentMethodWithingDescribe:
+        "Prefer using '{{ testKeywordWithinDescribe }}' instead of '{{ oppositeTestKeyword }}' within describe",
+    },
     schema: [
       {
         type: 'object',
@@ -47,8 +53,7 @@ module.exports = {
           const oppositeTestKeyword = getOppositeTestKeyword(testKeyword);
 
           context.report({
-            message:
-              "Prefer using '{{ testKeyword }}' instead of '{{ oppositeTestKeyword }}'",
+            messageId: 'consistentMethod',
             node: node.callee,
             data: { testKeyword, oppositeTestKeyword },
             fix(fixer) {
@@ -73,8 +78,7 @@ module.exports = {
           );
 
           context.report({
-            message:
-              "Prefer using '{{ testKeywordWithinDescribe }}' instead of '{{ oppositeTestKeyword }}' within describe",
+            messageId: 'consistentMethodWithingDescribe',
             node: node.callee,
             data: { testKeywordWithinDescribe, oppositeTestKeyword },
             fix(fixer) {

--- a/src/rules/expect-expect.js
+++ b/src/rules/expect-expect.js
@@ -12,6 +12,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      noAssertions: 'Test has no assertions',
+    },
     schema: [
       {
         type: 'object',
@@ -51,10 +54,7 @@ module.exports = {
       },
       'Program:exit'() {
         unchecked.forEach(node =>
-          context.report({
-            message: 'Test has no assertions',
-            node,
-          }),
+          context.report({ messageId: 'noAssertions', node }),
         );
       },
     };

--- a/src/rules/lowercase-name.js
+++ b/src/rules/lowercase-name.js
@@ -52,6 +52,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      unexpectedLowercase: '`{{ method }}`s should begin with lowercase',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -70,7 +73,7 @@ module.exports = {
 
         if (erroneousMethod && !isIgnoredFunctionName(node)) {
           context.report({
-            message: '`{{ method }}`s should begin with lowercase',
+            messageId: 'unexpectedLowercase',
             data: { method: erroneousMethod },
             node,
             fix(fixer) {

--- a/src/rules/no-alias-methods.js
+++ b/src/rules/no-alias-methods.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      replaceAlias: `Replace {{ replace }}() with its canonical name of {{ canonical }}()`,
+    },
     fixable: 'code',
   },
   create(context) {
@@ -52,15 +55,13 @@ module.exports = {
 
         if (methodItem) {
           context.report({
-            message: `Replace {{ replace }}() with its canonical name of {{ canonical }}()`,
+            messageId: 'replaceAlias',
             data: {
               replace: methodItem[1],
               canonical: methodItem[0],
             },
             node: targetNode,
-            fix(fixer) {
-              return [fixer.replaceText(targetNode, methodItem[0])];
-            },
+            fix: fixer => [fixer.replaceText(targetNode, methodItem[0])],
           });
         }
       },

--- a/src/rules/no-commented-out-tests.js
+++ b/src/rules/no-commented-out-tests.js
@@ -2,8 +2,6 @@
 
 const { getDocsUrl } = require('./util');
 
-const message = 'Some tests seem to be commented';
-
 function hasTests(node) {
   return /^\s*(x|f)?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/m.test(
     node.value,
@@ -15,17 +13,19 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      commentedTests: 'Some tests seem to be commented',
+    },
   },
   create(context) {
     const sourceCode = context.getSourceCode();
 
     function checkNode(node) {
-      if (!hasTests(node)) return;
+      if (!hasTests(node)) {
+        return;
+      }
 
-      context.report({
-        message,
-        node,
-      });
+      context.report({ messageId: 'commentedTests', node });
     }
 
     return {

--- a/src/rules/no-disabled-tests.js
+++ b/src/rules/no-disabled-tests.js
@@ -7,6 +7,16 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      missingFunction: 'Test is missing function argument',
+      skippedTestSuite: 'Skipped test suite',
+      skippedTest: 'Skipped test',
+      pending: 'Call to pending()',
+      pendingSuite: 'Call to pending() within test suite',
+      pendingTest: 'Call to pending() within test',
+      disabledSuite: 'Disabled test suite',
+      disabledTest: 'Disabled test',
+    },
   },
   create(context) {
     let suiteDepth = 0;
@@ -20,22 +30,19 @@ module.exports = {
         testDepth++;
       },
       'CallExpression[callee.name=/^(it|test)$/][arguments.length<2]'(node) {
-        context.report({
-          message: 'Test is missing function argument',
-          node,
-        });
+        context.report({ messageId: 'missingFunction', node });
       },
       CallExpression(node) {
         const functionName = getNodeName(node.callee);
 
         switch (functionName) {
           case 'describe.skip':
-            context.report({ message: 'Skipped test suite', node });
+            context.report({ messageId: 'skippedTestSuite', node });
             break;
 
           case 'it.skip':
           case 'test.skip':
-            context.report({ message: 'Skipped test', node });
+            context.report({ messageId: 'skippedTest', node });
             break;
         }
       },
@@ -45,27 +52,18 @@ module.exports = {
         }
 
         if (testDepth > 0) {
-          context.report({
-            message: 'Call to pending() within test',
-            node,
-          });
+          context.report({ messageId: 'pendingTest', node });
         } else if (suiteDepth > 0) {
-          context.report({
-            message: 'Call to pending() within test suite',
-            node,
-          });
+          context.report({ messageId: 'pendingSuite', node });
         } else {
-          context.report({
-            message: 'Call to pending()',
-            node,
-          });
+          context.report({ messageId: 'pending', node });
         }
       },
       'CallExpression[callee.name="xdescribe"]'(node) {
-        context.report({ message: 'Disabled test suite', node });
+        context.report({ messageId: 'disabledSuite', node });
       },
       'CallExpression[callee.name=/^xit|xtest$/]'(node) {
-        context.report({ message: 'Disabled test', node });
+        context.report({ messageId: 'disabledTest', node });
       },
       'CallExpression[callee.name="describe"]:exit'() {
         suiteDepth--;

--- a/src/rules/no-empty-title.js
+++ b/src/rules/no-empty-title.js
@@ -10,15 +10,14 @@ const {
   getStringValue,
 } = require('./util');
 
-const errorMessages = {
-  describe: 'describe should not have an empty title',
-  test: 'test should not have an empty title',
-};
-
 module.exports = {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
+    },
+    messages: {
+      describe: 'describe should not have an empty title',
+      test: 'test should not have an empty title',
     },
   },
   create(context) {
@@ -39,16 +38,12 @@ module.exports = {
           return;
         }
         if (getStringValue(firstArgument) === '') {
-          const message = is.describe
-            ? errorMessages.describe
-            : errorMessages.test;
           context.report({
-            message,
+            messageId: is.describe ? 'describe' : 'test',
             node,
           });
         }
       },
     };
   },
-  errorMessages,
 };

--- a/src/rules/no-focused-tests.js
+++ b/src/rules/no-focused-tests.js
@@ -24,6 +24,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      focusedTest: 'Unexpected focused test.',
+    },
   },
   create: context => ({
     CallExpression(node) {
@@ -34,10 +37,7 @@ module.exports = {
           callee.object.type === 'Identifier' &&
           isCallToFocusedTestFunction(callee.object)
         ) {
-          context.report({
-            message: 'Unexpected focused test.',
-            node: callee.object,
-          });
+          context.report({ messageId: 'focusedTest', node: callee.object });
           return;
         }
 
@@ -46,27 +46,20 @@ module.exports = {
           isCallToTestOnlyFunction(callee.object)
         ) {
           context.report({
-            message: 'Unexpected focused test.',
+            messageId: 'focusedTest',
             node: callee.object.property,
           });
           return;
         }
 
         if (isCallToTestOnlyFunction(callee)) {
-          context.report({
-            message: 'Unexpected focused test.',
-            node: callee.property,
-          });
+          context.report({ messageId: 'focusedTest', node: callee.property });
           return;
         }
       }
 
       if (callee.type === 'Identifier' && isCallToFocusedTestFunction(callee)) {
-        context.report({
-          message: 'Unexpected focused test.',
-          node: callee,
-        });
-        return;
+        context.report({ messageId: 'focusedTest', node: callee });
       }
     },
   }),

--- a/src/rules/no-hooks.js
+++ b/src/rules/no-hooks.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      unexpectedHook: "Unexpected '{{ hookName }}' hook",
+    },
   },
   schema: [
     {
@@ -43,7 +46,7 @@ module.exports = {
         if (isHook(node) && !isWhitelisted(node)) {
           context.report({
             node,
-            message: "Unexpected '{{ hookName }}' hook",
+            messageId: 'unexpectedHook',
             data: { hookName: node.callee.name },
           });
         }

--- a/src/rules/no-identical-title.js
+++ b/src/rules/no-identical-title.js
@@ -17,11 +17,7 @@ const newDescribeContext = () => ({
 const handleTestCaseTitles = (context, titles, node, title) => {
   if (isTestCase(node)) {
     if (titles.indexOf(title) !== -1) {
-      context.report({
-        message:
-          'Test title is used multiple times in the same describe block.',
-        node,
-      });
+      context.report({ messageId: 'multipleTestTitle', node });
     }
     titles.push(title);
   }
@@ -32,11 +28,7 @@ const handleDescribeBlockTitles = (context, titles, node, title) => {
     return;
   }
   if (titles.indexOf(title) !== -1) {
-    context.report({
-      message:
-        'Describe block title is used multiple times in the same describe block.',
-      node,
-    });
+    context.report({ messageId: 'multipleDescribeTitle', node });
   }
   titles.push(title);
 };
@@ -55,6 +47,12 @@ module.exports = {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
+    },
+    messages: {
+      multipleTestTitle:
+        'Test title is used multiple times in the same describe block.',
+      multipleDescribeTitle:
+        'Describe block title is used multiple times in the same describe block.',
     },
   },
   create(context) {

--- a/src/rules/no-jasmine-globals.js
+++ b/src/rules/no-jasmine-globals.js
@@ -49,16 +49,10 @@ module.exports = {
               });
               break;
             case 'fail':
-              context.report({
-                node,
-                messageId: 'illegalFail',
-              });
+              context.report({ node, messageId: 'illegalFail' });
               break;
             case 'pending':
-              context.report({
-                node,
-                messageId: 'illegalPending',
-              });
+              context.report({ node, messageId: 'illegalPending' });
               break;
           }
           return;
@@ -112,10 +106,7 @@ module.exports = {
             return;
           }
 
-          context.report({
-            node,
-            messageId: 'illegalJasmine',
-          });
+          context.report({ node, messageId: 'illegalJasmine' });
         }
       },
       MemberExpression(node) {
@@ -132,15 +123,12 @@ module.exports = {
                   ];
                 },
                 node,
-                message: 'Illegal usage of jasmine global',
+                messageId: 'illegalJasmine',
               });
               return;
             }
 
-            context.report({
-              node,
-              message: 'Illegal usage of jasmine global',
-            });
+            context.report({ node, messageId: 'illegalJasmine' });
           }
         }
       },

--- a/src/rules/no-jest-import.js
+++ b/src/rules/no-jest-import.js
@@ -2,23 +2,24 @@
 
 const { getDocsUrl } = require('./util');
 
-const message = `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`;
-
 module.exports = {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      unexpectedImport: `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`,
+    },
   },
   create(context) {
     return {
       'ImportDeclaration[source.value="jest"]'(node) {
-        context.report({ node, message });
+        context.report({ node, messageId: 'unexpectedImport' });
       },
       'CallExpression[callee.name="require"][arguments.0.value="jest"]'(node) {
         context.report({
           loc: node.arguments[0].loc,
-          message,
+          messageId: 'unexpectedImport',
         });
       },
     };

--- a/src/rules/no-large-snapshots.js
+++ b/src/rules/no-large-snapshots.js
@@ -13,10 +13,7 @@ const reportOnViolation = (context, node) => {
 
   if (lineCount > lineLimit) {
     context.report({
-      message:
-        lineLimit === 0
-          ? 'Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long'
-          : 'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
+      messageId: lineLimit === 0 ? 'noSnapshot' : 'tooLongSnapshots',
       data: { lineLimit, lineCount },
       node,
     });
@@ -27,6 +24,11 @@ module.exports = {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
+    },
+    messages: {
+      noSnapshot: '`{{ lineCount }}`s should begin with lowercase',
+      tooLongSnapshots:
+        'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
     },
   },
   create(context) {

--- a/src/rules/no-mocks-import.js
+++ b/src/rules/no-mocks-import.js
@@ -4,7 +4,6 @@ const { posix } = require('path');
 const { getDocsUrl } = require('./util');
 
 const mocksDirName = '__mocks__';
-const message = `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use jest.mock and import from the original module path.`;
 
 const isMockPath = path => path.split(posix.sep).includes(mocksDirName);
 
@@ -13,12 +12,15 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      noManualImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use jest.mock and import from the original module path.`,
+    },
   },
   create(context) {
     return {
       ImportDeclaration(node) {
         if (isMockPath(node.source.value)) {
-          context.report({ node, message });
+          context.report({ node, messageId: 'noManualImport' });
         }
       },
       'CallExpression[callee.name="require"]'(node) {
@@ -29,7 +31,7 @@ module.exports = {
         ) {
           context.report({
             loc: node.arguments[0].loc,
-            message,
+            messageId: 'noManualImport',
           });
         }
       },

--- a/src/rules/no-test-callback.js
+++ b/src/rules/no-test-callback.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      illegalTestCallback: 'Illegal usage of test callback',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -28,7 +31,7 @@ module.exports = {
         const [argument] = callback.params;
         context.report({
           node: argument,
-          message: 'Illegal usage of test callback',
+          messageId: 'illegalTestCallback',
           fix(fixer) {
             const sourceCode = context.getSourceCode();
             const { body } = callback;

--- a/src/rules/no-test-prefixes.js
+++ b/src/rules/no-test-prefixes.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      usePreferredName: 'Use "{{ preferredNodeName }}" instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -21,7 +24,7 @@ module.exports = {
         if (!preferredNodeName) return;
 
         context.report({
-          message: 'Use "{{ preferredNodeName }}" instead',
+          messageId: 'usePreferredName',
           node: node.callee,
           data: { preferredNodeName },
           fix(fixer) {

--- a/src/rules/no-test-return-statement.js
+++ b/src/rules/no-test-return-statement.js
@@ -2,7 +2,6 @@
 
 const { getDocsUrl, isFunction, isTestCase } = require('./util');
 
-const MESSAGE = 'Jest tests should not return a value.';
 const RETURN_STATEMENT = 'ReturnStatement';
 const BLOCK_STATEMENT = 'BlockStatement';
 
@@ -22,6 +21,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      noReturnValue: 'Jest tests should not return a value.',
+    },
   },
   create(context) {
     return {
@@ -31,10 +33,7 @@ module.exports = {
         const returnStmt = body.find(t => t.type === RETURN_STATEMENT);
         if (!returnStmt) return;
 
-        context.report({
-          message: MESSAGE,
-          node: returnStmt,
-        });
+        context.report({ messageId: 'noReturnValue', node: returnStmt });
       },
     };
   },

--- a/src/rules/no-truthy-falsy.js
+++ b/src/rules/no-truthy-falsy.js
@@ -14,6 +14,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      avoidMessage: 'Avoid {{methodName}}',
+    },
   },
   create(context) {
     return {
@@ -33,7 +36,7 @@ module.exports = {
           if (methodName === 'toBeTruthy' || methodName === 'toBeFalsy') {
             context.report({
               data: { methodName },
-              message: 'Avoid {{methodName}}',
+              messageId: 'avoidMessage',
               node: methodNode,
             });
           }

--- a/src/rules/prefer-called-with.js
+++ b/src/rules/prefer-called-with.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      preferCalledWith: 'Prefer {{name}}With(/* expected args */)',
+    },
   },
   create(context) {
     return {
@@ -18,7 +21,7 @@ module.exports = {
           if (name === 'toBeCalled' || name === 'toHaveBeenCalled') {
             context.report({
               data: { name },
-              message: 'Prefer {{name}}With(/* expected args */)',
+              messageId: 'preferCalledWith',
               node: methodNode,
             });
           }

--- a/src/rules/prefer-expect-assertions.js
+++ b/src/rules/prefer-expect-assertions.js
@@ -2,9 +2,6 @@
 
 const { getDocsUrl } = require('./util');
 
-const ruleMsg =
-  'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression';
-
 const validateArguments = expression => {
   return (
     expression.arguments &&
@@ -40,16 +37,17 @@ const isFirstLineExprStmt = functionBody => {
 };
 
 const reportMsg = (context, node) => {
-  context.report({
-    message: ruleMsg,
-    node,
-  });
+  context.report({ messageId: 'haveExpectAssertions', node });
 };
 
 module.exports = {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
+    },
+    messages: {
+      haveExpectAssertions:
+        'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression',
     },
   },
   create(context) {

--- a/src/rules/prefer-inline-snapshots.js
+++ b/src/rules/prefer-inline-snapshots.js
@@ -7,6 +7,10 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      toMatch: 'Use toMatchInlineSnapshot() instead',
+      toMatchError: 'Use toThrowErrorMatchingInlineSnapshot() instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -23,7 +27,7 @@ module.exports = {
                 ),
               ];
             },
-            message: 'Use toMatchInlineSnapshot() instead',
+            messageId: 'toMatch',
             node: node.callee.property,
           });
         } else if (propertyName === 'toThrowErrorMatchingSnapshot') {
@@ -36,7 +40,7 @@ module.exports = {
                 ),
               ];
             },
-            message: 'Use toThrowErrorMatchingInlineSnapshot() instead',
+            messageId: 'toMatchError',
             node: node.callee.property,
           });
         }

--- a/src/rules/prefer-spy-on.js
+++ b/src/rules/prefer-spy-on.js
@@ -27,6 +27,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      useJestSpyOn: 'Use jest.spyOn() instead.',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -40,7 +43,7 @@ module.exports = {
 
         context.report({
           node,
-          message: 'Use jest.spyOn() instead.',
+          messageId: 'useJestSpyOn',
           fix(fixer) {
             const leftPropQuote =
               node.left.property.type === 'Identifier' ? "'" : '';

--- a/src/rules/prefer-strict-equal.js
+++ b/src/rules/prefer-strict-equal.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      useToStrictEqual: 'Use toStrictEqual() instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -23,7 +26,7 @@ module.exports = {
             fix(fixer) {
               return [fixer.replaceText(method(node), 'toStrictEqual')];
             },
-            message: 'Use toStrictEqual() instead',
+            messageId: 'useToStrictEqual',
             node: method(node),
           });
         }

--- a/src/rules/prefer-to-be-null.js
+++ b/src/rules/prefer-to-be-null.js
@@ -17,6 +17,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      useToBeNull: 'Use toBeNull() instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -40,7 +43,7 @@ module.exports = {
                 fixer.remove(argument2(node)),
               ];
             },
-            message: 'Use toBeNull() instead',
+            messageId: 'useToBeNull',
             node: is ? method(node) : method2(node),
           });
         }

--- a/src/rules/prefer-to-be-undefined.js
+++ b/src/rules/prefer-to-be-undefined.js
@@ -17,6 +17,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      useToBeUndefined: 'Use toBeUndefined() instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -42,7 +45,7 @@ module.exports = {
                 fixer.remove(argument2(node)),
               ];
             },
-            message: 'Use toBeUndefined() instead',
+            messageId: 'useToBeUndefined',
             node: is ? method(node) : method2(node),
           });
         }

--- a/src/rules/prefer-to-contain.js
+++ b/src/rules/prefer-to-contain.js
@@ -83,6 +83,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      useToContain: 'Use toContain() instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -119,7 +122,7 @@ module.exports = {
               );
               return fixArr;
             },
-            message: 'Use toContain() instead',
+            messageId: 'useToContain',
             node: method(node),
           });
         }

--- a/src/rules/prefer-to-have-length.js
+++ b/src/rules/prefer-to-have-length.js
@@ -14,6 +14,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      useToHaveLength: 'Use toHaveLength() instead',
+    },
     fixable: 'code',
   },
   create(context) {
@@ -45,7 +48,7 @@ module.exports = {
                 fixer.replaceText(method(node), 'toHaveLength'),
               ];
             },
-            message: 'Use toHaveLength() instead',
+            messageId: 'useToHaveLength',
             node: method(node),
           });
         }

--- a/src/rules/prefer-todo.js
+++ b/src/rules/prefer-todo.js
@@ -41,38 +41,41 @@ const isTestCase = node =>
   node.type === 'CallExpression' &&
   ['it', 'test', 'it.skip', 'test.skip'].includes(getNodeName(node.callee));
 
-function create(context) {
-  return {
-    CallExpression(node) {
-      if (isTestCase(node) && isFirstArgString(node)) {
-        const combineFixers = composeFixers(node);
-
-        if (isTestBodyEmpty(node)) {
-          context.report({
-            message: 'Prefer todo test case over empty test case',
-            node,
-            fix: combineFixers(removeSecondArg, addTodo),
-          });
-        }
-
-        if (isOnlyTestTitle(node)) {
-          context.report({
-            message: 'Prefer todo test case over unimplemented test case',
-            node,
-            fix: combineFixers(addTodo),
-          });
-        }
-      }
-    },
-  };
-}
-
 module.exports = {
-  create,
   meta: {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      todoOverEmpty: 'Prefer todo test case over empty test case',
+      todoOverUnimplemented:
+        'Prefer todo test case over unimplemented test case',
+    },
     fixable: 'code',
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (isTestCase(node) && isFirstArgString(node)) {
+          const combineFixers = composeFixers(node);
+
+          if (isTestBodyEmpty(node)) {
+            context.report({
+              messageId: 'todoOverEmpty',
+              node,
+              fix: combineFixers(removeSecondArg, addTodo),
+            });
+          }
+
+          if (isOnlyTestTitle(node)) {
+            context.report({
+              messageId: 'todoOverUnimplemented',
+              node,
+              fix: combineFixers(addTodo),
+            });
+          }
+        }
+      },
+    };
   },
 };

--- a/src/rules/require-tothrow-message.js
+++ b/src/rules/require-tothrow-message.js
@@ -7,6 +7,9 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      requireRethrow: 'Add an error message to {{ propertyName }}()',
+    },
   },
   create(context) {
     return {
@@ -23,10 +26,8 @@ module.exports = {
           !argument(node)
         ) {
           context.report({
-            message: `Add an error message to {{ propertyName }}()`,
-            data: {
-              propertyName,
-            },
+            messageId: 'requireRethrow',
+            data: { propertyName },
             node: method(node),
           });
         }

--- a/src/rules/valid-describe.js
+++ b/src/rules/valid-describe.js
@@ -30,6 +30,15 @@ module.exports = {
     docs: {
       url: getDocsUrl(__filename),
     },
+    messages: {
+      nameAndCallback: 'Describe requires name and callback arguments',
+      firstArgumentMustBeName: 'First argument must be name',
+      secondArgumentMustBeFunction: 'Second argument must be function',
+      noAsyncDescribeCallback: 'No async describe callback',
+      unexpectedDescribeArgument: 'Unexpected argument(s) in describe callback',
+      unexpectedReturnInDescribe:
+        'Unexpected return statement in describe callback',
+    },
   },
   create(context) {
     return {
@@ -37,7 +46,7 @@ module.exports = {
         if (isDescribe(node)) {
           if (node.arguments.length === 0) {
             return context.report({
-              message: 'Describe requires name and callback arguments',
+              messageId: 'nameAndCallback',
               loc: node.loc,
             });
           }
@@ -46,31 +55,35 @@ module.exports = {
           const [, callbackFunction] = node.arguments;
           if (!isString(name)) {
             context.report({
-              message: 'First argument must be name',
+              messageId: 'firstArgumentMustBeName',
               loc: paramsLocation(node.arguments),
             });
           }
           if (callbackFunction === undefined) {
-            return context.report({
-              message: 'Describe requires name and callback arguments',
+            context.report({
+              messageId: 'nameAndCallback',
               loc: paramsLocation(node.arguments),
             });
+
+            return;
           }
           if (!isFunction(callbackFunction)) {
-            return context.report({
-              message: 'Second argument must be function',
+            context.report({
+              messageId: 'secondArgumentMustBeFunction',
               loc: paramsLocation(node.arguments),
             });
+
+            return;
           }
           if (isAsync(callbackFunction)) {
             context.report({
-              message: 'No async describe callback',
+              messageId: 'noAsyncDescribeCallback',
               node: callbackFunction,
             });
           }
           if (hasParams(callbackFunction)) {
             context.report({
-              message: 'Unexpected argument(s) in describe callback',
+              messageId: 'unexpectedDescribeArgument',
               loc: paramsLocation(callbackFunction.params),
             });
           }
@@ -78,7 +91,7 @@ module.exports = {
             callbackFunction.body.body.forEach(node => {
               if (node.type === 'ReturnStatement') {
                 context.report({
-                  message: 'Unexpected return statement in describe callback',
+                  messageId: 'unexpectedReturnInDescribe',
                   node,
                 });
               }

--- a/src/rules/valid-expect-in-promise.js
+++ b/src/rules/valid-expect-in-promise.js
@@ -2,9 +2,6 @@
 
 const { getDocsUrl, isFunction } = require('./util');
 
-const reportMsg =
-  'Promise should be returned to test its fulfillment or rejection';
-
 const isThenOrCatch = node => {
   return (
     node.property &&
@@ -43,7 +40,7 @@ const reportReturnRequired = (context, node) => {
       },
       start: node.parent.parent.loc.start,
     },
-    message: reportMsg,
+    messageId: 'returnPromise',
     node,
   });
 };
@@ -129,6 +126,10 @@ module.exports = {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
+    },
+    messages: {
+      returnPromise:
+        'Promise should be returned to test its fulfillment or rejection',
     },
   },
   create(context) {


### PR DESCRIPTION
Fixes #201

The TypeScript util thing forces us to use `messageId` anyways, so I thought to just do it now to reduce the diff when migrating to TS