### PR TITLE
fix: add missing schemas so rule config is properly validated

### DIFF
--- a/src/rules/lowercase-name.js
+++ b/src/rules/lowercase-name.js
@@ -55,6 +55,21 @@ module.exports = {
     messages: {
       unexpectedLowercase: '`{{ method }}`s should begin with lowercase',
     },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignore: {
+            type: 'array',
+            items: {
+              enum: ['describe', 'test', 'it'],
+            },
+            additionalItems: false,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     fixable: 'code',
   },
   create(context) {

--- a/src/rules/no-alias-methods.js
+++ b/src/rules/no-alias-methods.js
@@ -11,6 +11,7 @@ module.exports = {
       replaceAlias: `Replace {{ replace }}() with its canonical name of {{ canonical }}()`,
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     // The Jest methods which have aliases. The canonical name is the first

--- a/src/rules/no-commented-out-tests.js
+++ b/src/rules/no-commented-out-tests.js
@@ -16,6 +16,7 @@ module.exports = {
     messages: {
       commentedTests: 'Some tests seem to be commented',
     },
+    schema: [],
   },
   create(context) {
     const sourceCode = context.getSourceCode();

--- a/src/rules/no-disabled-tests.js
+++ b/src/rules/no-disabled-tests.js
@@ -17,6 +17,7 @@ module.exports = {
       disabledSuite: 'Disabled test suite',
       disabledTest: 'Disabled test',
     },
+    schema: [],
   },
   create(context) {
     let suiteDepth = 0;

--- a/src/rules/no-empty-title.js
+++ b/src/rules/no-empty-title.js
@@ -19,6 +19,7 @@ module.exports = {
       describe: 'describe should not have an empty title',
       test: 'test should not have an empty title',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-focused-tests.js
+++ b/src/rules/no-focused-tests.js
@@ -27,6 +27,7 @@ module.exports = {
     messages: {
       focusedTest: 'Unexpected focused test.',
     },
+    schema: [],
   },
   create: context => ({
     CallExpression(node) {

--- a/src/rules/no-identical-title.js
+++ b/src/rules/no-identical-title.js
@@ -54,6 +54,7 @@ module.exports = {
       multipleDescribeTitle:
         'Describe block title is used multiple times in the same describe block.',
     },
+    schema: [],
   },
   create(context) {
     const contexts = [newDescribeContext()];

--- a/src/rules/no-jasmine-globals.js
+++ b/src/rules/no-jasmine-globals.js
@@ -19,6 +19,7 @@ module.exports = {
         'Illegal usage of `pending`, prefer explicitly skipping a test using `test.skip`',
       illegalJasmine: 'Illegal usage of jasmine global',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-jest-import.js
+++ b/src/rules/no-jest-import.js
@@ -10,6 +10,7 @@ module.exports = {
     messages: {
       unexpectedImport: `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`,
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-large-snapshots.js
+++ b/src/rules/no-large-snapshots.js
@@ -30,6 +30,17 @@ module.exports = {
       tooLongSnapshots:
         'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
     },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          maxSize: {
+            type: 'number',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   create(context) {
     if (context.getFilename().endsWith('.snap')) {

--- a/src/rules/no-mocks-import.js
+++ b/src/rules/no-mocks-import.js
@@ -15,6 +15,7 @@ module.exports = {
     messages: {
       noManualImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use jest.mock and import from the original module path.`,
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-test-callback.js
+++ b/src/rules/no-test-callback.js
@@ -11,6 +11,7 @@ module.exports = {
       illegalTestCallback: 'Illegal usage of test callback',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-test-prefixes.js
+++ b/src/rules/no-test-prefixes.js
@@ -11,6 +11,7 @@ module.exports = {
       usePreferredName: 'Use "{{ preferredNodeName }}" instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-test-return-statement.js
+++ b/src/rules/no-test-return-statement.js
@@ -24,6 +24,7 @@ module.exports = {
     messages: {
       noReturnValue: 'Jest tests should not return a value.',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/no-truthy-falsy.js
+++ b/src/rules/no-truthy-falsy.js
@@ -17,6 +17,7 @@ module.exports = {
     messages: {
       avoidMessage: 'Avoid {{methodName}}',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-called-with.js
+++ b/src/rules/prefer-called-with.js
@@ -10,6 +10,7 @@ module.exports = {
     messages: {
       preferCalledWith: 'Prefer {{name}}With(/* expected args */)',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-expect-assertions.js
+++ b/src/rules/prefer-expect-assertions.js
@@ -49,6 +49,7 @@ module.exports = {
       haveExpectAssertions:
         'Every test should have either `expect.assertions(<number of assertions>)` or `expect.hasAssertions()` as its first expression',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-inline-snapshots.js
+++ b/src/rules/prefer-inline-snapshots.js
@@ -12,6 +12,7 @@ module.exports = {
       toMatchError: 'Use toThrowErrorMatchingInlineSnapshot() instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-spy-on.js
+++ b/src/rules/prefer-spy-on.js
@@ -31,6 +31,7 @@ module.exports = {
       useJestSpyOn: 'Use jest.spyOn() instead.',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-strict-equal.js
+++ b/src/rules/prefer-strict-equal.js
@@ -11,6 +11,7 @@ module.exports = {
       useToStrictEqual: 'Use toStrictEqual() instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-to-be-null.js
+++ b/src/rules/prefer-to-be-null.js
@@ -21,6 +21,7 @@ module.exports = {
       useToBeNull: 'Use toBeNull() instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-to-be-undefined.js
+++ b/src/rules/prefer-to-be-undefined.js
@@ -21,6 +21,7 @@ module.exports = {
       useToBeUndefined: 'Use toBeUndefined() instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-to-contain.js
+++ b/src/rules/prefer-to-contain.js
@@ -87,6 +87,7 @@ module.exports = {
       useToContain: 'Use toContain() instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-to-have-length.js
+++ b/src/rules/prefer-to-have-length.js
@@ -18,6 +18,7 @@ module.exports = {
       useToHaveLength: 'Use toHaveLength() instead',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/prefer-todo.js
+++ b/src/rules/prefer-todo.js
@@ -52,6 +52,7 @@ module.exports = {
         'Prefer todo test case over unimplemented test case',
     },
     fixable: 'code',
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/require-tothrow-message.js
+++ b/src/rules/require-tothrow-message.js
@@ -10,6 +10,7 @@ module.exports = {
     messages: {
       requireRethrow: 'Add an error message to {{ propertyName }}()',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/valid-describe.js
+++ b/src/rules/valid-describe.js
@@ -39,6 +39,7 @@ module.exports = {
       unexpectedReturnInDescribe:
         'Unexpected return statement in describe callback',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/valid-expect-in-promise.js
+++ b/src/rules/valid-expect-in-promise.js
@@ -131,6 +131,7 @@ module.exports = {
       returnPromise:
         'Promise should be returned to test its fulfillment or rejection',
     },
+    schema: [],
   },
   create(context) {
     return {

--- a/src/rules/valid-expect.js
+++ b/src/rules/valid-expect.js
@@ -23,6 +23,7 @@ module.exports = {
       propertyWithoutMatcher: '"{{ propertyName }}" needs to call a matcher.',
       matcherOnPropertyNotCalled: '"{{ propertyName }}" was not called.',
     },
+    schema: [],
   },
   create(context) {
     return {


### PR DESCRIPTION
I noticed that two rules (`lowercase-name` and `no-large-snapshots`) were missing schemas for their config.
This adds those schemas. Also to be explicit, I also declared all rules with no config as explicitly exposing no config by adding `schema: []`.