### PR TITLE
chore: remove misleading changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# [22.2.0](https://github.com/jest-community/eslint-plugin-jest/compare/v22.1.3...v22.2.0) (2019-01-29)
-
-
-### Features
-
-* **rules:** add prefer-todo rule ([#218](https://github.com/jest-community/eslint-plugin-jest/issues/218)) ([0933d82](https://github.com/jest-community/eslint-plugin-jest/commit/0933d82)), closes [#217](https://github.com/jest-community/eslint-plugin-jest/issues/217)


### PR DESCRIPTION
The `CHANGELOG.md` file is outdated and serves no purpose as far as I can tell.

Up to date changelog available on the [releases page](https://github.com/jest-community/eslint-plugin-jest/releases).