### PR TITLE
methodName: ensure method(node) returns truthy before trying to use return

### DIFF
--- a/src/rules/__tests__/prefer-to-be-null.test.js
+++ b/src/rules/__tests__/prefer-to-be-null.test.js
@@ -17,6 +17,7 @@ ruleTester.run('prefer-to-be-null', rule, {
     'expect("a string").not.toMatchSnapshot();',
     "expect(something).toEqual('a string');",
     'expect(null).toBe',
+    'expect("something");',
   ],
 
   invalid: [

--- a/src/rules/__tests__/prefer-to-be-undefined.test.js
+++ b/src/rules/__tests__/prefer-to-be-undefined.test.js
@@ -14,6 +14,7 @@ ruleTester.run('prefer-to-be-undefined', rule, {
     'expect(something).not.toBe(somethingElse)',
     'expect(something).not.toEqual(somethingElse)',
     'expect(undefined).toBe',
+    'expect("something");',
   ],
 
   invalid: [

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -89,7 +89,7 @@ export const method2 = node => node.parent.parent.property;
 
 const methodName = node => method(node) && method(node).name;
 
-const methodName2 = node => method2(node).name;
+const methodName2 = node => method2(node) && method2(node).name;
 
 export const argument = node =>
   node.parent.parent.arguments && node.parent.parent.arguments[0];

--- a/src/rules/util.js
+++ b/src/rules/util.js
@@ -87,7 +87,7 @@ export const method = node => node.parent.property;
 
 export const method2 = node => node.parent.parent.property;
 
-const methodName = node => method(node).name;
+const methodName = node => method(node) && method(node).name;
 
 const methodName2 = node => method2(node).name;
 


### PR DESCRIPTION
Fixes #357 

It's a simple quick fix, as the underlying problem is fixed by the upcoming ts conversation stuff.