### PR TITLE
feat(rules): no-snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ installations requiring long-term consistency.
 | [no-test-prefixes][]         | Disallow using `f` & `x` prefixes to define focused/skipped tests | ![recommended][] | ![fixable-green][]  |
 | [no-test-return-statement][] | Disallow explicitly returning from tests                          |                  |                     |
 | [no-truthy-falsy][]          | Disallow using `toBeTruthy()` & `toBeFalsy()`                     |                  |                     |
+| [no-snapshots][]             | Disallow snapshots                                                |                  |                     |
 | [prefer-expect-assertions][] | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
 | [prefer-spy-on][]            | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
 | [prefer-strict-equal][]      | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
@@ -177,6 +178,7 @@ https://github.com/dangreenisrael/eslint-plugin-jest-formatting
 [no-test-prefixes]: docs/rules/no-test-prefixes.md
 [no-test-return-statement]: docs/rules/no-test-return-statement.md
 [no-truthy-falsy]: docs/rules/no-truthy-falsy.md
+[no-snapshots]: docs/rules/no-snapshots.md
 [prefer-called-with]: docs/rules/prefer-called-with.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
 [prefer-spy-on]: docs/rules/prefer-spy-on.md

--- a/docs/rules/no-snapshots.md
+++ b/docs/rules/no-snapshots.md
@@ -1,0 +1,32 @@
+# Disallow snapshots (no-snapshots)
+
+Jest’s snapshot feature allows you to assert that a value has not changed from a
+stored value in a previous test. The matchers `toMatchSnapshot`,
+`toMatchInlineSnapshot`, `toThrowErrorMatchingSnapshot` and
+`toThrowErrorMatchingInlineSnapshot` will generate snapshots when used inside
+test blocks.
+
+## Rule Details
+
+Using snapshots will often result in poorly documented, difficult to debug tests
+that encourage writing a single test to cover a broad area of functionality when
+seperate, more specific tests would be preferred. This rule aims to prevent the
+use of jest snapshots.
+
+Example of **incorrect** code for this rule:
+
+```js
+expect(doWork()).toMatchSnapshot();
+```
+
+```js
+expect(doWork()).toMatchInlineSnapshot();
+```
+
+```js
+expect(doWork()).toThrowErrorMatchingSnapshot();
+```
+
+```js
+expect(doWork()).toThrowErrorMatchingInlineSnapshot();
+```

--- a/docs/rules/no-snapshots.md
+++ b/docs/rules/no-snapshots.md
@@ -8,8 +8,8 @@ test blocks.
 
 ## Rule Details
 
-Using snapshots will often result in poorly documented, difficult to debug tests
-that encourage writing a single test to cover a broad area of functionality when
+Using snapshots may result in poorly documented, difficult to debug tests that
+encourage writing a single test to cover a broad area of functionality when
 seperate, more specific tests would be preferred. This rule aims to prevent the
 use of jest snapshots.
 

--- a/src/__tests__/rules.test.js
+++ b/src/__tests__/rules.test.js
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import { rules } from '../';
 
 const ruleNames = Object.keys(rules);
-const numberOfRules = 35;
+const numberOfRules = 36;
 
 describe('rules', () => {
   it('should have a corresponding doc for each rule', () => {

--- a/src/rules/__tests__/no-snapshots.test.js
+++ b/src/rules/__tests__/no-snapshots.test.js
@@ -1,0 +1,32 @@
+import { RuleTester } from 'eslint';
+import rule from '../no-snapshots';
+
+const ruleTester = new RuleTester();
+
+const errors = [{ messageId: 'noSnapshots' }];
+
+ruleTester.run('no-snapshots', rule, {
+  valid: [
+    {
+      code: `expect(foo).toHaveProperty('foo');`,
+    },
+  ],
+  invalid: [
+    {
+      code: 'expect(foo).toMatchSnapshot();',
+      errors,
+    },
+    {
+      code: 'expect(foo).toMatchInlineSnapshot();',
+      errors,
+    },
+    {
+      code: 'expect(foo).toThrowErrorMatchingSnapshot();',
+      errors,
+    },
+    {
+      code: 'expect(foo).toThrowErrorMatchingInlineSnapshot();',
+      errors,
+    },
+  ],
+});

--- a/src/rules/__tests__/no-snapshots.test.js
+++ b/src/rules/__tests__/no-snapshots.test.js
@@ -3,30 +3,31 @@ import rule from '../no-snapshots';
 
 const ruleTester = new RuleTester();
 
-const errors = [{ messageId: 'noSnapshots' }];
-
 ruleTester.run('no-snapshots', rule, {
   valid: [
-    {
-      code: `expect(foo).toHaveProperty('foo');`,
-    },
+    `expect(foo).toHaveProperty('foo');`,
+    `expect(a)`,
+    `toMatchSnapshot();`,
+    `toMatchInlineSnapshot()`,
+    `toThrowErrorMatchingSnapshot()`,
+    `toThrowErrorMatchingInlineSnapshot()`,
   ],
   invalid: [
     {
       code: 'expect(foo).toMatchSnapshot();',
-      errors,
+      errors: [{ messageId: 'noSnapshots' }],
     },
     {
       code: 'expect(foo).toMatchInlineSnapshot();',
-      errors,
+      errors: [{ messageId: 'noSnapshots' }],
     },
     {
       code: 'expect(foo).toThrowErrorMatchingSnapshot();',
-      errors,
+      errors: [{ messageId: 'noSnapshots' }],
     },
     {
       code: 'expect(foo).toThrowErrorMatchingInlineSnapshot();',
-      errors,
+      errors: [{ messageId: 'noSnapshots' }],
     },
   ],
 });

--- a/src/rules/no-snapshots.js
+++ b/src/rules/no-snapshots.js
@@ -1,0 +1,37 @@
+import { getDocsUrl } from './util';
+
+export default {
+  meta: {
+    docs: {
+      description: 'Disallow snapshots',
+      uri: getDocsUrl(__filename),
+    },
+    messages: {
+      noSnapshots:
+        'Do not use {{method}} or related methods that generate snapshots.',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression({ callee: { property } }) {
+        if (isSnapshot(property && property.name)) {
+          context.report({
+            messageId: 'noSnapshots',
+            node: property,
+            data: { method: property.name },
+          });
+        }
+      },
+    };
+  },
+};
+
+function isSnapshot(name) {
+  return [
+    'toMatchSnapshot',
+    'toMatchInlineSnapshot',
+    'toThrowErrorMatchingSnapshot',
+    'toThrowErrorMatchingInlineSnapshot',
+  ].some(method => method === name);
+}

--- a/src/rules/no-snapshots.js
+++ b/src/rules/no-snapshots.js
@@ -8,14 +8,18 @@ export default {
     },
     messages: {
       noSnapshots:
-        'Do not use {{method}} or related methods that generate snapshots.',
+        'Do not use {{ method }} or related methods that generate snapshots.',
     },
   },
 
   create(context) {
     return {
       CallExpression({ callee: { property } }) {
-        if (isSnapshot(property && property.name)) {
+        if (!property) {
+          return;
+        }
+
+        if (isSnapshot(property.name)) {
           context.report({
             messageId: 'noSnapshots',
             node: property,
@@ -33,5 +37,5 @@ function isSnapshot(name) {
     'toMatchInlineSnapshot',
     'toThrowErrorMatchingSnapshot',
     'toThrowErrorMatchingInlineSnapshot',
-  ].some(method => method === name);
+  ].includes(name);
 }


### PR DESCRIPTION
This rule prevents all snapshots methods: `toMatchSnapshot()`, `toMatchInlineSnapshot()`, `toThrowErrorMatchingSnapshot()` and `toThrowErrorMatchingInlineSnapshot()`.

Closes https://github.com/jest-community/eslint-plugin-jest/issues/312