### PR TITLE
ts-migration/no-alias-methods

### DIFF
--- a/src/rules/__tests__/no-alias-methods.test.ts
+++ b/src/rules/__tests__/no-alias-methods.test.ts
@@ -1,7 +1,7 @@
-import { RuleTester } from 'eslint';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../no-alias-methods';
 
-const ruleTester = new RuleTester();
+const ruleTester = new TSESLint.RuleTester();
 
 ruleTester.run('no-alias-methods', rule, {
   valid: [

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -336,14 +336,6 @@ export interface ParsedExpectMatcher<
   Node extends ExpectMember<Matcher> = ExpectMember<Matcher>
 > extends ParsedExpectMember<Matcher, Node> {
   arguments: TSESTree.CallExpression['arguments'] | null;
-  // isNamed<PossibleName extends Matcher>(
-  //   name: PossibleName,
-  //   ...or: PossibleName[]
-  // ): this is ParsedExpectMatcher<PossibleName>;
-  // isNamed<PossibleName extends Matcher>(
-  //   // name: PossibleName,
-  //   ...names: [PossibleName, ...PossibleName[]]
-  // ): this is ParsedExpectMatcher<PossibleName, Node>;
 }
 
 type BaseParsedModifier<
@@ -403,9 +395,6 @@ const reparseAsMatcher = (
     parsedMember.node.parent.type === AST_NODE_TYPES.CallExpression
       ? parsedMember.node.parent.arguments
       : null,
-  // isNamed(...names: string[]) {
-  //   return names.includes(this.name);
-  // },
 });
 
 /**

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -320,6 +320,185 @@ export const isExpectCallWithParent = (
   node.parent.type === AST_NODE_TYPES.MemberExpression &&
   node.parent.property.type === AST_NODE_TYPES.Identifier;
 
+interface ParsedExpectMember<
+  Name extends ExpectPropertyName = ExpectPropertyName,
+  Node extends ExpectMember<Name> = ExpectMember<Name>
+> {
+  name: Name;
+  node: Node;
+}
+
+/**
+ * Represents a parsed expect matcher, such as `toBe`, `toContain`, and so on.
+ */
+export interface ParsedExpectMatcher<
+  Matcher extends MatcherName = MatcherName,
+  Node extends ExpectMember<Matcher> = ExpectMember<Matcher>
+> extends ParsedExpectMember<Matcher, Node> {
+  arguments: TSESTree.CallExpression['arguments'] | null;
+  // isNamed<PossibleName extends Matcher>(
+  //   name: PossibleName,
+  //   ...or: PossibleName[]
+  // ): this is ParsedExpectMatcher<PossibleName>;
+  // isNamed<PossibleName extends Matcher>(
+  //   // name: PossibleName,
+  //   ...names: [PossibleName, ...PossibleName[]]
+  // ): this is ParsedExpectMatcher<PossibleName, Node>;
+}
+
+type BaseParsedModifier<
+  Modifier extends ModifierName = ModifierName
+> = ParsedExpectMember<Modifier>;
+
+type NegatableModifierName = ModifierName.rejects | ModifierName.resolves;
+type NotNegatableModifierName = ModifierName.not;
+
+/**
+ * Represents a parsed modifier that can be followed by a `not` negation modifier.
+ */
+interface NegatableParsedModifier<
+  Modifier extends NegatableModifierName = NegatableModifierName
+> extends BaseParsedModifier<Modifier> {
+  negation?: ExpectMember<ModifierName.not>;
+}
+
+/**
+ * Represents a parsed modifier that cannot be followed by a `not` negation modifier.
+ */
+export interface NotNegatableParsedModifier<
+  Modifier extends NotNegatableModifierName = NotNegatableModifierName
+> extends BaseParsedModifier<Modifier> {
+  negation?: never;
+}
+
+type ParsedExpectModifier =
+  | NotNegatableParsedModifier<NotNegatableModifierName>
+  | NegatableParsedModifier<NegatableModifierName>;
+
+interface Expectation<ExpectNode extends ExpectCall = ExpectCall> {
+  expect: ExpectNode;
+  modifier?: ParsedExpectModifier;
+  matcher?: ParsedExpectMatcher;
+}
+
+const parseExpectMember = <S extends ExpectPropertyName>(
+  expectMember: ExpectMember<S>,
+): ParsedExpectMember<S> => ({
+  name: getAccessorValue<S>(expectMember.property),
+  node: expectMember,
+});
+
+const reparseAsMatcher = (
+  parsedMember: ParsedExpectMember,
+): ParsedExpectMatcher => ({
+  ...parsedMember,
+  /**
+   * The arguments being passed to this `Matcher`, if any.
+   *
+   * If this matcher isn't called, this will be `null`.
+   */
+  arguments:
+    /* istanbul ignore next */
+    parsedMember.node.parent &&
+    parsedMember.node.parent.type === AST_NODE_TYPES.CallExpression
+      ? parsedMember.node.parent.arguments
+      : null,
+  // isNamed(...names: string[]) {
+  //   return names.includes(this.name);
+  // },
+});
+
+/**
+ * Re-parses the given `parsedMember` as a `ParsedExpectModifier`.
+ *
+ * If the given `parsedMember` does not have a `name` of a valid `Modifier`,
+ * an exception will be thrown.
+ *
+ * @param {ParsedExpectMember<ModifierName>} parsedMember
+ *
+ * @return {ParsedExpectModifier}
+ */
+const reparseMemberAsModifier = (
+  parsedMember: ParsedExpectMember<ModifierName>,
+): ParsedExpectModifier => {
+  if (isSpecificMember(parsedMember, ModifierName.not)) {
+    return parsedMember;
+  }
+
+  /* istanbul ignore if */
+  if (
+    !isSpecificMember(parsedMember, ModifierName.resolves) &&
+    !isSpecificMember(parsedMember, ModifierName.rejects)
+  ) {
+    throw new Error(
+      `modifier name must be either "${ModifierName.resolves}" or "${ModifierName.rejects}" (got "${parsedMember.name}")`,
+    ); // ts doesn't think that the ModifierName.not check is the direct inverse as the above two checks
+  } // todo: impossible at runtime, but can't be typed w/o negation support
+
+  /* istanbul ignore next */
+  const negation =
+    parsedMember.node.parent &&
+    isExpectMember(parsedMember.node.parent, ModifierName.not)
+      ? parsedMember.node.parent
+      : undefined;
+
+  return {
+    ...parsedMember,
+    negation,
+  };
+};
+
+const isSpecificMember = <Name extends ExpectPropertyName>(
+  member: ParsedExpectMember,
+  specific: Name,
+): member is ParsedExpectMember<Name> => member.name === specific;
+
+/**
+ * Checks if the given `ParsedExpectMember` should be re-parsed as an `ParsedExpectModifier`.
+ *
+ * @param {ParsedExpectMember} member
+ *
+ * @return {member is ParsedExpectMember<ModifierName>}
+ */
+const shouldBeParsedExpectModifier = (
+  member: ParsedExpectMember,
+): member is ParsedExpectMember<ModifierName> =>
+  ModifierName.hasOwnProperty(member.name);
+
+export const parseExpectCall = <ExpectNode extends ExpectCall>(
+  expect: ExpectNode,
+): Expectation<ExpectNode> => {
+  const expectation: Expectation<ExpectNode> = {
+    expect,
+  };
+
+  if (!isExpectMember(expect.parent)) {
+    return expectation;
+  }
+
+  const parsedMember = parseExpectMember(expect.parent);
+  if (!shouldBeParsedExpectModifier(parsedMember)) {
+    expectation.matcher = reparseAsMatcher(parsedMember);
+
+    return expectation;
+  }
+
+  const modifier = (expectation.modifier = reparseMemberAsModifier(
+    parsedMember,
+  ));
+
+  const memberNode =
+    ('negation' in modifier && modifier.negation) || modifier.node;
+
+  if (!memberNode.parent || !isExpectMember(memberNode.parent)) {
+    return expectation;
+  }
+
+  expectation.matcher = reparseAsMatcher(parseExpectMember(memberNode.parent));
+
+  return expectation;
+};
+
 export enum DescribeAlias {
   'describe' = 'describe',
   'fdescribe' = 'fdescribe',

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -489,8 +489,7 @@ export const parseExpectCall = <ExpectNode extends ExpectCall>(
     parsedMember,
   ));
 
-  const memberNode =
-    ('negation' in modifier && modifier.negation) || modifier.node;
+  const memberNode = modifier.negation || modifier.node;
 
   if (!memberNode.parent || !isExpectMember(memberNode.parent)) {
     return expectation;

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -430,10 +430,12 @@ const reparseMemberAsModifier = (
     !isSpecificMember(parsedMember, ModifierName.resolves) &&
     !isSpecificMember(parsedMember, ModifierName.rejects)
   ) {
+    // ts doesn't think that the ModifierName.not check is the direct inverse as the above two checks
+    // todo: impossible at runtime, but can't be typed w/o negation support
     throw new Error(
       `modifier name must be either "${ModifierName.resolves}" or "${ModifierName.rejects}" (got "${parsedMember.name}")`,
-    ); // ts doesn't think that the ModifierName.not check is the direct inverse as the above two checks
-  } // todo: impossible at runtime, but can't be typed w/o negation support
+    );
+  }
 
   /* istanbul ignore next */
   const negation =


### PR DESCRIPTION
`/* simenb ignore next it's that or radically restructure the types just to revert them in the next PR*/`