### PR TITLE
fix(tsutils): identify only valid global properties

### DIFF
--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -96,6 +96,19 @@ export enum HookName {
   'afterEach' = 'afterEach',
 }
 
+export enum DescribeProperty {
+  'each' = 'each',
+  'only' = 'only',
+  'skip' = 'skip',
+}
+
+export enum TestCaseProperty {
+  'each' = 'each',
+  'only' = 'only',
+  'skip' = 'skip',
+  'todo' = 'todo',
+}
+
 export type JestFunctionName = DescribeAlias | TestCaseName | HookName;
 
 export interface JestFunctionIdentifier<FunctionName extends JestFunctionName>
@@ -178,7 +191,9 @@ export const isTestCase = (
       TestCaseName.hasOwnProperty(node.callee.name)) ||
     (node.callee.type === AST_NODE_TYPES.MemberExpression &&
       node.callee.object.type === AST_NODE_TYPES.Identifier &&
-      TestCaseName.hasOwnProperty(node.callee.object.name))
+      TestCaseName.hasOwnProperty(node.callee.object.name) &&
+      node.callee.property.type === AST_NODE_TYPES.Identifier &&
+      TestCaseProperty.hasOwnProperty(node.callee.property.name))
   );
 };
 
@@ -190,7 +205,9 @@ export const isDescribe = (
       DescribeAlias.hasOwnProperty(node.callee.name)) ||
     (node.callee.type === AST_NODE_TYPES.MemberExpression &&
       node.callee.object.type === AST_NODE_TYPES.Identifier &&
-      DescribeAlias.hasOwnProperty(node.callee.object.name))
+      DescribeAlias.hasOwnProperty(node.callee.object.name) &&
+      node.callee.property.type === AST_NODE_TYPES.Identifier &&
+      DescribeProperty.hasOwnProperty(node.callee.property.name))
   );
 };
 

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -112,6 +112,7 @@ export const isTestCase = node =>
     (node.callee.type === 'MemberExpression' &&
       node.callee.object.type === 'Identifier' &&
       testCaseNames.has(node.callee.object.name) &&
+      node.callee.property.type === 'Identifier' &&
       testCaseProperties.has(node.callee.property.name)));
 
 export const isDescribe = node =>
@@ -122,6 +123,7 @@ export const isDescribe = node =>
     (node.callee.type === 'MemberExpression' &&
       node.callee.object.type === 'Identifier' &&
       describeAliases.has(node.callee.object.name) &&
+      node.callee.property.type === 'Identifier' &&
       describeProperties.has(node.callee.property.name)));
 
 export const isFunction = node =>


### PR DESCRIPTION
This PR fixes #340 for TypeScript as well after implementing it on #341.

The types has reminded me that I've needed to verify that the property is an identifier before accessing its name, so I've changed it as well in the js `util`.