### PR TITLE
Use enum values

### DIFF
--- a/src/rules/no-empty-title.ts
+++ b/src/rules/no-empty-title.ts
@@ -1,4 +1,11 @@
-import { createRule, isDescribe, isStringNode, isTestCase } from './utils';
+import {
+  DescribeAlias,
+  TestCaseName,
+  createRule,
+  isDescribe,
+  isStringNode,
+  isTestCase,
+} from './utils';
 
 export default createRule({
   name: __filename,
@@ -28,7 +35,9 @@ export default createRule({
         }
 
         context.report({
-          messageId: isDescribe(node) ? 'describe' : 'test',
+          messageId: isDescribe(node)
+            ? DescribeAlias.describe
+            : TestCaseName.test,
           node,
         });
       },

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -4,7 +4,11 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import { DescribeAlias, TestCaseName, createRule } from './utils';
 
-const testFunctions = new Set(['describe', 'it', 'test']);
+const testFunctions = new Set<string>([
+  DescribeAlias.describe,
+  TestCaseName.test,
+  TestCaseName.it,
+]);
 
 const matchesTestFunction = (
   object: TSESTree.LeftHandSideExpression | undefined,

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -49,7 +49,7 @@ const isTargetedTestCase = (
   node: TSESTree.CallExpression,
 ): node is JestFunctionCallExpression<TestCaseName> =>
   isTestCase(node) &&
-  (['it', 'test', 'it.skip', 'test.skip'] as Array<string | null>).includes(
+  [TestCaseName.it, TestCaseName.test, 'it.skip', 'test.skip'].includes(
     getNodeName(node.callee),
   );
 


### PR DESCRIPTION
Using the enum values as much as possible means it's easier to track where we depend on the name of jest functions; in turn makes it easier for me to create parsers (among other things) 😄 