### PR TITLE
fix(util): identify only valid global properties

### DIFF
--- a/src/rules/__tests__/no-identical-title.test.js
+++ b/src/rules/__tests__/no-identical-title.test.js
@@ -113,6 +113,26 @@ ruleTester.run('no-identical-title', rule, {
         es6: true,
       },
     },
+    {
+      code: [
+        'const test = { content: () => "foo" }',
+        'test.content(`testing backticks with the same title`);',
+        'test.content(`testing backticks with the same title`);',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
+    {
+      code: [
+        'const describe = { content: () => "foo" }',
+        'describe.content(`testing backticks with the same title`);',
+        'describe.content(`testing backticks with the same title`);',
+      ].join('\n'),
+      env: {
+        es6: true,
+      },
+    },
   ],
 
   invalid: [

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -101,13 +101,18 @@ const describeAliases = new Set(['describe', 'fdescribe', 'xdescribe']);
 
 const testCaseNames = new Set(['fit', 'it', 'test', 'xit', 'xtest']);
 
+const describeProperties = new Set(['each', 'only', 'skip']);
+
+const testCaseProperties = new Set(['each', 'only', 'skip', 'todo']);
+
 export const isTestCase = node =>
   node &&
   node.type === 'CallExpression' &&
   ((node.callee.type === 'Identifier' && testCaseNames.has(node.callee.name)) ||
     (node.callee.type === 'MemberExpression' &&
       node.callee.object.type === 'Identifier' &&
-      testCaseNames.has(node.callee.object.name)));
+      testCaseNames.has(node.callee.object.name) &&
+      testCaseProperties.has(node.callee.property.name)));
 
 export const isDescribe = node =>
   node &&
@@ -116,7 +121,8 @@ export const isDescribe = node =>
     describeAliases.has(node.callee.name)) ||
     (node.callee.type === 'MemberExpression' &&
       node.callee.object.type === 'Identifier' &&
-      describeAliases.has(node.callee.object.name)));
+      describeAliases.has(node.callee.object.name) &&
+      describeProperties.has(node.callee.property.name)));
 
 export const isFunction = node =>
   node &&


### PR DESCRIPTION
This PR fixes #340 (well, only a part of it)

By improving the utilities `isTestCase` and `isDescribe` to return `true` only when used with valid properties (e.g. `test.skip`) in oppose to `test.foo` which is not a valid test case.