### PR TITLE
improve no-mocks-import

### DIFF
--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -306,10 +306,6 @@ export const isDescribe = (
   );
 };
 
-export const isLiteralNode = (node: {
-  type: AST_NODE_TYPES;
-}): node is TSESTree.Literal => node.type === AST_NODE_TYPES.Literal;
-
 export const hasExpressions = (
   node: TSESTree.Node,
 ): node is TSESTree.Expression =>


### PR DESCRIPTION
I can't remember what logic I used to justify `isLiteralNode` :joy:

```
export const isLiteralNode = (node: {	
  type: AST_NODE_TYPES;	
}): node is TSESTree.Literal => node.type === AST_NODE_TYPES.Literal;
```