### PR TITLE
Improve no identical title

### DIFF
--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -1,7 +1,6 @@
 import {
   createRule,
-  getStringValue,
-  hasExpressions,
+  getAccessorValue,
   isDescribe,
   isStringNode,
   isTemplateLiteral,
@@ -44,15 +43,15 @@ export default createRule({
         if (isDescribe(node)) {
           contexts.push(newDescribeContext());
         }
-        const [firstArgument] = node.arguments;
+        const [argument] = node.arguments;
         if (
-          !firstArgument ||
-          !isStringNode(firstArgument) ||
-          (isTemplateLiteral(firstArgument) && hasExpressions(firstArgument))
+          !argument ||
+          !isStringNode(argument) ||
+          (isTemplateLiteral(argument) && argument.expressions.length > 0)
         ) {
           return;
         }
-        const title = getStringValue(firstArgument);
+        const title = getAccessorValue(argument);
         if (isTestCase(node)) {
           if (currentLayer.testTitles.includes(title)) {
             context.report({ messageId: 'multipleTestTitle', node });

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -109,41 +109,6 @@ export const getStringValue = <S extends string>(node: StringNode<S>): S =>
   isTemplateLiteral(node) ? node.quasis[0].value.raw : node.value;
 
 /**
- * Represents a `MemberExpression` with a "known" `property`.
- */
-interface KnownMemberExpression<Name extends string = string>
-  extends TSESTree.MemberExpression {
-  property: AccessorNode<Name>;
-}
-
-/**
- * Represents a `CallExpression` with a "known" `property` accessor.
- *
- * i.e `KnownCallExpression<'includes'>` represents `.includes()`.
- */
-export interface KnownCallExpression<Name extends string = string>
-  extends TSESTree.CallExpression {
-  callee: CalledKnownMemberExpression<Name>;
-}
-
-/**
- * Represents a `MemberExpression` with a "known" `property`, that is called.
- *
- * This is `KnownCallExpression` from the perspective of the `MemberExpression` node.
- */
-export interface CalledKnownMemberExpression<Name extends string = string>
-  extends KnownMemberExpression<Name> {
-  parent: KnownCallExpression<Name>;
-}
-
-/**
- * An `Identifier` with a known `name` value - i.e `expect`.
- */
-interface KnownIdentifier<Name extends string> extends TSESTree.Identifier {
-  name: Name;
-}
-
-/**
  * Gets the value of the given `AccessorNode`,
  * account for the different node types.
  *
@@ -186,13 +151,6 @@ interface JestExpectCallExpression extends TSESTree.CallExpression {
 // represents expect usage like "expect().toBe" & "expect().not.toBe"
 interface JestExpectCallMemberExpression extends TSESTree.MemberExpression {
   object: JestExpectCallMemberExpression | JestExpectCallExpression;
-  property: TSESTree.Identifier;
-}
-
-// represents expect usage like "expect.anything" & "expect.hasAssertions"
-interface JestExpectNamespaceMemberExpression
-  extends TSESTree.MemberExpression {
-  object: JestExpectIdentifier;
   property: TSESTree.Identifier;
 }
 

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -108,6 +108,57 @@ export const isStringNode = <V extends string>(
 export const getStringValue = <S extends string>(node: StringNode<S>): S =>
   isTemplateLiteral(node) ? node.quasis[0].value.raw : node.value;
 
+/**
+ * Represents a `MemberExpression` with a "known" `property`.
+ */
+interface KnownMemberExpression<Name extends string = string>
+  extends TSESTree.MemberExpression {
+  property: AccessorNode<Name>;
+}
+
+/**
+ * Represents a `CallExpression` with a "known" `property` accessor.
+ *
+ * i.e `KnownCallExpression<'includes'>` represents `.includes()`.
+ */
+export interface KnownCallExpression<Name extends string = string>
+  extends TSESTree.CallExpression {
+  callee: CalledKnownMemberExpression<Name>;
+}
+
+/**
+ * Represents a `MemberExpression` with a "known" `property`, that is called.
+ *
+ * This is `KnownCallExpression` from the perspective of the `MemberExpression` node.
+ */
+export interface CalledKnownMemberExpression<Name extends string = string>
+  extends KnownMemberExpression<Name> {
+  parent: KnownCallExpression<Name>;
+}
+
+/**
+ * An `Identifier` with a known `name` value - i.e `expect`.
+ */
+interface KnownIdentifier<Name extends string> extends TSESTree.Identifier {
+  name: Name;
+}
+
+/**
+ * Gets the value of the given `AccessorNode`,
+ * account for the different node types.
+ *
+ * @param {AccessorNode<S>} accessor
+ *
+ * @return {S}
+ *
+ * @template S
+ */
+export const getAccessorValue = <S extends string = string>(
+  accessor: AccessorNode<S>,
+): S => getStringValue(accessor);
+
+type AccessorNode<Specifics extends string = string> = StringNode<Specifics>;
+
 interface JestExpectIdentifier extends TSESTree.Identifier {
   name: 'expect';
 }

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -315,11 +315,6 @@ export const isDescribe = (
   );
 };
 
-export const hasExpressions = (
-  node: TSESTree.Node,
-): node is TSESTree.Expression =>
-  'expressions' in node && node.expressions.length > 0;
-
 const collectReferences = (scope: TSESLint.Scope.Scope) => {
   const locals = new Set();
   const unresolved = new Set();


### PR DESCRIPTION
This is based off #374, which should be reviewed & merged first.

I had to simplify `getAccessorValue` & `AccessorNode` to not handle `Identifier` nodes, as nothing covers that yet.

Otherwise it's a direct port.