### PR TITLE
adjust js guard behavior

### DIFF
--- a/src/rules/no-if.js
+++ b/src/rules/no-if.js
@@ -1,10 +1,9 @@
-import { getDocsUrl, getNodeName, isTestCase, testCaseNames } from './util';
+import { getDocsUrl, isTestCase } from './util';
 
 const isTestArrowFunction = node =>
   node !== undefined &&
   node.type === 'ArrowFunctionExpression' &&
-  node.parent.type === 'CallExpression' &&
-  testCaseNames.has(getNodeName(node.parent.callee));
+  isTestCase(node.parent);
 
 export default {
   meta: {

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -77,25 +77,9 @@ export const argument = node =>
 export const argument2 = node =>
   node.parent.parent.parent.arguments && node.parent.parent.parent.arguments[0];
 
-const describeAliases = new Set([
-  'describe',
-  'describe.only',
-  'describe.skip',
-  'fdescribe',
-  'xdescribe',
-]);
+const describeAliases = new Set(['describe', 'fdescribe', 'xdescribe']);
 
-export const testCaseNames = new Set([
-  'fit',
-  'it',
-  'it.only',
-  'it.skip',
-  'test',
-  'test.only',
-  'test.skip',
-  'xit',
-  'xtest',
-]);
+export const testCaseNames = new Set(['fit', 'it', 'test', 'xit', 'xtest']);
 
 const testHookNames = new Set([
   'beforeAll',
@@ -127,17 +111,25 @@ export const getNodeName = node => {
 export const isHook = node =>
   node &&
   node.type === 'CallExpression' &&
-  testHookNames.has(getNodeName(node.callee));
+  node.callee.type === 'Identifier' &&
+  testHookNames.has(node.callee.name);
 
 export const isTestCase = node =>
   node &&
   node.type === 'CallExpression' &&
-  testCaseNames.has(getNodeName(node.callee));
+  ((node.callee.type === 'Identifier' && testCaseNames.has(node.callee.name)) ||
+    (node.callee.type === 'MemberExpression' &&
+      node.callee.object.type === 'Identifier' &&
+      testCaseNames.has(node.callee.object.name)));
 
 export const isDescribe = node =>
   node &&
   node.type === 'CallExpression' &&
-  describeAliases.has(getNodeName(node.callee));
+  ((node.callee.type === 'Identifier' &&
+    describeAliases.has(node.callee.name)) ||
+    (node.callee.type === 'MemberExpression' &&
+      node.callee.object.type === 'Identifier' &&
+      describeAliases.has(node.callee.object.name)));
 
 export const isFunction = node =>
   node &&

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -79,7 +79,7 @@ export const argument2 = node =>
 
 const describeAliases = new Set(['describe', 'fdescribe', 'xdescribe']);
 
-export const testCaseNames = new Set(['fit', 'it', 'test', 'xit', 'xtest']);
+const testCaseNames = new Set(['fit', 'it', 'test', 'xit', 'xtest']);
 
 const testHookNames = new Set([
   'beforeAll',


### PR DESCRIPTION
This changes the behaviour of the js guard functions (`isHook`, `isTestCase`, and `isDescribe`) to match the TS behaviour in #316 

Currently only `CallExpression`s whose entire member chain is described in the related `Set` are considered to be "X" (where "X" is a hook, test case, or describe depending on which `is<x>` method is called).

For example, this means that `describe.only.each` isn't considered a `describe` by `isDescribe`.

This PR changes that behaviour to just the first member in the chain for if they're in the related `Set`.

Neither behaviour is strictly right or wrong, but this behavioural change currently exists in the TS branch, and so a change has to happen somewhere.

The new behaviour doesn't cause any tests to fail (aside from in `no-if`, which has been fixed), so it could be merged & released to get a scope on what the impact of this change will be.