### PR TITLE
ts-migration/convert-is-utils-fns

### DIFF
--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -1,5 +1,6 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../lowercase-name';
+import { DescribeAlias, TestCaseName } from '../tsUtils';
 
 const ruleTester = new TSESLint.RuleTester({
   parserOptions: {
@@ -54,7 +55,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'it' },
+          data: { method: TestCaseName.it },
           column: 1,
           line: 1,
         },
@@ -66,7 +67,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'it' },
+          data: { method: TestCaseName.it },
           column: 1,
           line: 1,
         },
@@ -78,7 +79,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'it' },
+          data: { method: TestCaseName.it },
           column: 1,
           line: 1,
         },
@@ -90,7 +91,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'test' },
+          data: { method: TestCaseName.test },
           column: 1,
           line: 1,
         },
@@ -102,7 +103,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'test' },
+          data: { method: TestCaseName.test },
           column: 1,
           line: 1,
         },
@@ -114,7 +115,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'test' },
+          data: { method: TestCaseName.test },
           column: 1,
           line: 1,
         },
@@ -126,7 +127,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'describe' },
+          data: { method: DescribeAlias.describe },
           column: 1,
           line: 1,
         },
@@ -138,7 +139,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'describe' },
+          data: { method: DescribeAlias.describe },
           column: 1,
           line: 1,
         },
@@ -150,7 +151,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'describe' },
+          data: { method: DescribeAlias.describe },
           column: 1,
           line: 1,
         },
@@ -162,7 +163,7 @@ ruleTester.run('lowercase-name', rule, {
       errors: [
         {
           messageId: 'unexpectedLowercase',
-          data: { method: 'describe' },
+          data: { method: DescribeAlias.describe },
           column: 1,
           line: 1,
         },
@@ -175,15 +176,15 @@ ruleTester.run('lowercase-name with ignore=describe', rule, {
   valid: [
     {
       code: "describe('Foo', function () {})",
-      options: [{ ignore: ['describe'] }],
+      options: [{ ignore: [DescribeAlias.describe] }],
     },
     {
       code: 'describe("Foo", function () {})',
-      options: [{ ignore: ['describe'] }],
+      options: [{ ignore: [DescribeAlias.describe] }],
     },
     {
       code: 'describe(`Foo`, function () {})',
-      options: [{ ignore: ['describe'] }],
+      options: [{ ignore: [DescribeAlias.describe] }],
     },
   ],
   invalid: [],
@@ -193,15 +194,15 @@ ruleTester.run('lowercase-name with ignore=test', rule, {
   valid: [
     {
       code: "test('Foo', function () {})",
-      options: [{ ignore: ['test'] }],
+      options: [{ ignore: [TestCaseName.test] }],
     },
     {
       code: 'test("Foo", function () {})',
-      options: [{ ignore: ['test'] }],
+      options: [{ ignore: [TestCaseName.test] }],
     },
     {
       code: 'test(`Foo`, function () {})',
-      options: [{ ignore: ['test'] }],
+      options: [{ ignore: [TestCaseName.test] }],
     },
   ],
   invalid: [],
@@ -211,15 +212,15 @@ ruleTester.run('lowercase-name with ignore=it', rule, {
   valid: [
     {
       code: "it('Foo', function () {})",
-      options: [{ ignore: ['it'] }],
+      options: [{ ignore: [TestCaseName.it] }],
     },
     {
       code: 'it("Foo", function () {})',
-      options: [{ ignore: ['it'] }],
+      options: [{ ignore: [TestCaseName.it] }],
     },
     {
       code: 'it(`Foo`, function () {})',
-      options: [{ ignore: ['it'] }],
+      options: [{ ignore: [TestCaseName.it] }],
     },
   ],
   invalid: [],

--- a/src/rules/lowercase-name.ts
+++ b/src/rules/lowercase-name.ts
@@ -2,17 +2,15 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
-import { createRule } from './tsUtils';
-
-type JestFunctionName = 'it' | 'test' | 'describe';
-
-interface JestFunctionIdentifier extends TSESTree.Identifier {
-  name: JestFunctionName;
-}
-
-interface TestFunctionCallExpression extends TSESTree.CallExpression {
-  callee: JestFunctionIdentifier;
-}
+import {
+  DescribeAlias,
+  JestFunctionCallExpression,
+  JestFunctionName,
+  TestCaseName,
+  createRule,
+  isDescribe,
+  isTestCase,
+} from './tsUtils';
 
 type ArgumentLiteral = TSESTree.Literal | TSESTree.TemplateLiteral;
 
@@ -20,22 +18,10 @@ interface FirstArgumentStringCallExpression extends TSESTree.CallExpression {
   arguments: [ArgumentLiteral];
 }
 
-type CallExpressionWithCorrectCalleeAndArguments = TestFunctionCallExpression &
+type CallExpressionWithCorrectCalleeAndArguments = JestFunctionCallExpression<
+  TestCaseName.it | TestCaseName.test | DescribeAlias.describe
+> &
   FirstArgumentStringCallExpression;
-
-const isItTestOrDescribeFunction = (
-  node: TSESTree.CallExpression,
-): node is TestFunctionCallExpression => {
-  const { callee } = node;
-
-  if (callee.type !== AST_NODE_TYPES.Identifier) {
-    return false;
-  }
-
-  const { name } = callee;
-
-  return name === 'it' || name === 'test' || name === 'describe';
-};
 
 const hasStringAsFirstArgument = (
   node: TSESTree.CallExpression,
@@ -48,7 +34,9 @@ const hasStringAsFirstArgument = (
 const isJestFunctionWithLiteralArg = (
   node: TSESTree.CallExpression,
 ): node is CallExpressionWithCorrectCalleeAndArguments =>
-  isItTestOrDescribeFunction(node) && hasStringAsFirstArgument(node);
+  (isTestCase(node) || isDescribe(node)) &&
+  ['it', 'test', 'describe'].includes(node.callee.name) &&
+  hasStringAsFirstArgument(node);
 
 const testDescription = (argument: ArgumentLiteral): string | null => {
   if (argument.type === AST_NODE_TYPES.Literal) {

--- a/src/rules/lowercase-name.ts
+++ b/src/rules/lowercase-name.ts
@@ -1,5 +1,6 @@
 import {
   AST_NODE_TYPES,
+  TSESLint,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import {
@@ -130,7 +131,7 @@ export default createRule({
               // guaranteed by jestFunctionName
               const description = testDescription(firstArg)!;
 
-              const rangeIgnoringQuotes: [number, number] = [
+              const rangeIgnoringQuotes: TSESLint.AST.Range = [
                 firstArg.range[0] + 1,
                 firstArg.range[1] - 1,
               ];

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -20,6 +20,13 @@ enum DescribeAlias {
   'xdescribe',
 }
 
+enum HookName {
+  'beforeAll',
+  'beforeEach',
+  'afterAll',
+  'afterEach',
+}
+
 export type FunctionExpression =
   | TSESTree.ArrowFunctionExpression
   | TSESTree.FunctionExpression;
@@ -27,6 +34,16 @@ export type FunctionExpression =
 export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
   node.type === AST_NODE_TYPES.FunctionExpression ||
   node.type === AST_NODE_TYPES.ArrowFunctionExpression;
+
+export const isHook = (node: TSESTree.CallExpression): boolean => {
+  return (
+    (node.callee.type === AST_NODE_TYPES.Identifier &&
+      node.callee.name in HookName) ||
+    (node.callee.type === AST_NODE_TYPES.MemberExpression &&
+      node.callee.object.type === AST_NODE_TYPES.Identifier &&
+      node.callee.object.name in HookName)
+  );
+};
 
 export const isDescribe = (node: TSESTree.CallExpression): boolean => {
   return (

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -14,13 +14,13 @@ export const createRule = ESLintUtils.RuleCreator(name => {
   return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
 });
 
-enum DescribeAlias {
+export enum DescribeAlias {
   'describe' = 'describe',
   'fdescribe' = 'fdescribe',
   'xdescribe' = 'xdescribe',
 }
 
-enum TestCaseName {
+export enum TestCaseName {
   'fit' = 'fit',
   'it' = 'it',
   'test' = 'test',
@@ -28,7 +28,7 @@ enum TestCaseName {
   'xtest' = 'xtest',
 }
 
-enum HookName {
+export enum HookName {
   'beforeAll' = 'beforeAll',
   'beforeEach' = 'beforeEach',
   'afterAll' = 'afterAll',

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -20,6 +20,14 @@ enum DescribeAlias {
   'xdescribe',
 }
 
+enum TestCaseName {
+  'fit',
+  'it',
+  'test',
+  'xit',
+  'xtest',
+}
+
 enum HookName {
   'beforeAll',
   'beforeEach',
@@ -42,6 +50,16 @@ export const isHook = (node: TSESTree.CallExpression): boolean => {
     (node.callee.type === AST_NODE_TYPES.MemberExpression &&
       node.callee.object.type === AST_NODE_TYPES.Identifier &&
       node.callee.object.name in HookName)
+  );
+};
+
+export const isTestCase = (node: TSESTree.CallExpression): boolean => {
+  return (
+    (node.callee.type === AST_NODE_TYPES.Identifier &&
+      node.callee.name in TestCaseName) ||
+    (node.callee.type === AST_NODE_TYPES.MemberExpression &&
+      node.callee.object.type === AST_NODE_TYPES.Identifier &&
+      node.callee.object.name in TestCaseName)
   );
 };
 

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -35,6 +35,19 @@ export enum HookName {
   'afterEach' = 'afterEach',
 }
 
+export type JestFunctionName = DescribeAlias | TestCaseName | HookName;
+
+interface JestFunctionIdentifier<FunctionName extends JestFunctionName>
+  extends TSESTree.Identifier {
+  name: FunctionName;
+}
+
+export interface JestFunctionCallExpression<
+  FunctionName extends JestFunctionName = JestFunctionName
+> extends TSESTree.CallExpression {
+  callee: JestFunctionIdentifier<FunctionName>;
+}
+
 export type FunctionExpression =
   | TSESTree.ArrowFunctionExpression
   | TSESTree.FunctionExpression;
@@ -43,7 +56,10 @@ export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
   node.type === AST_NODE_TYPES.FunctionExpression ||
   node.type === AST_NODE_TYPES.ArrowFunctionExpression;
 
-export const isHook = (node: TSESTree.CallExpression): boolean => {
+/* istanbul ignore next */
+export const isHook = (
+  node: TSESTree.CallExpression,
+): node is JestFunctionCallExpression<HookName> => {
   return (
     (node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name in HookName) ||
@@ -53,7 +69,10 @@ export const isHook = (node: TSESTree.CallExpression): boolean => {
   );
 };
 
-export const isTestCase = (node: TSESTree.CallExpression): boolean => {
+/* istanbul ignore next */
+export const isTestCase = (
+  node: TSESTree.CallExpression,
+): node is JestFunctionCallExpression<TestCaseName> => {
   return (
     (node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name in TestCaseName) ||
@@ -63,7 +82,9 @@ export const isTestCase = (node: TSESTree.CallExpression): boolean => {
   );
 };
 
-export const isDescribe = (node: TSESTree.CallExpression): boolean => {
+export const isDescribe = (
+  node: TSESTree.CallExpression,
+): node is JestFunctionCallExpression<DescribeAlias> => {
   return (
     (node.callee.type === AST_NODE_TYPES.Identifier &&
       node.callee.name in DescribeAlias) ||

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -15,24 +15,24 @@ export const createRule = ESLintUtils.RuleCreator(name => {
 });
 
 enum DescribeAlias {
-  'describe',
-  'fdescribe',
-  'xdescribe',
+  'describe' = 'describe',
+  'fdescribe' = 'fdescribe',
+  'xdescribe' = 'xdescribe',
 }
 
 enum TestCaseName {
-  'fit',
-  'it',
-  'test',
-  'xit',
-  'xtest',
+  'fit' = 'fit',
+  'it' = 'it',
+  'test' = 'test',
+  'xit' = 'xit',
+  'xtest' = 'xtest',
 }
 
 enum HookName {
-  'beforeAll',
-  'beforeEach',
-  'afterAll',
-  'afterEach',
+  'beforeAll' = 'beforeAll',
+  'beforeEach' = 'beforeEach',
+  'afterAll' = 'afterAll',
+  'afterEach' = 'afterEach',
 }
 
 export type FunctionExpression =

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -69,7 +69,6 @@ export const isHook = (
   );
 };
 
-/* istanbul ignore next */
 export const isTestCase = (
   node: TSESTree.CallExpression,
 ): node is JestFunctionCallExpression<TestCaseName> => {


### PR DESCRIPTION
Converts a couple of `isX` utility methods into their TS variants, so that it's easier to convert rules :)