### PR TITLE
ts-migration/no-empty-title

### DIFF
--- a/src/rules/__tests__/no-empty-title.test.ts
+++ b/src/rules/__tests__/no-empty-title.test.ts
@@ -1,7 +1,7 @@
-import { RuleTester } from 'eslint';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../no-empty-title';
 
-const ruleTester = new RuleTester({
+const ruleTester = new TSESLint.RuleTester({
   parserOptions: {
     sourceType: 'module',
   },

--- a/src/rules/no-empty-title.ts
+++ b/src/rules/no-empty-title.ts
@@ -1,36 +1,37 @@
 import {
-  getDocsUrl,
+  createRule,
   getStringValue,
   hasExpressions,
   isDescribe,
-  isString,
+  isStringNode,
   isTemplateLiteral,
   isTestCase,
-} from './util';
+} from './tsUtils';
 
-export default {
+export default createRule({
+  name: __filename,
   meta: {
     docs: {
-      url: getDocsUrl(__filename),
+      category: 'Best Practices',
+      description: 'Disallow empty titles',
+      recommended: false,
     },
     messages: {
       describe: 'describe should not have an empty title',
       test: 'test should not have an empty title',
     },
+    type: 'suggestion',
     schema: [],
   },
+  defaultOptions: [],
   create(context) {
     return {
       CallExpression(node) {
-        const is = {
-          describe: isDescribe(node),
-          testCase: isTestCase(node),
-        };
-        if (!is.describe && !is.testCase) {
+        if (!isDescribe(node) && !isTestCase(node)) {
           return;
         }
         const [firstArgument] = node.arguments;
-        if (!isString(firstArgument)) {
+        if (!isStringNode(firstArgument)) {
           return;
         }
         if (isTemplateLiteral(firstArgument) && hasExpressions(firstArgument)) {
@@ -38,11 +39,11 @@ export default {
         }
         if (getStringValue(firstArgument) === '') {
           context.report({
-            messageId: is.describe ? 'describe' : 'test',
+            messageId: isDescribe(node) ? 'describe' : 'test',
             node,
           });
         }
       },
     };
   },
-};
+});

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -212,8 +212,15 @@ export const isTemplateLiteral = (
 ): node is TSESTree.TemplateLiteral =>
   node && node.type === AST_NODE_TYPES.TemplateLiteral;
 
-export const isStringNode = (node: TSESTree.Node): node is StringNode =>
-  isStringLiteral(node) || isTemplateLiteral(node);
+export const isStringNode = (
+  node: TSESTree.Node | undefined,
+): node is StringNode =>
+  node !== undefined && (isStringLiteral(node) || isTemplateLiteral(node));
+
+export const hasExpressions = (
+  node: TSESTree.Node,
+): node is TSESTree.Expression =>
+  'expressions' in node && node.expressions.length > 0;
 
 /* istanbul ignore next we'll need this later */
 export const getStringValue = (arg: StringNode): string =>


### PR DESCRIPTION
This PR converts the `no-empty-title` rule from JavaScript to TypeScript.