### PR TITLE
feat(to-match-snapshot): show no-large-snapshots in js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@babel/preset-env": "^7.4.4",
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
+    "babel-eslint": "^10.0.2",
     "babel-jest": "^24.8.0",
     "eslint": "^5.1.0",
     "eslint-config-prettier": "^4.1.0",

--- a/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -8,27 +8,134 @@ Array [
       "lineLimit": 0,
     },
     "messageId": "noSnapshot",
-    "node": Object {
-      "callee": Object {
-        "object": Object {
+    "node": Node {
+      "_babelType": "CallExpression",
+      "arguments": Array [],
+      "callee": Node {
+        "_babelType": "MemberExpression",
+        "computed": false,
+        "end": 33,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "object": Node {
+          "_babelType": "CallExpression",
           "arguments": Array [
-            Object {
+            Node {
+              "_babelType": "Identifier",
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 16,
+                  "line": 1,
+                },
+                "identifierName": "something",
+                "start": Position {
+                  "column": 7,
+                  "line": 1,
+                },
+              },
               "name": "something",
+              "range": Array [
+                7,
+                16,
+              ],
+              "start": 7,
               "type": "Identifier",
             },
           ],
-          "callee": Object {
+          "callee": Node {
+            "_babelType": "Identifier",
+            "end": 6,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 6,
+                "line": 1,
+              },
+              "identifierName": "expect",
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
             "name": "expect",
+            "range": Array [
+              0,
+              6,
+            ],
+            "start": 0,
             "type": "Identifier",
           },
+          "end": 17,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 17,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            17,
+          ],
+          "start": 0,
           "type": "CallExpression",
         },
-        "property": Object {
+        "property": Node {
+          "_babelType": "Identifier",
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "identifierName": "toMatchSnapshot",
+            "start": Position {
+              "column": 18,
+              "line": 1,
+            },
+          },
           "name": "toMatchSnapshot",
+          "range": Array [
+            18,
+            33,
+          ],
+          "start": 18,
           "type": "Identifier",
         },
+        "range": Array [
+          0,
+          33,
+        ],
+        "start": 0,
         "type": "MemberExpression",
       },
+      "end": 35,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        35,
+      ],
+      "start": 0,
       "type": "CallExpression",
     },
   },
@@ -43,27 +150,134 @@ Array [
       "lineLimit": 70,
     },
     "messageId": "tooLongSnapshots",
-    "node": Object {
-      "callee": Object {
-        "object": Object {
+    "node": Node {
+      "_babelType": "CallExpression",
+      "arguments": Array [],
+      "callee": Node {
+        "_babelType": "MemberExpression",
+        "computed": false,
+        "end": 33,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "object": Node {
+          "_babelType": "CallExpression",
           "arguments": Array [
-            Object {
+            Node {
+              "_babelType": "Identifier",
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 16,
+                  "line": 1,
+                },
+                "identifierName": "something",
+                "start": Position {
+                  "column": 7,
+                  "line": 1,
+                },
+              },
               "name": "something",
+              "range": Array [
+                7,
+                16,
+              ],
+              "start": 7,
               "type": "Identifier",
             },
           ],
-          "callee": Object {
+          "callee": Node {
+            "_babelType": "Identifier",
+            "end": 6,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 6,
+                "line": 1,
+              },
+              "identifierName": "expect",
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
             "name": "expect",
+            "range": Array [
+              0,
+              6,
+            ],
+            "start": 0,
             "type": "Identifier",
           },
+          "end": 17,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 17,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            17,
+          ],
+          "start": 0,
           "type": "CallExpression",
         },
-        "property": Object {
+        "property": Node {
+          "_babelType": "Identifier",
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "identifierName": "toMatchSnapshot",
+            "start": Position {
+              "column": 18,
+              "line": 1,
+            },
+          },
           "name": "toMatchSnapshot",
+          "range": Array [
+            18,
+            33,
+          ],
+          "start": 18,
           "type": "Identifier",
         },
+        "range": Array [
+          0,
+          33,
+        ],
+        "start": 0,
         "type": "MemberExpression",
       },
+      "end": 35,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        35,
+      ],
+      "start": 0,
       "type": "CallExpression",
     },
   },
@@ -78,27 +292,134 @@ Array [
       "lineLimit": 50,
     },
     "messageId": "tooLongSnapshots",
-    "node": Object {
-      "callee": Object {
-        "object": Object {
+    "node": Node {
+      "_babelType": "CallExpression",
+      "arguments": Array [],
+      "callee": Node {
+        "_babelType": "MemberExpression",
+        "computed": false,
+        "end": 33,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "object": Node {
+          "_babelType": "CallExpression",
           "arguments": Array [
-            Object {
+            Node {
+              "_babelType": "Identifier",
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 16,
+                  "line": 1,
+                },
+                "identifierName": "something",
+                "start": Position {
+                  "column": 7,
+                  "line": 1,
+                },
+              },
               "name": "something",
+              "range": Array [
+                7,
+                16,
+              ],
+              "start": 7,
               "type": "Identifier",
             },
           ],
-          "callee": Object {
+          "callee": Node {
+            "_babelType": "Identifier",
+            "end": 6,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 6,
+                "line": 1,
+              },
+              "identifierName": "expect",
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
             "name": "expect",
+            "range": Array [
+              0,
+              6,
+            ],
+            "start": 0,
             "type": "Identifier",
           },
+          "end": 17,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 17,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            17,
+          ],
+          "start": 0,
           "type": "CallExpression",
         },
-        "property": Object {
+        "property": Node {
+          "_babelType": "Identifier",
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "identifierName": "toMatchSnapshot",
+            "start": Position {
+              "column": 18,
+              "line": 1,
+            },
+          },
           "name": "toMatchSnapshot",
+          "range": Array [
+            18,
+            33,
+          ],
+          "start": 18,
           "type": "Identifier",
         },
+        "range": Array [
+          0,
+          33,
+        ],
+        "start": 0,
         "type": "MemberExpression",
       },
+      "end": 35,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        35,
+      ],
+      "start": 0,
       "type": "CallExpression",
     },
   },
@@ -114,27 +435,134 @@ Array [
         "lineLimit": 50,
       },
       "messageId": "tooLongSnapshots",
-      "node": Object {
-        "callee": Object {
-          "object": Object {
+      "node": Node {
+        "_babelType": "CallExpression",
+        "arguments": Array [],
+        "callee": Node {
+          "_babelType": "MemberExpression",
+          "computed": false,
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "object": Node {
+            "_babelType": "CallExpression",
             "arguments": Array [
-              Object {
+              Node {
+                "_babelType": "Identifier",
+                "end": 16,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "identifierName": "something",
+                  "start": Position {
+                    "column": 7,
+                    "line": 1,
+                  },
+                },
                 "name": "something",
+                "range": Array [
+                  7,
+                  16,
+                ],
+                "start": 7,
                 "type": "Identifier",
               },
             ],
-            "callee": Object {
+            "callee": Node {
+              "_babelType": "Identifier",
+              "end": 6,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 6,
+                  "line": 1,
+                },
+                "identifierName": "expect",
+                "start": Position {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
               "name": "expect",
+              "range": Array [
+                0,
+                6,
+              ],
+              "start": 0,
               "type": "Identifier",
             },
+            "end": 17,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              0,
+              17,
+            ],
+            "start": 0,
             "type": "CallExpression",
           },
-          "property": Object {
+          "property": Node {
+            "_babelType": "Identifier",
+            "end": 33,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 1,
+              },
+              "identifierName": "toMatchSnapshot",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+              },
+            },
             "name": "toMatchSnapshot",
+            "range": Array [
+              18,
+              33,
+            ],
+            "start": 18,
             "type": "Identifier",
           },
+          "range": Array [
+            0,
+            33,
+          ],
+          "start": 0,
           "type": "MemberExpression",
         },
+        "end": 35,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          35,
+        ],
+        "start": 0,
         "type": "CallExpression",
       },
     },
@@ -146,27 +574,134 @@ Array [
         "lineLimit": 50,
       },
       "messageId": "tooLongSnapshots",
-      "node": Object {
-        "callee": Object {
-          "object": Object {
+      "node": Node {
+        "_babelType": "CallExpression",
+        "arguments": Array [],
+        "callee": Node {
+          "_babelType": "MemberExpression",
+          "computed": false,
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "object": Node {
+            "_babelType": "CallExpression",
             "arguments": Array [
-              Object {
+              Node {
+                "_babelType": "Identifier",
+                "end": 16,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "identifierName": "something",
+                  "start": Position {
+                    "column": 7,
+                    "line": 1,
+                  },
+                },
                 "name": "something",
+                "range": Array [
+                  7,
+                  16,
+                ],
+                "start": 7,
                 "type": "Identifier",
               },
             ],
-            "callee": Object {
+            "callee": Node {
+              "_babelType": "Identifier",
+              "end": 6,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 6,
+                  "line": 1,
+                },
+                "identifierName": "expect",
+                "start": Position {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
               "name": "expect",
+              "range": Array [
+                0,
+                6,
+              ],
+              "start": 0,
               "type": "Identifier",
             },
+            "end": 17,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              0,
+              17,
+            ],
+            "start": 0,
             "type": "CallExpression",
           },
-          "property": Object {
+          "property": Node {
+            "_babelType": "Identifier",
+            "end": 33,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 1,
+              },
+              "identifierName": "toMatchSnapshot",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+              },
+            },
             "name": "toMatchSnapshot",
+            "range": Array [
+              18,
+              33,
+            ],
+            "start": 18,
             "type": "Identifier",
           },
+          "range": Array [
+            0,
+            33,
+          ],
+          "start": 0,
           "type": "MemberExpression",
         },
+        "end": 35,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          35,
+        ],
+        "start": 0,
         "type": "CallExpression",
       },
     },
@@ -182,27 +717,134 @@ Array [
       "lineLimit": 50,
     },
     "messageId": "tooLongSnapshots",
-    "node": Object {
-      "callee": Object {
-        "object": Object {
+    "node": Node {
+      "_babelType": "CallExpression",
+      "arguments": Array [],
+      "callee": Node {
+        "_babelType": "MemberExpression",
+        "computed": false,
+        "end": 33,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "object": Node {
+          "_babelType": "CallExpression",
           "arguments": Array [
-            Object {
+            Node {
+              "_babelType": "Identifier",
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 16,
+                  "line": 1,
+                },
+                "identifierName": "something",
+                "start": Position {
+                  "column": 7,
+                  "line": 1,
+                },
+              },
               "name": "something",
+              "range": Array [
+                7,
+                16,
+              ],
+              "start": 7,
               "type": "Identifier",
             },
           ],
-          "callee": Object {
+          "callee": Node {
+            "_babelType": "Identifier",
+            "end": 6,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 6,
+                "line": 1,
+              },
+              "identifierName": "expect",
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
             "name": "expect",
+            "range": Array [
+              0,
+              6,
+            ],
+            "start": 0,
             "type": "Identifier",
           },
+          "end": 17,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 17,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            17,
+          ],
+          "start": 0,
           "type": "CallExpression",
         },
-        "property": Object {
+        "property": Node {
+          "_babelType": "Identifier",
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "identifierName": "toMatchSnapshot",
+            "start": Position {
+              "column": 18,
+              "line": 1,
+            },
+          },
           "name": "toMatchSnapshot",
+          "range": Array [
+            18,
+            33,
+          ],
+          "start": 18,
           "type": "Identifier",
         },
+        "range": Array [
+          0,
+          33,
+        ],
+        "start": 0,
         "type": "MemberExpression",
       },
+      "end": 35,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        35,
+      ],
+      "start": 0,
       "type": "CallExpression",
     },
   },

--- a/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`no-large-snapshots ExpressionStatement function should report if maxSize is zero 1`] = `
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report if maxSize is zero 1`] = `
 Array [
   Object {
     "data": Object {
@@ -9,42 +9,68 @@ Array [
     },
     "messageId": "noSnapshot",
     "node": Object {
-      "loc": Object {
-        "end": Object {
-          "line": 2,
+      "callee": Object {
+        "object": Object {
+          "arguments": Array [
+            Object {
+              "name": "something",
+              "type": "Identifier",
+            },
+          ],
+          "callee": Object {
+            "name": "expect",
+            "type": "Identifier",
+          },
+          "type": "CallExpression",
         },
-        "start": Object {
-          "line": 1,
+        "property": Object {
+          "name": "toMatchSnapshot",
+          "type": "Identifier",
         },
+        "type": "MemberExpression",
       },
+      "type": "CallExpression",
     },
   },
 ]
 `;
 
-exports[`no-large-snapshots ExpressionStatement function should report if node has more lines of code than number given in sizeThreshold option 1`] = `
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report if node has more lines of code than number given in sizeThreshold option 1`] = `
 Array [
   Object {
     "data": Object {
-      "lineCount": 83,
+      "lineCount": 108,
       "lineLimit": 70,
     },
     "messageId": "tooLongSnapshots",
     "node": Object {
-      "loc": Object {
-        "end": Object {
-          "line": 103,
+      "callee": Object {
+        "object": Object {
+          "arguments": Array [
+            Object {
+              "name": "something",
+              "type": "Identifier",
+            },
+          ],
+          "callee": Object {
+            "name": "expect",
+            "type": "Identifier",
+          },
+          "type": "CallExpression",
         },
-        "start": Object {
-          "line": 20,
+        "property": Object {
+          "name": "toMatchSnapshot",
+          "type": "Identifier",
         },
+        "type": "MemberExpression",
       },
+      "type": "CallExpression",
     },
   },
 ]
 `;
 
-exports[`no-large-snapshots ExpressionStatement function should report if node has more than 50 lines of code and no sizeThreshold option is passed 1`] = `
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report if node has more than 50 lines of code and no sizeThreshold option is passed 1`] = `
 Array [
   Object {
     "data": Object {
@@ -53,14 +79,27 @@ Array [
     },
     "messageId": "tooLongSnapshots",
     "node": Object {
-      "loc": Object {
-        "end": Object {
-          "line": 53,
+      "callee": Object {
+        "object": Object {
+          "arguments": Array [
+            Object {
+              "name": "something",
+              "type": "Identifier",
+            },
+          ],
+          "callee": Object {
+            "name": "expect",
+            "type": "Identifier",
+          },
+          "type": "CallExpression",
         },
-        "start": Object {
-          "line": 1,
+        "property": Object {
+          "name": "toMatchSnapshot",
+          "type": "Identifier",
         },
+        "type": "MemberExpression",
       },
+      "type": "CallExpression",
     },
   },
 ]

--- a/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -1411,3 +1411,145 @@ Array [
   },
 ]
 `;
+
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report on a snapshot in a describe 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "lineCount": 58,
+      "lineLimit": 50,
+    },
+    "messageId": "tooLongSnapshots",
+    "node": Node {
+      "_babelType": "CallExpression",
+      "arguments": Array [],
+      "callee": Node {
+        "_babelType": "MemberExpression",
+        "computed": false,
+        "end": 33,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 33,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "object": Node {
+          "_babelType": "CallExpression",
+          "arguments": Array [
+            Node {
+              "_babelType": "Identifier",
+              "end": 16,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 16,
+                  "line": 1,
+                },
+                "identifierName": "something",
+                "start": Position {
+                  "column": 7,
+                  "line": 1,
+                },
+              },
+              "name": "something",
+              "range": Array [
+                7,
+                16,
+              ],
+              "start": 7,
+              "type": "Identifier",
+            },
+          ],
+          "callee": Node {
+            "_babelType": "Identifier",
+            "end": 6,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 6,
+                "line": 1,
+              },
+              "identifierName": "expect",
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "name": "expect",
+            "range": Array [
+              0,
+              6,
+            ],
+            "start": 0,
+            "type": "Identifier",
+          },
+          "end": 17,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 17,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "range": Array [
+            0,
+            17,
+          ],
+          "start": 0,
+          "type": "CallExpression",
+        },
+        "property": Node {
+          "_babelType": "Identifier",
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "identifierName": "toMatchSnapshot",
+            "start": Position {
+              "column": 18,
+              "line": 1,
+            },
+          },
+          "name": "toMatchSnapshot",
+          "range": Array [
+            18,
+            33,
+          ],
+          "start": 18,
+          "type": "Identifier",
+        },
+        "range": Array [
+          0,
+          33,
+        ],
+        "start": 0,
+        "type": "MemberExpression",
+      },
+      "end": 35,
+      "loc": SourceLocation {
+        "end": Position {
+          "column": 35,
+          "line": 1,
+        },
+        "start": Position {
+          "column": 0,
+          "line": 1,
+        },
+      },
+      "range": Array [
+        0,
+        35,
+      ],
+      "start": 0,
+      "type": "CallExpression",
+    },
+  },
+]
+`;

--- a/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -426,6 +426,567 @@ Array [
 ]
 `;
 
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report on 2 snapshots in 2 seperate test cases 1`] = `
+Array [
+  Array [
+    Object {
+      "data": Object {
+        "lineCount": 58,
+        "lineLimit": 50,
+      },
+      "messageId": "tooLongSnapshots",
+      "node": Node {
+        "_babelType": "CallExpression",
+        "arguments": Array [],
+        "callee": Node {
+          "_babelType": "MemberExpression",
+          "computed": false,
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "object": Node {
+            "_babelType": "CallExpression",
+            "arguments": Array [
+              Node {
+                "_babelType": "Identifier",
+                "end": 16,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "identifierName": "something",
+                  "start": Position {
+                    "column": 7,
+                    "line": 1,
+                  },
+                },
+                "name": "something",
+                "range": Array [
+                  7,
+                  16,
+                ],
+                "start": 7,
+                "type": "Identifier",
+              },
+            ],
+            "callee": Node {
+              "_babelType": "Identifier",
+              "end": 6,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 6,
+                  "line": 1,
+                },
+                "identifierName": "expect",
+                "start": Position {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "name": "expect",
+              "range": Array [
+                0,
+                6,
+              ],
+              "start": 0,
+              "type": "Identifier",
+            },
+            "end": 17,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              0,
+              17,
+            ],
+            "start": 0,
+            "type": "CallExpression",
+          },
+          "property": Node {
+            "_babelType": "Identifier",
+            "end": 33,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 1,
+              },
+              "identifierName": "toMatchSnapshot",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+              },
+            },
+            "name": "toMatchSnapshot",
+            "range": Array [
+              18,
+              33,
+            ],
+            "start": 18,
+            "type": "Identifier",
+          },
+          "range": Array [
+            0,
+            33,
+          ],
+          "start": 0,
+          "type": "MemberExpression",
+        },
+        "end": 35,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          35,
+        ],
+        "start": 0,
+        "type": "CallExpression",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "lineCount": 58,
+        "lineLimit": 50,
+      },
+      "messageId": "tooLongSnapshots",
+      "node": Node {
+        "_babelType": "CallExpression",
+        "arguments": Array [],
+        "callee": Node {
+          "_babelType": "MemberExpression",
+          "computed": false,
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "object": Node {
+            "_babelType": "CallExpression",
+            "arguments": Array [
+              Node {
+                "_babelType": "Identifier",
+                "end": 16,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "identifierName": "something",
+                  "start": Position {
+                    "column": 7,
+                    "line": 1,
+                  },
+                },
+                "name": "something",
+                "range": Array [
+                  7,
+                  16,
+                ],
+                "start": 7,
+                "type": "Identifier",
+              },
+            ],
+            "callee": Node {
+              "_babelType": "Identifier",
+              "end": 6,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 6,
+                  "line": 1,
+                },
+                "identifierName": "expect",
+                "start": Position {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "name": "expect",
+              "range": Array [
+                0,
+                6,
+              ],
+              "start": 0,
+              "type": "Identifier",
+            },
+            "end": 17,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              0,
+              17,
+            ],
+            "start": 0,
+            "type": "CallExpression",
+          },
+          "property": Node {
+            "_babelType": "Identifier",
+            "end": 33,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 1,
+              },
+              "identifierName": "toMatchSnapshot",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+              },
+            },
+            "name": "toMatchSnapshot",
+            "range": Array [
+              18,
+              33,
+            ],
+            "start": 18,
+            "type": "Identifier",
+          },
+          "range": Array [
+            0,
+            33,
+          ],
+          "start": 0,
+          "type": "MemberExpression",
+        },
+        "end": 35,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          35,
+        ],
+        "start": 0,
+        "type": "CallExpression",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "lineCount": 58,
+        "lineLimit": 50,
+      },
+      "messageId": "tooLongSnapshots",
+      "node": Node {
+        "_babelType": "CallExpression",
+        "arguments": Array [],
+        "callee": Node {
+          "_babelType": "MemberExpression",
+          "computed": false,
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "object": Node {
+            "_babelType": "CallExpression",
+            "arguments": Array [
+              Node {
+                "_babelType": "Identifier",
+                "end": 16,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "identifierName": "something",
+                  "start": Position {
+                    "column": 7,
+                    "line": 1,
+                  },
+                },
+                "name": "something",
+                "range": Array [
+                  7,
+                  16,
+                ],
+                "start": 7,
+                "type": "Identifier",
+              },
+            ],
+            "callee": Node {
+              "_babelType": "Identifier",
+              "end": 6,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 6,
+                  "line": 1,
+                },
+                "identifierName": "expect",
+                "start": Position {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "name": "expect",
+              "range": Array [
+                0,
+                6,
+              ],
+              "start": 0,
+              "type": "Identifier",
+            },
+            "end": 17,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              0,
+              17,
+            ],
+            "start": 0,
+            "type": "CallExpression",
+          },
+          "property": Node {
+            "_babelType": "Identifier",
+            "end": 33,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 1,
+              },
+              "identifierName": "toMatchSnapshot",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+              },
+            },
+            "name": "toMatchSnapshot",
+            "range": Array [
+              18,
+              33,
+            ],
+            "start": 18,
+            "type": "Identifier",
+          },
+          "range": Array [
+            0,
+            33,
+          ],
+          "start": 0,
+          "type": "MemberExpression",
+        },
+        "end": 35,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          35,
+        ],
+        "start": 0,
+        "type": "CallExpression",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "lineCount": 58,
+        "lineLimit": 50,
+      },
+      "messageId": "tooLongSnapshots",
+      "node": Node {
+        "_babelType": "CallExpression",
+        "arguments": Array [],
+        "callee": Node {
+          "_babelType": "MemberExpression",
+          "computed": false,
+          "end": 33,
+          "loc": SourceLocation {
+            "end": Position {
+              "column": 33,
+              "line": 1,
+            },
+            "start": Position {
+              "column": 0,
+              "line": 1,
+            },
+          },
+          "object": Node {
+            "_babelType": "CallExpression",
+            "arguments": Array [
+              Node {
+                "_babelType": "Identifier",
+                "end": 16,
+                "loc": SourceLocation {
+                  "end": Position {
+                    "column": 16,
+                    "line": 1,
+                  },
+                  "identifierName": "something",
+                  "start": Position {
+                    "column": 7,
+                    "line": 1,
+                  },
+                },
+                "name": "something",
+                "range": Array [
+                  7,
+                  16,
+                ],
+                "start": 7,
+                "type": "Identifier",
+              },
+            ],
+            "callee": Node {
+              "_babelType": "Identifier",
+              "end": 6,
+              "loc": SourceLocation {
+                "end": Position {
+                  "column": 6,
+                  "line": 1,
+                },
+                "identifierName": "expect",
+                "start": Position {
+                  "column": 0,
+                  "line": 1,
+                },
+              },
+              "name": "expect",
+              "range": Array [
+                0,
+                6,
+              ],
+              "start": 0,
+              "type": "Identifier",
+            },
+            "end": 17,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 17,
+                "line": 1,
+              },
+              "start": Position {
+                "column": 0,
+                "line": 1,
+              },
+            },
+            "range": Array [
+              0,
+              17,
+            ],
+            "start": 0,
+            "type": "CallExpression",
+          },
+          "property": Node {
+            "_babelType": "Identifier",
+            "end": 33,
+            "loc": SourceLocation {
+              "end": Position {
+                "column": 33,
+                "line": 1,
+              },
+              "identifierName": "toMatchSnapshot",
+              "start": Position {
+                "column": 18,
+                "line": 1,
+              },
+            },
+            "name": "toMatchSnapshot",
+            "range": Array [
+              18,
+              33,
+            ],
+            "start": 18,
+            "type": "Identifier",
+          },
+          "range": Array [
+            0,
+            33,
+          ],
+          "start": 0,
+          "type": "MemberExpression",
+        },
+        "end": 35,
+        "loc": SourceLocation {
+          "end": Position {
+            "column": 35,
+            "line": 1,
+          },
+          "start": Position {
+            "column": 0,
+            "line": 1,
+          },
+        },
+        "range": Array [
+          0,
+          35,
+        ],
+        "start": 0,
+        "type": "CallExpression",
+      },
+    },
+  ],
+]
+`;
+
 exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report on 2 snapshots in the same test 1`] = `
 Array [
   Array [

--- a/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
+++ b/src/rules/__tests__/__snapshots__/no-large-snapshots.test.js.snap
@@ -104,3 +104,107 @@ Array [
   },
 ]
 `;
+
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report on 2 snapshots in the same test 1`] = `
+Array [
+  Array [
+    Object {
+      "data": Object {
+        "lineCount": 58,
+        "lineLimit": 50,
+      },
+      "messageId": "tooLongSnapshots",
+      "node": Object {
+        "callee": Object {
+          "object": Object {
+            "arguments": Array [
+              Object {
+                "name": "something",
+                "type": "Identifier",
+              },
+            ],
+            "callee": Object {
+              "name": "expect",
+              "type": "Identifier",
+            },
+            "type": "CallExpression",
+          },
+          "property": Object {
+            "name": "toMatchSnapshot",
+            "type": "Identifier",
+          },
+          "type": "MemberExpression",
+        },
+        "type": "CallExpression",
+      },
+    },
+  ],
+  Array [
+    Object {
+      "data": Object {
+        "lineCount": 58,
+        "lineLimit": 50,
+      },
+      "messageId": "tooLongSnapshots",
+      "node": Object {
+        "callee": Object {
+          "object": Object {
+            "arguments": Array [
+              Object {
+                "name": "something",
+                "type": "Identifier",
+              },
+            ],
+            "callee": Object {
+              "name": "expect",
+              "type": "Identifier",
+            },
+            "type": "CallExpression",
+          },
+          "property": Object {
+            "name": "toMatchSnapshot",
+            "type": "Identifier",
+          },
+          "type": "MemberExpression",
+        },
+        "type": "CallExpression",
+      },
+    },
+  ],
+]
+`;
+
+exports[`no-large-snapshots toMatchSnapshot expression statement and call expressions should report on 2nd snapshot in a test, but not 1st 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "lineCount": 58,
+      "lineLimit": 50,
+    },
+    "messageId": "tooLongSnapshots",
+    "node": Object {
+      "callee": Object {
+        "object": Object {
+          "arguments": Array [
+            Object {
+              "name": "something",
+              "type": "Identifier",
+            },
+          ],
+          "callee": Object {
+            "name": "expect",
+            "type": "Identifier",
+          },
+          "type": "CallExpression",
+        },
+        "property": Object {
+          "name": "toMatchSnapshot",
+          "type": "Identifier",
+        },
+        "type": "MemberExpression",
+      },
+      "type": "CallExpression",
+    },
+  },
+]
+`;

--- a/src/rules/__tests__/no-large-snapshots.test.js
+++ b/src/rules/__tests__/no-large-snapshots.test.js
@@ -282,5 +282,161 @@ describe('no-large-snapshots', () => {
 
       expect(mockReport).not.toHaveBeenCalled();
     });
+
+    it('should report on 2nd snapshot in a test, but not 1st', () => {
+      const snapshotNode1 = {
+        type: 'ExpressionStatement',
+        expression: {
+          left: {
+            property: {
+              type: 'TemplateLiteral',
+              quasis: [
+                {
+                  type: 'TemplateElement',
+                  value: {
+                    raw: 'a big component 1',
+                    cooked: 'a big component 1',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 5,
+          },
+        },
+      };
+      const snapshotNode2 = {
+        type: 'ExpressionStatement',
+        expression: {
+          left: {
+            property: {
+              type: 'TemplateLiteral',
+              quasis: [
+                {
+                  type: 'TemplateElement',
+                  value: {
+                    raw: 'a big component 2',
+                    cooked: 'a big component 2',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 59,
+          },
+        },
+      };
+
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [],
+        report: mockReport,
+      };
+
+      //2 snapshots
+      noLargeSnapshots(mockContext).ExpressionStatement(snapshotNode1);
+      noLargeSnapshots(mockContext).ExpressionStatement(snapshotNode2);
+
+      mockContext.getFilename = () => 'mock.test.js';
+      noLargeSnapshots(mockContext).CallExpression(testNode);
+
+      //2 expects
+      noLargeSnapshots(mockContext).CallExpression(expectNode);
+      noLargeSnapshots(mockContext).CallExpression(expectNode);
+
+      expect(mockReport).toHaveBeenCalledTimes(1);
+      expect(mockReport.mock.calls[0]).toMatchSnapshot();
+    });
+
+    it('should report on 2 snapshots in the same test', () => {
+      const snapshotNode1 = {
+        type: 'ExpressionStatement',
+        expression: {
+          left: {
+            property: {
+              type: 'TemplateLiteral',
+              quasis: [
+                {
+                  type: 'TemplateElement',
+                  value: {
+                    raw: 'a big component 1',
+                    cooked: 'a big component 1',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 59,
+          },
+        },
+      };
+      const snapshotNode2 = {
+        type: 'ExpressionStatement',
+        expression: {
+          left: {
+            property: {
+              type: 'TemplateLiteral',
+              quasis: [
+                {
+                  type: 'TemplateElement',
+                  value: {
+                    raw: 'a big component 2',
+                    cooked: 'a big component 2',
+                  },
+                },
+              ],
+            },
+          },
+        },
+        loc: {
+          start: {
+            line: 1,
+          },
+          end: {
+            line: 59,
+          },
+        },
+      };
+
+      const mockReport = jest.fn();
+      const mockContext = {
+        getFilename: () => 'mock-component.jsx.snap',
+        options: [],
+        report: mockReport,
+      };
+
+      //2 snapshots
+      noLargeSnapshots(mockContext).ExpressionStatement(snapshotNode1);
+      noLargeSnapshots(mockContext).ExpressionStatement(snapshotNode2);
+
+      mockContext.getFilename = () => 'mock.test.js';
+      noLargeSnapshots(mockContext).CallExpression(testNode);
+
+      //2 expects
+      noLargeSnapshots(mockContext).CallExpression(expectNode);
+      noLargeSnapshots(mockContext).CallExpression(expectNode);
+
+      expect(mockReport).toHaveBeenCalledTimes(2);
+      expect(mockReport.mock.calls).toMatchSnapshot();
+    });
   });
 });

--- a/src/rules/no-large-snapshots.js
+++ b/src/rules/no-large-snapshots.js
@@ -1,8 +1,63 @@
 'use strict';
 
-const { getDocsUrl } = require('./util');
+const {
+  getDocsUrl,
+  isDescribe,
+  isTestCase,
+  getStringValue,
+} = require('./util');
 
-const reportOnViolation = (context, node) => {
+const allSnapshots = {};
+
+let titles = [];
+let snapshotCall = 0;
+
+const reportToMatchSnapshot = (context, snapshotName) => {
+  const props = ['lineCount', 'lineLimit', 'node'];
+  for (let prop of props) {
+    if (!allSnapshots[snapshotName].hasOwnProperty(prop)) {
+      return;
+    }
+  }
+  const { lineLimit, lineCount, node } = allSnapshots[snapshotName];
+
+  reportOnViolation(lineCount, lineLimit, context, node);
+
+  delete allSnapshots[snapshotName];
+};
+
+const captureSnapshot = (context, node) => {
+  const { lineCount, lineLimit } = getSnapshotStats(context, node);
+
+  if (node.expression && node.expression.left) {
+    const snapshotName = getStringValue(node.expression.left.property);
+
+    allSnapshots[snapshotName] = allSnapshots[snapshotName] || {};
+    allSnapshots[snapshotName].lineCount = lineCount;
+    allSnapshots[snapshotName].lineLimit = lineLimit;
+
+    reportToMatchSnapshot(context, snapshotName);
+  }
+};
+const reportOnViolation = (lineCount, lineLimit, context, node) => {
+  if (lineCount > lineLimit) {
+    context.report({
+      messageId: lineLimit === 0 ? 'noSnapshot' : 'tooLongSnapshots',
+      data: { lineLimit, lineCount },
+      node,
+    });
+  }
+};
+const captureToMatchSnapshot = (context, node) => {
+  const snapshotName = `${titles.join(' ')} ${++snapshotCall}`; //getSnapshotName(context, node);
+
+  allSnapshots[snapshotName] = allSnapshots[snapshotName] || {};
+  allSnapshots[snapshotName].node = node;
+
+  reportToMatchSnapshot(context, snapshotName);
+};
+
+const getSnapshotStats = (context, node) => {
   const lineLimit =
     context.options[0] && Number.isFinite(context.options[0].maxSize)
       ? context.options[0].maxSize
@@ -11,13 +66,12 @@ const reportOnViolation = (context, node) => {
   const endLine = node.loc.end.line;
   const lineCount = endLine - startLine;
 
-  if (lineCount > lineLimit) {
-    context.report({
-      messageId: lineLimit === 0 ? 'noSnapshot' : 'tooLongSnapshots',
-      data: { lineLimit, lineCount },
-      node,
-    });
-  }
+  return { lineCount, lineLimit };
+};
+const captureInlineSnapshot = (context, node) => {
+  const { lineCount, lineLimit } = getSnapshotStats(context, node);
+
+  reportOnViolation(lineCount, lineLimit, context, node);
 };
 
 module.exports = {
@@ -35,19 +89,32 @@ module.exports = {
     if (context.getFilename().endsWith('.snap')) {
       return {
         ExpressionStatement(node) {
-          reportOnViolation(context, node);
+          captureSnapshot(context, node);
         },
       };
     } else if (context.getFilename().endsWith('.js')) {
       return {
         CallExpression(node) {
-          const propertyName =
-            node.callee.property && node.callee.property.name;
-          if (
-            propertyName === 'toMatchInlineSnapshot' ||
-            propertyName === 'toThrowErrorMatchingInlineSnapshot'
-          ) {
-            reportOnViolation(context, node);
+          if (isTestCase(node) || isDescribe(node)) {
+            const [firstArgument] = node.arguments;
+            titles.push(getStringValue(firstArgument));
+          } else {
+            const propertyName =
+              node.callee.property && node.callee.property.name;
+            if (
+              propertyName === 'toMatchInlineSnapshot' ||
+              propertyName === 'toThrowErrorMatchingInlineSnapshot'
+            ) {
+              captureInlineSnapshot(context, node);
+            } else if (propertyName === 'toMatchSnapshot') {
+              captureToMatchSnapshot(context, node);
+            }
+          }
+        },
+        'CallExpression:exit'(node) {
+          if (isDescribe(node) || isTestCase(node)) {
+            titles.pop();
+            snapshotCall = 0;
           }
         },
       };


### PR DESCRIPTION

BREAKING CHANGE: this change will no longer report errors in the snap file, but instead report them on `.toMatchSnapshot()` calls instead.

Currently, when the `no-large-snapshots` rule runs, it highlights the problem in the .snap file.  The problem is you can't use `eslint-disable-next-line` in those files as they are generated and will get wiped out whenever `-u` is used.  This PR instead match the snapshot with the `toMatchSnapshot()` call thus allowing eslint-disable-next-line.  This is very useful for teams like ours which have a large number of large snapshots that we need to set to disable, while still blocking new large snapshots going forward.

The change here will still parse the snap files, but will keep track of them and align them with the test that is calling toMatchSnapshot.