### PR TITLE
fix(require-tothrow-message): require throw messages on async functions

### DIFF
--- a/docs/rules/require-tothrow-message.md
+++ b/docs/rules/require-tothrow-message.md
@@ -18,6 +18,10 @@ The following patterns are considered warnings:
 expect(() => a()).toThrow();
 
 expect(() => a()).toThrowError();
+
+await expect(a()).rejects.toThrow();
+
+await expect(a()).rejects.toThrowError();
 ```
 
 The following patterns are not considered warnings:
@@ -26,4 +30,8 @@ The following patterns are not considered warnings:
 expect(() => a()).toThrow('a');
 
 expect(() => a()).toThrowError('a');
+
+await expect(a()).rejects.toThrow('a');
+
+await expect(a()).rejects.toThrowError('a');
 ```

--- a/src/rules/__tests__/require-tothrow-message.test.js
+++ b/src/rules/__tests__/require-tothrow-message.test.js
@@ -12,70 +12,50 @@ const ruleTester = new RuleTester({
 ruleTester.run('require-tothrow-message', rule, {
   valid: [
     // String
+    "expect(() => { throw new Error('a'); }).toThrow('a');",
+    "expect(() => { throw new Error('a'); }).toThrowError('a');",
     `test('string', async () => {
-        const error = new Error('a');
-        const throwErrorSync = () => { throw new Error(error) };
-        const throwErrorAsync = async () => { throw new Error(error) };
-
-        expect(() => throwErrorSync()).toThrow('a');
-        expect(() => throwErrorSync()).toThrowError('a');
-
+        const throwErrorAsync = async () => { throw new Error('a') };
         await expect(throwErrorAsync()).rejects.toThrow('a');
         await expect(throwErrorAsync()).rejects.toThrowError('a');
     })`,
 
     // Template literal
+    "const a = 'a'; expect(() => { throw new Error('a'); }).toThrow(`${a}`);",
+    "const a = 'a'; expect(() => { throw new Error('a'); }).toThrowError(`${a}`);",
     `test('Template literal', async () => {
         const a = 'a';
-
-        const error = new Error('a');
-        const throwErrorSync = () => { throw new Error(error) };
-        const throwErrorAsync = async () => { throw new Error(error) };
-
-        expect(() => throwErrorSync()).toThrow(\`\${a}\`);
-        expect(() => throwErrorSync()).toThrowError(\`\${a}\`);
-
+        const throwErrorAsync = async () => { throw new Error('a') };
         await expect(throwErrorAsync()).rejects.toThrow(\`\${a}\`);
         await expect(throwErrorAsync()).rejects.toThrowError(\`\${a}\`);
     })`,
 
     // Regex
+    "expect(() => { throw new Error('a'); }).toThrow(/^a$/);",
+    "expect(() => { throw new Error('a'); }).toThrowError(/^a$/);",
     `test('Regex', async () => {
-        const error = new Error('a');
-        const throwErrorSync = () => { throw new Error(error) };
-        const throwErrorAsync = async () => { throw new Error(error) };
-
-        expect(() => throwErrorSync()).toThrow(/^a$/);
-        expect(() => throwErrorSync()).toThrowError(/^a$/);
-
+        const throwErrorAsync = async () => { throw new Error('a') };
         await expect(throwErrorAsync()).rejects.toThrow(/^a$/);
         await expect(throwErrorAsync()).rejects.toThrowError(/^a$/);
     })`,
 
     // Function
+    "expect(() => { throw new Error('a'); })" +
+      ".toThrow((() => { return 'a'; })());",
+    "expect(() => { throw new Error('a'); })" +
+      ".toThrowError((() => { return 'a'; })());",
     `test('Function', async () => {
-        const error = new Error('a');
-        const throwErrorSync = () => { throw new Error(error) };
-        const throwErrorAsync = async () => { throw new Error(error) };
-
+        const throwErrorAsync = async () => { throw new Error('a') };
         const fn = () => { return 'a'; };
-
-        expect(() => throwErrorSync()).toThrow(fn());
-        expect(() => throwErrorSync()).toThrowError(fn());
-
         await expect(throwErrorAsync()).rejects.toThrow(fn());
         await expect(throwErrorAsync()).rejects.toThrowError(fn());
     })`,
 
     // Allow no message for `not`.
+    "expect(() => { throw new Error('a'); }).not.toThrow();",
+    "expect(() => { throw new Error('a'); }).not.toThrowError();",
     `test('Allow no message for "not"', async () => {
-        const error = new Error('a');
-        const throwErrorSync = () => { throw new Error(error) };
-        const throwErrorAsync = async () => { throw new Error(error) };
-
-        expect(() => throwErrorSync()).not.toThrow();
-        expect(() => throwErrorSync()).not.toThrowError();
-
+        const throwErrorAsync = async () => { throw new Error('a') };
         await expect(throwErrorAsync()).resolves.not.toThrow();
         await expect(throwErrorAsync()).resolves.not.toThrowError();
     })`,

--- a/src/rules/__tests__/require-tothrow-message.test.js
+++ b/src/rules/__tests__/require-tothrow-message.test.js
@@ -5,28 +5,80 @@ const rule = require('../require-tothrow-message');
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 8,
   },
 });
 
 ruleTester.run('require-tothrow-message', rule, {
   valid: [
     // String
-    "expect(() => { throw new Error('a'); }).toThrow('a');",
-    "expect(() => { throw new Error('a'); }).toThrowError('a');",
+    `test('string', async () => {
+        const error = new Error('a');
+        const throwErrorSync = () => { throw new Error(error) };
+        const throwErrorAsync = async () => { throw new Error(error) };
+
+        expect(() => throwErrorSync()).toThrow('a');
+        expect(() => throwErrorSync()).toThrowError('a');
+
+        await expect(throwErrorAsync()).rejects.toThrow('a');
+        await expect(throwErrorAsync()).rejects.toThrowError('a');
+    })`,
 
     // Template literal
-    "const a = 'a'; expect(() => { throw new Error('a'); }).toThrow(`${a}`);",
+    `test('Template literal', async () => {
+        const a = 'a';
+
+        const error = new Error('a');
+        const throwErrorSync = () => { throw new Error(error) };
+        const throwErrorAsync = async () => { throw new Error(error) };
+
+        expect(() => throwErrorSync()).toThrow(\`\${a}\`);
+        expect(() => throwErrorSync()).toThrowError(\`\${a}\`);
+
+        await expect(throwErrorAsync()).rejects.toThrow(\`\${a}\`);
+        await expect(throwErrorAsync()).rejects.toThrowError(\`\${a}\`);
+    })`,
 
     // Regex
-    "expect(() => { throw new Error('a'); }).toThrow(/^a$/);",
+    `test('Regex', async () => {
+        const error = new Error('a');
+        const throwErrorSync = () => { throw new Error(error) };
+        const throwErrorAsync = async () => { throw new Error(error) };
+
+        expect(() => throwErrorSync()).toThrow(/^a$/);
+        expect(() => throwErrorSync()).toThrowError(/^a$/);
+
+        await expect(throwErrorAsync()).rejects.toThrow(/^a$/);
+        await expect(throwErrorAsync()).rejects.toThrowError(/^a$/);
+    })`,
 
     // Function
-    "expect(() => { throw new Error('a'); })" +
-      ".toThrow((() => { return 'a'; })());",
+    `test('Function', async () => {
+        const error = new Error('a');
+        const throwErrorSync = () => { throw new Error(error) };
+        const throwErrorAsync = async () => { throw new Error(error) };
+
+        const fn = () => { return 'a'; };
+
+        expect(() => throwErrorSync()).toThrow(fn());
+        expect(() => throwErrorSync()).toThrowError(fn());
+
+        await expect(throwErrorAsync()).rejects.toThrow(fn());
+        await expect(throwErrorAsync()).rejects.toThrowError(fn());
+    })`,
 
     // Allow no message for `not`.
-    "expect(() => { throw new Error('a'); }).not.toThrow();",
+    `test('Allow no message for "not"', async () => {
+        const error = new Error('a');
+        const throwErrorSync = () => { throw new Error(error) };
+        const throwErrorAsync = async () => { throw new Error(error) };
+
+        expect(() => throwErrorSync()).not.toThrow();
+        expect(() => throwErrorSync()).not.toThrowError();
+
+        await expect(throwErrorAsync()).resolves.not.toThrow();
+        await expect(throwErrorAsync()).resolves.not.toThrowError();
+    })`,
   ],
 
   invalid: [
@@ -51,6 +103,29 @@ ruleTester.run('require-tothrow-message', rule, {
           data: { propertyName: 'toThrowError' },
           column: 41,
           line: 1,
+        },
+      ],
+    },
+
+    // Empty rejects.toThrow / rejects.toThrowError
+    {
+      code: `test('empty rejects.toThrow', async () => {
+        const throwErrorAsync = async () => { throw new Error('a') };
+        await expect(throwErrorAsync()).rejects.toThrow();
+        await expect(throwErrorAsync()).rejects.toThrowError();
+    })`,
+      errors: [
+        {
+          messageId: 'requireRethrow',
+          data: { propertyName: 'toThrow' },
+          column: 49,
+          line: 3,
+        },
+        {
+          messageId: 'requireRethrow',
+          data: { propertyName: 'toThrowError' },
+          column: 49,
+          line: 4,
         },
       ],
     },

--- a/src/rules/require-tothrow-message.js
+++ b/src/rules/require-tothrow-message.js
@@ -19,17 +19,22 @@ module.exports = {
           return;
         }
 
-        const propertyName = method(node) && method(node).name;
+        let targetNode = method(node);
+        if (targetNode.name === 'rejects') {
+          targetNode = method(node.parent);
+        }
+
+        const propertyName = method(targetNode) && method(targetNode).name;
 
         // Look for `toThrow` calls with no arguments.
         if (
           ['toThrow', 'toThrowError'].includes(propertyName) &&
-          !argument(node)
+          !argument(targetNode)
         ) {
           context.report({
             messageId: 'requireRethrow',
             data: { propertyName },
-            node: method(node),
+            node: targetNode,
           });
         }
       },


### PR DESCRIPTION
This PR fixes `require-tothrow-message` to properly require messages for async functions that use `.rejects.toThrow(Error)`.