### PR TITLE
feat(matcher): add toStrictEqual as equality matcher

### DIFF
--- a/docs/rules/prefer-to-be-null.md
+++ b/docs/rules/prefer-to-be-null.md
@@ -5,7 +5,8 @@ asserting expections on null value.
 
 ## Rule details
 
-This rule triggers a warning if `toBe()` is used to assert a null value.
+This rule triggers a warning if `toBe()`, `isEqual()` or `toStrictEqual()` is
+used to assert a null value.
 
 ```js
 expect(null).toBe(null);
@@ -15,10 +16,14 @@ This rule is enabled by default.
 
 ### Default configuration
 
-The following pattern is considered warning:
+The following patterns are considered warnings:
 
 ```js
 expect(null).toBe(null);
+
+expect(null).isEqual(null);
+
+expect(null).toStrictEqual(null);
 ```
 
 The following pattern is not warning:

--- a/docs/rules/prefer-to-be-undefined.md
+++ b/docs/rules/prefer-to-be-undefined.md
@@ -5,7 +5,8 @@ asserting expections on undefined value.
 
 ## Rule details
 
-This rule triggers a warning if `toBe()` is used to assert a undefined value.
+This rule triggers a warning if `toBe()`, `isEqual()` or `toStrictEqual()` is
+used to assert an undefined value.
 
 ```js
 expect(undefined).toBe(undefined);
@@ -15,10 +16,14 @@ This rule is enabled by default.
 
 ### Default configuration
 
-The following pattern is considered warning:
+The following patterns are considered warnings:
 
 ```js
 expect(undefined).toBe(undefined);
+
+expect(undefined).isEqual(undefined);
+
+expect(undefined).toStrictEqual(undefined);
 ```
 
 The following pattern is not warning:

--- a/docs/rules/prefer-to-contain.md
+++ b/docs/rules/prefer-to-contain.md
@@ -5,8 +5,8 @@ asserting expectations on an array containing an object.
 
 ## Rule details
 
-This rule triggers a warning if `toBe()` or `isEqual()` is used to assert object
-inclusion in an array
+This rule triggers a warning if `toBe()`, `isEqual()` or `toStrictEqual()` is
+used to assert object inclusion in an array
 
 ```js
 expect(a.includes(b)).toBe(true);
@@ -22,26 +22,24 @@ expect(a.includes(b)).toBe(false);
 
 ### Default configuration
 
-The following patterns are considered a warning:
+The following patterns are considered warnings:
 
 ```js
 expect(a.includes(b)).toBe(true);
-```
 
-```js
 expect(a.includes(b)).not.toBe(true);
-```
 
-```js
 expect(a.includes(b)).toBe(false);
+
+expect(a.includes(b)).toEqual(true);
+
+expect(a.includes(b)).toStrictEqual(true);
 ```
 
-The following patterns are not a warning:
+The following patterns are not considered warnings:
 
 ```js
 expect(a).toContain(b);
-```
 
-```js
 expect(a).not.toContain(b);
 ```

--- a/docs/rules/prefer-to-have-length.md
+++ b/docs/rules/prefer-to-have-length.md
@@ -5,8 +5,8 @@ asserting expectations on object's length property.
 
 ## Rule details
 
-This rule triggers a warning if `toBe()` is used to assert object's length
-property.
+This rule triggers a warning if `toBe()`, `isEqual()` or `toStrictEqual()` is
+used to assert object's length property.
 
 ```js
 expect(files.length).toBe(1);

--- a/docs/rules/prefer-to-have-length.md
+++ b/docs/rules/prefer-to-have-length.md
@@ -16,10 +16,14 @@ This rule is enabled by default.
 
 ### Default configuration
 
-The following pattern is considered warning:
+The following patterns are considered warnings:
 
 ```js
 expect(files.length).toBe(1);
+
+expect(files.length).toEqual(1);
+
+expect(files.length).toStrictEqual(1);
 ```
 
 The following pattern is not warning:

--- a/src/rules/__tests__/prefer-to-be-null.test.ts
+++ b/src/rules/__tests__/prefer-to-be-null.test.ts
@@ -32,12 +32,22 @@ ruleTester.run('prefer-to-be-null', rule, {
       output: 'expect(null).toBeNull();',
     },
     {
+      code: 'expect(null).toStrictEqual(null);',
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
+      output: 'expect(null).toBeNull();',
+    },
+    {
       code: 'expect("a string").not.toBe(null);',
       errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
     },
     {
       code: 'expect("a string").not.toEqual(null);',
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
+      output: 'expect("a string").not.toBeNull();',
+    },
+    {
+      code: 'expect("a string").not.toStrictEqual(null);',
       errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
     },

--- a/src/rules/__tests__/prefer-to-be-undefined.test.ts
+++ b/src/rules/__tests__/prefer-to-be-undefined.test.ts
@@ -30,12 +30,22 @@ ruleTester.run('prefer-to-be-undefined', rule, {
       output: 'expect(undefined).toBeUndefined();',
     },
     {
+      code: 'expect(undefined).toStrictEqual(undefined);',
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
+      output: 'expect(undefined).toBeUndefined();',
+    },
+    {
       code: 'expect("a string").not.toBe(undefined);',
       errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
     },
     {
       code: 'expect("a string").not.toEqual(undefined);',
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
+      output: 'expect("a string").not.toBeUndefined();',
+    },
+    {
+      code: 'expect("a string").not.toStrictEqual(undefined);',
       errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
     },

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -73,6 +73,26 @@ ruleTester.run('prefer-to-contain', rule, {
       output: 'expect(a).not.toContain(b);',
     },
     {
+      code: 'expect(a.includes(b)).toStrictEqual(true);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      output: 'expect(a).toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).toStrictEqual(false);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      output: 'expect(a).not.toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).not.toStrictEqual(false);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      output: 'expect(a).toContain(b);',
+    },
+    {
+      code: 'expect(a.includes(b)).not.toStrictEqual(true);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      output: 'expect(a).not.toContain(b);',
+    },
+    {
       code: 'expect(a.test(t).includes(b.test(p))).toEqual(true);',
       errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).toContain(b.test(p));',
@@ -109,6 +129,26 @@ ruleTester.run('prefer-to-contain', rule, {
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(false);',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      output: 'expect([{a:1}]).toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).toStrictEqual(true);',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      output: 'expect([{a:1}]).toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).toStrictEqual(false);',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      output: 'expect([{a:1}]).not.toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(true);',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      output: 'expect([{a:1}]).not.toContain({a:1});',
+    },
+    {
+      code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(false);',
       errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
     },

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -36,5 +36,10 @@ ruleTester.run('prefer-to-have-length', rule, {
       errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
       output: 'expect(files).toHaveLength(1);',
     },
+    {
+      code: 'expect(files.length).toStrictEqual(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
+      output: 'expect(files).toHaveLength(1);',
+    },
   ],
 });

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -341,6 +341,7 @@ export enum ModifierName {
 enum EqualityMatcher {
   toBe = 'toBe',
   toEqual = 'toEqual',
+  toStrictEqual = 'toStrictEqual',
 }
 
 export const isParsedEqualityMatcherCall = (


### PR DESCRIPTION
This PR adds `toStrictEqual` as equality matcher. This fixes the following rules:
- `prefer-to-be-null`
- `prefer-to-be-undefined`
- `prefer-to-contain`
- `prefer-to-have-length`

The tests and documentation have also been updated.