### PR TITLE
fix(prefer-spy-on): do not change behavior of fixed instances

### DIFF
--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -31,7 +31,7 @@ ruleTester.run('prefer-spy-on', rule, {
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(obj, 'a'); const test = 10;",
+      output: "jest.spyOn(obj, 'a').mockImplementation(); const test = 10;",
     },
     {
       code: "Date['now'] = jest['fn']()",
@@ -41,7 +41,7 @@ ruleTester.run('prefer-spy-on', rule, {
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(Date, 'now')",
+      output: "jest.spyOn(Date, 'now').mockImplementation()",
     },
     {
       code: 'window[`${name}`] = jest[`fn`]()',
@@ -51,7 +51,7 @@ ruleTester.run('prefer-spy-on', rule, {
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: 'jest.spyOn(window, `${name}`)',
+      output: 'jest.spyOn(window, `${name}`).mockImplementation()',
     },
     {
       code: "obj['prop' + 1] = jest['fn']()",
@@ -61,7 +61,7 @@ ruleTester.run('prefer-spy-on', rule, {
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(obj, 'prop' + 1)",
+      output: "jest.spyOn(obj, 'prop' + 1).mockImplementation()",
     },
     {
       code: 'obj.one.two = jest.fn(); const test = 10;',
@@ -71,7 +71,8 @@ ruleTester.run('prefer-spy-on', rule, {
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(obj.one, 'two'); const test = 10;",
+      output:
+        "jest.spyOn(obj.one, 'two').mockImplementation(); const test = 10;",
     },
     {
       code: 'obj.a = jest.fn(() => 10)',

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -79,7 +79,7 @@ export default createRule({
             const argSource = arg && context.getSourceCode().getText(arg);
             const mockImplementation = argSource
               ? `.mockImplementation(${argSource})`
-              : '';
+              : '.mockImplementation()';
 
             return [
               fixer.insertTextBefore(left, `jest.spyOn(`),


### PR DESCRIPTION
If this is expected behavior, I'd suggest removing the autofix when `mockImplementation` is empty because it can (and did in my case) break people's code.

Fixes: #389 
