### PR TITLE
ts-migration/no-try-expect

### DIFF
--- a/src/rules/__tests__/no-try-expect.test.ts
+++ b/src/rules/__tests__/no-try-expect.test.ts
@@ -1,11 +1,14 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../no-try-expect';
 
-const ruleTester = new TSESLint.RuleTester({
-  parserOptions: {
-    ecmaVersion: 9,
+const ruleTester = new TSESLint.RuleTester(
+  // @ts-ignore: https://github.com/typescript-eslint/typescript-eslint/pull/746
+  {
+    parserOptions: {
+      ecmaVersion: 2019,
+    },
   },
-});
+);
 
 ruleTester.run('no-try-catch', rule, {
   valid: [
@@ -17,13 +20,13 @@ ruleTester.run('no-try-catch', rule, {
     });
     try {
 
-    } catch(e) {
+    } catch {
       expect('foo').toEqual('foo');
     }`,
     `it.skip('foo');
     try {
 
-    } catch(e) {
+    } catch {
       expect('foo').toEqual('foo');
     }`,
   ],

--- a/src/rules/__tests__/no-try-expect.test.ts
+++ b/src/rules/__tests__/no-try-expect.test.ts
@@ -1,9 +1,9 @@
-import { RuleTester } from 'eslint';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../no-try-expect';
 
-const ruleTester = new RuleTester({
+const ruleTester = new TSESLint.RuleTester({
   parserOptions: {
-    ecmaVersion: 2019,
+    ecmaVersion: 9,
   },
 });
 
@@ -17,13 +17,13 @@ ruleTester.run('no-try-catch', rule, {
     });
     try {
 
-    } catch {
+    } catch(e) {
       expect('foo').toEqual('foo');
     }`,
     `it.skip('foo');
     try {
 
-    } catch {
+    } catch(e) {
       expect('foo').toEqual('foo');
     }`,
   ],

--- a/src/rules/no-try-expect.ts
+++ b/src/rules/no-try-expect.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
-import { createRule, isTestCase } from './tsUtils';
+import { createRule, isExpectCall, isTestCase } from './tsUtils';
 
 export default createRule({
   name: __filename,
@@ -25,9 +25,7 @@ export default createRule({
     let catchDepth = 0;
 
     function isThrowExpectCall(node: TSESTree.CallExpression) {
-      return (
-        catchDepth > 0 && 'name' in node.callee && node.callee.name === 'expect'
-      );
+      return catchDepth > 0 && isExpectCall(node);
     }
 
     return {

--- a/src/rules/no-try-expect.ts
+++ b/src/rules/no-try-expect.ts
@@ -1,10 +1,13 @@
-import { getDocsUrl, isTestCase } from './util';
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { createRule, isTestCase } from './tsUtils';
 
-export default {
+export default createRule({
+  name: __filename,
   meta: {
     docs: {
       description: 'Prefer using toThrow for exception tests',
-      uri: getDocsUrl(__filename),
+      category: 'Best Practices',
+      recommended: false,
     },
     messages: {
       noTryExpect: [
@@ -13,13 +16,18 @@ export default {
         'or "await expect(yourFunction()).rejects.toThrow()" for async tests',
       ].join(' '),
     },
+    type: 'problem',
+    schema: [],
   },
+  defaultOptions: [],
   create(context) {
     let isTest = false;
     let catchDepth = 0;
 
-    function isThrowExpectCall(node) {
-      return catchDepth > 0 && node.callee.name === 'expect';
+    function isThrowExpectCall(node: TSESTree.CallExpression) {
+      return (
+        catchDepth > 0 && 'name' in node.callee && node.callee.name === 'expect'
+      );
     }
 
     return {
@@ -50,4 +58,4 @@ export default {
       },
     };
   },
-};
+});

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -59,7 +59,9 @@ interface JestExpectNamespaceMemberExpression
  *
  * @return {node is JestExpectCallExpression}
  */
-const isExpectCall = (node: TSESTree.Node): node is JestExpectCallExpression =>
+export const isExpectCall = (
+  node: TSESTree.Node,
+): node is JestExpectCallExpression =>
   node.type === AST_NODE_TYPES.CallExpression &&
   isExpectIdentifier(node.callee);
 


### PR DESCRIPTION
I had to alter the tests from using `catch` w/o a parameter.

For some reason it would cause a parsing error - I don't know if that's a TS or ESlint support problem, but since it's not critical to the rule (it just changes the `CatchClause#param` property from `Identifier` to `null`), I've omitted it for now.