### PR TITLE
ts-migration/improve-no-empty-title

### DIFF
--- a/src/rules/no-empty-title.ts
+++ b/src/rules/no-empty-title.ts
@@ -1,12 +1,4 @@
-import {
-  createRule,
-  getStringValue,
-  hasExpressions,
-  isDescribe,
-  isStringNode,
-  isTemplateLiteral,
-  isTestCase,
-} from './tsUtils';
+import { createRule, isDescribe, isStringNode, isTestCase } from './tsUtils';
 
 export default createRule({
   name: __filename,
@@ -31,18 +23,14 @@ export default createRule({
           return;
         }
         const [firstArgument] = node.arguments;
-        if (!isStringNode(firstArgument)) {
+        if (!firstArgument || !isStringNode(firstArgument, '')) {
           return;
         }
-        if (isTemplateLiteral(firstArgument) && hasExpressions(firstArgument)) {
-          return;
-        }
-        if (getStringValue(firstArgument) === '') {
-          context.report({
-            messageId: isDescribe(node) ? 'describe' : 'test',
-            node,
-          });
-        }
+
+        context.report({
+          messageId: isDescribe(node) ? 'describe' : 'test',
+          node,
+        });
       },
     };
   },

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -46,6 +46,7 @@ export default createRule({
         }
         const [firstArgument] = node.arguments;
         if (
+          !firstArgument ||
           !isStringNode(firstArgument) ||
           (isTemplateLiteral(firstArgument) && hasExpressions(firstArgument))
         ) {


### PR DESCRIPTION
I was converting `no-large-snapshots`, as that pulls in all the `getAccessorValue` & related stuff w/o needing the expect parsing, when I realised that `no-empty-title` can be easily simplified :D