### PR TITLE
ts-migration/no-test-callbacks

### DIFF
--- a/src/rules/__tests__/no-test-callback.test.ts
+++ b/src/rules/__tests__/no-test-callback.test.ts
@@ -1,7 +1,7 @@
-import { RuleTester } from 'eslint';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../no-test-callback';
 
-const ruleTester = new RuleTester({
+const ruleTester = new TSESLint.RuleTester({
   parserOptions: {
     ecmaVersion: 8,
   },

--- a/src/rules/no-test-callback.ts
+++ b/src/rules/no-test-callback.ts
@@ -30,16 +30,17 @@ export default createRule({
         }
 
         const [argument] = callback.params;
-        const { body } = callback;
-
-        if (!body || !('name' in argument)) {
-          return;
-        }
 
         context.report({
           node: argument,
           messageId: 'illegalTestCallback',
           fix(fixer) {
+            const { body } = callback;
+
+            if (!body) {
+              throw new Error('Unexpected null - please file a github issue');
+            }
+
             const sourceCode = context.getSourceCode();
             const firstBodyToken = sourceCode.getFirstToken(body);
             const lastBodyToken = sourceCode.getLastToken(body);
@@ -47,6 +48,7 @@ export default createRule({
             const tokenAfterArgument = sourceCode.getTokenAfter(argument);
 
             if (
+              !('name' in argument) ||
               !firstBodyToken ||
               !lastBodyToken ||
               !tokenBeforeArgument ||

--- a/src/rules/no-test-callback.ts
+++ b/src/rules/no-test-callback.ts
@@ -37,8 +37,11 @@ export default createRule({
           fix(fixer) {
             const { body } = callback;
 
+            /* istanbul ignore if */
             if (!body) {
-              throw new Error('Unexpected null - please file a github issue');
+              throw new Error(
+                `Unexpected null when attempting to fix ${context.getFilename()} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
+              );
             }
 
             const sourceCode = context.getSourceCode();
@@ -47,6 +50,7 @@ export default createRule({
             const tokenBeforeArgument = sourceCode.getTokenBefore(argument);
             const tokenAfterArgument = sourceCode.getTokenAfter(argument);
 
+            /* istanbul ignore if */
             if (
               !('name' in argument) ||
               !firstBodyToken ||
@@ -54,7 +58,9 @@ export default createRule({
               !tokenBeforeArgument ||
               !tokenAfterArgument
             ) {
-              throw new Error('Unexpected null - please file a github issue');
+              throw new Error(
+                `Unexpected null when attempting to fix ${context.getFilename()} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
+              );
             }
 
             const argumentInParens =


### PR DESCRIPTION
This is a bit of a tricky one, b/c it's got a bit of "hypothetical" nulls that I can't figure out how to reproduce in action.

As a result, coverage is currently failing, and I've stuck a "please file a github issue" throw as we could use that code to actually test those branches :joy:

We could eliminate at least one check by having `isFunction` narrow to `ArrowFunctionExpression` rather than `ArrowFunctionExpression | FunctionExpression`, as only the latter has `body` defined as being nullable (for reasons I can't figure out - anything I try either has a body or gets thrown out as a syntax error).

Personally, I think they might be typed like that for if you're constructing AST nodes? But I can't find anything solid explanation :/

The other alternative is to use `!`, but personally I'm not really a fan since it mainly means you'll just have messy errors if it ever is `null`.