### PR TITLE
improve-prefer-strict-equal

### DIFF
--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -1,4 +1,4 @@
-import { createRule, isExpectCallWithParent } from './tsUtils';
+import { createRule, isExpectCall, parseExpectCall } from './tsUtils';
 
 export default createRule({
   name: __filename,
@@ -12,26 +12,26 @@ export default createRule({
       useToStrictEqual: 'Use toStrictEqual() instead',
     },
     fixable: 'code',
-    schema: [],
     type: 'suggestion',
+    schema: [],
   },
   defaultOptions: [],
   create(context) {
     return {
       CallExpression(node) {
-        if (!isExpectCallWithParent(node)) {
+        if (!isExpectCall(node)) {
           return;
         }
 
-        const methodNode = node.parent.property;
+        const { matcher } = parseExpectCall(node);
 
-        if (methodNode && methodNode.name === 'toEqual') {
+        if (matcher && matcher.name === 'toEqual') {
           context.report({
-            fix(fixer) {
-              return [fixer.replaceText(methodNode, 'toStrictEqual')];
-            },
+            fix: fixer => [
+              fixer.replaceText(matcher.node.property, 'toStrictEqual'),
+            ],
             messageId: 'useToStrictEqual',
-            node: methodNode,
+            node: matcher.node.property,
           });
         }
       },

--- a/src/rules/tsUtils.ts
+++ b/src/rules/tsUtils.ts
@@ -308,18 +308,6 @@ export const isExpectCall = (node: TSESTree.Node): node is ExpectCall =>
   isSupportedAccessor(node.callee, 'expect') &&
   node.parent !== undefined;
 
-interface JestExpectCallWithParent extends JestExpectCallExpression {
-  parent: JestExpectCallMemberExpression;
-}
-
-export const isExpectCallWithParent = (
-  node: TSESTree.Node,
-): node is JestExpectCallWithParent =>
-  isExpectCall(node) &&
-  node.parent !== undefined &&
-  node.parent.type === AST_NODE_TYPES.MemberExpression &&
-  node.parent.property.type === AST_NODE_TYPES.Identifier;
-
 interface ParsedExpectMember<
   Name extends ExpectPropertyName = ExpectPropertyName,
   Node extends ExpectMember<Name> = ExpectMember<Name>


### PR DESCRIPTION
chore(prefer-strict-equal): use `parseExpectCall`