### PR TITLE
feat: support `allow` option in `lowercase-name` rule

### DIFF
--- a/docs/rules/lowercase-name.md
+++ b/docs/rules/lowercase-name.md
@@ -70,3 +70,19 @@ Example of **correct** code for the `{ "ignore": ["it"] }` option:
 
 it('Uppercase description');
 ```
+
+### `allow`
+
+This array option whitelists prefixes that titles can start with with capitals.
+This can be useful when writing tests for api endpoints, where you'd like to
+prefix with the HTTP method.
+
+By default, nothing is allowed (the equivalent of `{ "allow": [] }`).
+
+Example of **correct** code for the `{ "allow": ["GET"] }` option:
+
+```js
+/* eslint jest/lowercase-name: ["error", { "allow": ["GET"] }] */
+
+describe('GET /live');
+```

--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -46,6 +46,10 @@ ruleTester.run('lowercase-name', rule, {
     'describe(``)',
     'describe("")',
     'describe(42)',
+    {
+      code: 'describe(42)',
+      options: [{ ignore: undefined, allowedPrefixes: undefined }],
+    },
   ],
 
   invalid: [
@@ -221,6 +225,24 @@ ruleTester.run('lowercase-name with ignore=it', rule, {
     {
       code: 'it(`Foo`, function () {})',
       options: [{ ignore: [TestCaseName.it] }],
+    },
+  ],
+  invalid: [],
+});
+
+ruleTester.run('lowercase-name with allowedPrefixes', rule, {
+  valid: [
+    {
+      code: "it('GET /live', function () {})",
+      options: [{ allowedPrefixes: ['GET'] }],
+    },
+    {
+      code: 'it("POST /live", function () {})',
+      options: [{ allowedPrefixes: ['GET', 'POST'] }],
+    },
+    {
+      code: 'it(`PATCH /live`, function () {})',
+      options: [{ allowedPrefixes: ['GET', 'PATCH'] }],
     },
   ],
   invalid: [],


### PR DESCRIPTION
This makes things a bit nicer for writing tests for `supertest`.

When I finally get time to finish off my test prefix rule, it might be worth merging into that, but that'd require the whole rule to be merged in.