### PR TITLE
ts-migration/improve-guards

### DIFF
--- a/src/rules/lowercase-name.ts
+++ b/src/rules/lowercase-name.ts
@@ -5,7 +5,7 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import {
   DescribeAlias,
-  JestFunctionCallExpression,
+  JestFunctionCallExpressionWithIdentifierCallee,
   JestFunctionName,
   TestCaseName,
   createRule,
@@ -19,7 +19,7 @@ interface FirstArgumentStringCallExpression extends TSESTree.CallExpression {
   arguments: [ArgumentLiteral];
 }
 
-type CallExpressionWithCorrectCalleeAndArguments = JestFunctionCallExpression<
+type CallExpressionWithCorrectCalleeAndArguments = JestFunctionCallExpressionWithIdentifierCallee<
   TestCaseName.it | TestCaseName.test | DescribeAlias.describe
 > &
   FirstArgumentStringCallExpression;
@@ -36,7 +36,7 @@ const isJestFunctionWithLiteralArg = (
   node: TSESTree.CallExpression,
 ): node is CallExpressionWithCorrectCalleeAndArguments =>
   (isTestCase(node) || isDescribe(node)) &&
-  ['it', 'test', 'describe'].includes(node.callee.name) &&
+  node.callee.type === AST_NODE_TYPES.Identifier &&
   hasStringAsFirstArgument(node);
 
 const testDescription = (argument: ArgumentLiteral): string | null => {

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -38,16 +38,42 @@ export enum HookName {
 
 export type JestFunctionName = DescribeAlias | TestCaseName | HookName;
 
-interface JestFunctionIdentifier<FunctionName extends JestFunctionName>
+export interface JestFunctionIdentifier<FunctionName extends JestFunctionName>
   extends TSESTree.Identifier {
   name: FunctionName;
 }
 
-export interface JestFunctionCallExpression<
-  FunctionName extends JestFunctionName = JestFunctionName
+export interface JestFunctionMemberExpression<
+  FunctionName extends JestFunctionName
+> extends TSESTree.MemberExpression {
+  object: JestFunctionIdentifier<FunctionName>;
+}
+
+export interface JestFunctionCallExpressionWithMemberExpressionCallee<
+  FunctionName extends JestFunctionName
+> extends TSESTree.CallExpression {
+  callee: JestFunctionMemberExpression<FunctionName>;
+}
+
+export interface JestFunctionCallExpressionWithIdentifierCallee<
+  FunctionName extends JestFunctionName
 > extends TSESTree.CallExpression {
   callee: JestFunctionIdentifier<FunctionName>;
 }
+
+export type JestFunctionCallExpression<
+  FunctionName extends JestFunctionName = JestFunctionName
+> =
+  | JestFunctionCallExpressionWithMemberExpressionCallee<FunctionName>
+  | JestFunctionCallExpressionWithIdentifierCallee<FunctionName>;
+
+export type FunctionExpression =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionExpression;
+
+export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
+  node.type === AST_NODE_TYPES.FunctionExpression ||
+  node.type === AST_NODE_TYPES.ArrowFunctionExpression;
 
 export const getNodeName = (node: TSESTree.Node): string | null => {
   function joinNames(a?: string | null, b?: string | null): string | null {
@@ -68,14 +94,6 @@ export const getNodeName = (node: TSESTree.Node): string | null => {
 
   return null;
 };
-
-export type FunctionExpression =
-  | TSESTree.ArrowFunctionExpression
-  | TSESTree.FunctionExpression;
-
-export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
-  node.type === AST_NODE_TYPES.FunctionExpression ||
-  node.type === AST_NODE_TYPES.ArrowFunctionExpression;
 
 /* istanbul ignore next */
 export const isHook = (

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -98,13 +98,10 @@ export const getNodeName = (node: TSESTree.Node): string | null => {
 /* istanbul ignore next */
 export const isHook = (
   node: TSESTree.CallExpression,
-): node is JestFunctionCallExpression<HookName> => {
+): node is JestFunctionCallExpressionWithIdentifierCallee<HookName> => {
   return (
-    (node.callee.type === AST_NODE_TYPES.Identifier &&
-      node.callee.name in HookName) ||
-    (node.callee.type === AST_NODE_TYPES.MemberExpression &&
-      node.callee.object.type === AST_NODE_TYPES.Identifier &&
-      node.callee.object.name in HookName)
+    node.callee.type === AST_NODE_TYPES.Identifier &&
+    node.callee.name in HookName
   );
 };
 

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -67,14 +67,6 @@ export type JestFunctionCallExpression<
   | JestFunctionCallExpressionWithMemberExpressionCallee<FunctionName>
   | JestFunctionCallExpressionWithIdentifierCallee<FunctionName>;
 
-export type FunctionExpression =
-  | TSESTree.ArrowFunctionExpression
-  | TSESTree.FunctionExpression;
-
-export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
-  node.type === AST_NODE_TYPES.FunctionExpression ||
-  node.type === AST_NODE_TYPES.ArrowFunctionExpression;
-
 export const getNodeName = (node: TSESTree.Node): string | null => {
   function joinNames(a?: string | null, b?: string | null): string | null {
     return a && b ? `${a}.${b}` : null;
@@ -94,6 +86,14 @@ export const getNodeName = (node: TSESTree.Node): string | null => {
 
   return null;
 };
+
+export type FunctionExpression =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionExpression;
+
+export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
+  node.type === AST_NODE_TYPES.FunctionExpression ||
+  node.type === AST_NODE_TYPES.ArrowFunctionExpression;
 
 /* istanbul ignore next */
 export const isHook = (


### PR DESCRIPTION
I didn't type the guards correctly the first time - see [this comment](https://github.com/jest-community/eslint-plugin-jest/pull/314#discussion_r305560370) for some more info.

This is something that should be looked into at some point; in JS the type guards are implemented using `getNodeName`, which'll give you the following:

```
describe(); // describe
describe.only(); // describe.only
describe.only.each('') // describe.only.each
```

This is then checked using `#has` against a `Set`, which has since become an enum.
However the original `Set` contained both functions and function chains:

```
const describeAliases = new Set([
  'describe',
  'describe.only',
  'describe.skip',
  'fdescribe',
  'xdescribe',
]);
```

I've retyped the guards so that they now match the actual runtime checks that are happening, but this means that there is a behavioural difference from the JS version that I think should be commented on.

The behavioural change is that now things like `describe.<anything>()` will be cause `isDescribe` to return true.

It's all left me a bit paranoid right now, b/c I've not got enough info to know how big of an impact this'll have on everything - so far I've not had any problems (i.e no tests have failed), but it's technically possible that it means the plugin could try and lint things it shouldn't (which wouldn't necessarily cause an error, since it'll be doing other checks) which we might care about?

This PR should definitely be merged, as it only changes the types to reflect the runtime checks.