### PR TITLE
feat(no-export): new rule for no-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ installations requiring long-term consistency.
 | [no-commented-out-tests][]   | Disallow commented out tests                                      |                  |                     |
 | [no-duplicate-hooks][]       | Disallow duplicate hooks within a `describe` block                |                  |                     |
 | [no-empty-title][]           | Disallow empty titles                                             |                  |                     |
+| [no-export][]                | Disallow export from test files                                   | ![recommended][] |                     |
 | [no-focused-tests][]         | Disallow focused tests                                            | ![recommended][] |                     |
 | [no-hooks][]                 | Disallow setup and teardown hooks                                 |                  |                     |
 | [no-identical-title][]       | Disallow identical titles                                         | ![recommended][] |                     |
@@ -163,6 +164,7 @@ https://github.com/dangreenisrael/eslint-plugin-jest-formatting
 [no-duplicate-hooks]: docs/rules/no-duplicate-hooks.md
 [no-commented-out-tests]: docs/rules/no-commented-out-tests.md
 [no-empty-title]: docs/rules/no-empty-title.md
+[no-export]: docs/rules/no-export.md
 [no-focused-tests]: docs/rules/no-focused-tests.md
 [no-hooks]: docs/rules/no-hooks.md
 [no-identical-title]: docs/rules/no-identical-title.md

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ installations requiring long-term consistency.
 | [no-commented-out-tests][]   | Disallow commented out tests                                      |                  |                     |
 | [no-duplicate-hooks][]       | Disallow duplicate hooks within a `describe` block                |                  |                     |
 | [no-empty-title][]           | Disallow empty titles                                             |                  |                     |
-| [no-export][]                | Disallow export from test files                                   | ![recommended][] |                     |
+| [no-export][]                | Disallow export from test files                                   |                  |                     |
 | [no-focused-tests][]         | Disallow focused tests                                            | ![recommended][] |                     |
 | [no-hooks][]                 | Disallow setup and teardown hooks                                 |                  |                     |
 | [no-identical-title][]       | Disallow identical titles                                         | ![recommended][] |                     |

--- a/docs/rules/no-export.md
+++ b/docs/rules/no-export.md
@@ -1,12 +1,7 @@
 # no export from test file (no-export)
 
-I ran into this issue when we had a set of helper functions in 1 test file that
-got exported directly from a `-test.js` file. The test that was importing this
-file then executes both it's own tests as well as the tests in the imported
-file. We started seeing phantom snapshots show up that we weren't able to find
-the origin of until we finally tracked it down and realized that a test file was
-exporting shared functions. We fixed this by moving those functions out into
-seperate files, but that was the inspiration of this rule.
+Prevents exports from test files. If a file has at least 1 test in it, then this
+rule will prevent exports.
 
 ## Rule Details
 

--- a/docs/rules/no-export.md
+++ b/docs/rules/no-export.md
@@ -1,0 +1,51 @@
+# no export from test file (no-export)
+
+I ran into this issue when we had a set of helper functions in 1 test file that
+got exported directly from a `-test.js` file. The test that was importing this
+file then executes both it's own tests as well as the tests in the imported
+file. We started seeing phantom snapshots show up that we weren't able to find
+the origin of until we finally tracked it down and realized that a test file was
+exporting shared functions. We fixed this by moving those functions out into
+seperate files, but that was the inspiration of this rule.
+
+## Rule Details
+
+This rule aims to eliminate duplicate runs of tests by exporting things from
+test files. If you import from a test file, then all the tests in that file will
+be run in each imported instance, so bottom line, don't export from a test, but
+instead move helper functions into a seperate file when they need to be shared
+across tests.
+
+Examples of **incorrect** code for this rule:
+
+```js
+export function myHelper() {}
+
+module.exports = function() {};
+
+module.exports = {
+  something: 'that should be moved to a non-test file',
+};
+
+describe('a test', () => {
+  expect(1).toBe(1);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+function myHelper() {}
+
+const myThing = {
+  something: 'that can live here',
+};
+
+describe('a test', () => {
+  expect(1).toBe(1);
+});
+```
+
+## When Not To Use It
+
+Don't use this rule on non-jest test files.

--- a/src/__tests__/rules.test.js
+++ b/src/__tests__/rules.test.js
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { rules } from '../';
 
 const ruleNames = Object.keys(rules);
-const numberOfRules = 34;
+const numberOfRules = 35;
 
 describe('rules', () => {
   it('should have a corresponding doc for each rule', () => {

--- a/src/rules/__tests__/no-export.test.js
+++ b/src/rules/__tests__/no-export.test.js
@@ -1,0 +1,24 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-export';
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run('no-export', rule, {
+  valid: [
+    {
+      code: 'describe("a test", () => { expect(1).toBe(1); })',
+    },
+  ],
+  invalid: [
+    {
+      code:
+        'export const myThing = "hello";  describe("a test", () => { expect(1).toBe(1);});',
+      parserOptions: { sourceType: 'module' },
+      errors: [{ endColumn: 32, column: 1, messageId: 'unexpectedExport' }],
+    },
+  ],
+});

--- a/src/rules/__tests__/no-export.test.js
+++ b/src/rules/__tests__/no-export.test.js
@@ -9,9 +9,9 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-export', rule, {
   valid: [
-    {
-      code: 'describe("a test", () => { expect(1).toBe(1); })',
-    },
+    'describe("a test", () => { expect(1).toBe(1); })',
+    'window.location = "hello"',
+    'module.somethingElse = "foo";',
   ],
   invalid: [
     {
@@ -19,6 +19,20 @@ ruleTester.run('no-export', rule, {
         'export const myThing = "hello";  describe("a test", () => { expect(1).toBe(1);});',
       parserOptions: { sourceType: 'module' },
       errors: [{ endColumn: 32, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code:
+        'export default function() {};  describe("a test", () => { expect(1).toBe(1);});',
+      parserOptions: { sourceType: 'module' },
+      errors: [{ endColumn: 29, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.exports = function() {};',
+      errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.export.thing = function() {};',
+      errors: [{ endColumn: 20, column: 1, messageId: 'unexpectedExport' }],
     },
   ],
 });

--- a/src/rules/__tests__/no-export.test.js
+++ b/src/rules/__tests__/no-export.test.js
@@ -27,6 +27,11 @@ ruleTester.run('no-export', rule, {
       errors: [{ endColumn: 29, column: 1, messageId: 'unexpectedExport' }],
     },
     {
+      code:
+        'module.exports["foo"] = function() {};  describe("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
       code: 'module.exports = function() {};',
       errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
     },

--- a/src/rules/__tests__/no-export.test.js
+++ b/src/rules/__tests__/no-export.test.js
@@ -4,40 +4,47 @@ import rule from '../no-export';
 const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2015,
+    sourceType: 'module',
   },
 });
 
 ruleTester.run('no-export', rule, {
   valid: [
     'describe("a test", () => { expect(1).toBe(1); })',
-    'window.location = "hello"',
+    'window.location = "valid"',
     'module.somethingElse = "foo";',
+    'export const myThing = "valid"',
+    'export default function () {}',
+    'module.exports = function(){}',
+    'module.exports.myThing = "valid";',
   ],
   invalid: [
     {
       code:
-        'export const myThing = "hello";  describe("a test", () => { expect(1).toBe(1);});',
+        'export const myThing = "invalid";  test("a test", () => { expect(1).toBe(1);});',
       parserOptions: { sourceType: 'module' },
-      errors: [{ endColumn: 32, column: 1, messageId: 'unexpectedExport' }],
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
     },
     {
       code:
-        'export default function() {};  describe("a test", () => { expect(1).toBe(1);});',
+        'export default function() {};  test("a test", () => { expect(1).toBe(1);});',
       parserOptions: { sourceType: 'module' },
       errors: [{ endColumn: 29, column: 1, messageId: 'unexpectedExport' }],
     },
     {
       code:
-        'module.exports["foo"] = function() {};  describe("a test", () => { expect(1).toBe(1);});',
-      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
+        'module.exports["invalid"] = function() {};  test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 26, column: 1, messageId: 'unexpectedExport' }],
     },
     {
-      code: 'module.exports = function() {};',
+      code:
+        'module.exports = function() {}; ;  test("a test", () => { expect(1).toBe(1);});',
       errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
     },
     {
-      code: 'module.export.thing = function() {};',
-      errors: [{ endColumn: 20, column: 1, messageId: 'unexpectedExport' }],
+      code:
+        'module.export.invalid = function() {}; ;  test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
     },
   ],
 });

--- a/src/rules/no-export.js
+++ b/src/rules/no-export.js
@@ -12,8 +12,19 @@ export default {
   },
   create(context) {
     return {
-      ExportNamedDeclaration(node) {
+      'ExportNamedDeclaration, ExportDefaultDeclaration'(node) {
         context.report({ node, messageId: 'unexpectedExport' });
+      },
+      'AssignmentExpression > MemberExpression'(node) {
+        let { object, property } = node;
+
+        if (object.type === 'MemberExpression') {
+          ({ object, property } = object);
+        }
+
+        if (object.name === 'module' && !!property.name.match(/^exports?$/)) {
+          context.report({ node, messageId: 'unexpectedExport' });
+        }
       },
     };
   },

--- a/src/rules/no-export.js
+++ b/src/rules/no-export.js
@@ -1,0 +1,20 @@
+import { getDocsUrl } from './util';
+
+export default {
+  meta: {
+    docs: {
+      url: getDocsUrl(__filename),
+    },
+    messages: {
+      unexpectedExport: `Do not export from a test file.`,
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      ExportNamedDeclaration(node) {
+        context.report({ node, messageId: 'unexpectedExport' });
+      },
+    };
+  },
+};

--- a/src/rules/no-export.js
+++ b/src/rules/no-export.js
@@ -1,28 +1,26 @@
 import { getDocsUrl, isTestCase } from './util';
 
-let exportNodes = [];
-let hasTestCase = false;
-const messageId = 'unexpectedExport';
 export default {
   meta: {
     docs: {
       url: getDocsUrl(__filename),
     },
     messages: {
-      [messageId]: `Do not export from a test file.`,
+      unexpectedExport: `Do not export from a test file.`,
     },
     schema: [],
   },
   create(context) {
+    const exportNodes = [];
+    let hasTestCase = false;
+
     return {
       'Program:exit'() {
         if (hasTestCase && exportNodes.length > 0) {
           for (let node of exportNodes) {
-            context.report({ node, messageId });
+            context.report({ node, messageId: 'unexpectedExport' });
           }
         }
-        exportNodes = [];
-        hasTestCase = false;
       },
 
       CallExpression(node) {
@@ -40,7 +38,7 @@ export default {
           ({ object, property } = object);
         }
 
-        if (object.name === 'module' && !!property.name.match(/^exports?$/)) {
+        if (object.name === 'module' && /^exports?$/.test(property.name)) {
           exportNodes.push(node);
         }
       },


### PR DESCRIPTION
I ran into this issue when we had a set of helper functions in 1 test file that
got exported directly from a `-test.js` file. The test that was importing this
file then executes both it's own tests as well as the tests in the imported
file. We started seeing phantom snapshots show up that we weren't able to find
the origin of until we finally tracked it down and realized that a test file was
exporting shared functions. We fixed this by moving those functions out into
seperate files, but that was the inspiration of this rule.

This rule aims to eliminate duplicate runs of tests by exporting things from
test files. If you import from a test file, then all the tests in that file will
be run in each imported instance, so bottom line, don't export from a test, but
instead move helper functions into a seperate file when they need to be shared
across tests.