### PR TITLE
chore(no-commented-out-tests): remove unneeded escape and improve regex

### DIFF
--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -2,7 +2,7 @@ import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createRule } from './utils';
 
 function hasTests(node: TSESTree.Comment) {
-  return /^\s*(x|f)?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/m.test(
+  return /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/m.test(
     node.value,
   );
 }


### PR DESCRIPTION
Super minor optimisations - `[xf]` is slightly faster than `x|f`, and lets us drop `()`, and `]` doesn't need to be escaped.

Saves us a few bytes all round.
