### PR TITLE
chore(utils): improve `followTypeAssertionChain` typing

### DIFF
--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -6,6 +6,7 @@ import {
 import {
   CallExpressionWithSingleArgument,
   KnownCallExpression,
+  MaybeTypeCast,
   ModifierName,
   NotNegatableParsedModifier,
   ParsedEqualityMatcherCall,
@@ -27,7 +28,7 @@ const isBooleanLiteral = (node: TSESTree.Node): node is BooleanLiteral =>
   node.type === AST_NODE_TYPES.Literal && typeof node.value === 'boolean';
 
 type ParsedBooleanEqualityMatcherCall = ParsedEqualityMatcherCall<
-  BooleanLiteral
+  MaybeTypeCast<BooleanLiteral>
 >;
 
 /**
@@ -104,7 +105,7 @@ const getNegationFixes = (
   const negationPropertyDot = findPropertyDotToken(modifier.node, sourceCode);
 
   const toContainFunc = buildToContainFuncExpectation(
-    matcher.arguments[0].value,
+    followTypeAssertionChain(matcher.arguments[0]).value,
   );
 
   /* istanbul ignore if */
@@ -218,7 +219,7 @@ export default createRule({
             }
 
             const toContainFunc = buildToContainFuncExpectation(
-              !matcher.arguments[0].value,
+              !followTypeAssertionChain(matcher.arguments[0]).value,
             );
 
             const [containArg] = includesCall.arguments;

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -33,14 +33,21 @@ interface TypeAssertionChain<
   Expression extends TSESTree.Expression = TSESTree.Expression
 > extends TSESTree.TSTypeAssertion {
   // expression: TypeAssertionChain<Expression> | Expression;
-  expression: any; // https://github.com/typescript-eslint/typescript-eslint/issues/802
+  expression: any; // todo: replace w/ above once typescript-eslint is updated to v2.0.0
 }
 
-export const followTypeAssertionChain = (
-  expression: TSESTree.Expression | TSTypeCastExpression,
-): TSESTree.Expression =>
-  expression.type === AST_NODE_TYPES.TSAsExpression ||
-  expression.type === AST_NODE_TYPES.TSTypeAssertion
+const isTypeCastExpression = <Expression extends TSESTree.Expression>(
+  node: MaybeTypeCast<Expression>,
+): node is TSTypeCastExpression<Expression> =>
+  node.type === AST_NODE_TYPES.TSAsExpression ||
+  node.type === AST_NODE_TYPES.TSTypeAssertion;
+
+export const followTypeAssertionChain = <
+  Expression extends TSESTree.Expression
+>(
+  expression: MaybeTypeCast<Expression>,
+): Expression =>
+  isTypeCastExpression(expression)
     ? followTypeAssertionChain(expression.expression)
     : expression;
 


### PR DESCRIPTION
@SimenB I figured since you liked the original code so much, you'd enjoy some more.

Totally wasn't me forgetting to update the types in `prefer-to-contain` :joy: