### PR TITLE
Improve prefer strict equal

### DIFF
--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -1,4 +1,10 @@
-import { createRule, isExpectCall, parseExpectCall } from './utils';
+import {
+  EqualityMatcher,
+  createRule,
+  isExpectCall,
+  isParsedEqualityMatcherCall,
+  parseExpectCall,
+} from './utils';
 
 export default createRule({
   name: __filename,
@@ -25,10 +31,16 @@ export default createRule({
 
         const { matcher } = parseExpectCall(node);
 
-        if (matcher && matcher.name === 'toEqual') {
+        if (
+          matcher &&
+          isParsedEqualityMatcherCall(matcher, EqualityMatcher.toEqual)
+        ) {
           context.report({
             fix: fixer => [
-              fixer.replaceText(matcher.node.property, 'toStrictEqual'),
+              fixer.replaceText(
+                matcher.node.property,
+                EqualityMatcher.toStrictEqual,
+              ),
             ],
             messageId: 'useToStrictEqual',
             node: matcher.node.property,

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -339,7 +339,7 @@ export enum ModifierName {
   resolves = 'resolves',
 }
 
-enum EqualityMatcher {
+export enum EqualityMatcher {
   toBe = 'toBe',
   toEqual = 'toEqual',
   toStrictEqual = 'toStrictEqual',

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -326,8 +326,9 @@ type MatcherName = string /* & not ModifierName */;
 type ExpectPropertyName = ModifierName | MatcherName;
 
 export type ParsedEqualityMatcherCall<
-  Argument extends TSESTree.Expression = TSESTree.Expression
-> = Omit<ParsedExpectMatcher<EqualityMatcher>, 'arguments'> & {
+  Argument extends TSESTree.Expression = TSESTree.Expression,
+  Matcher extends EqualityMatcher = EqualityMatcher
+> = Omit<ParsedExpectMatcher<Matcher>, 'arguments'> & {
   // todo: probs should also type node parent as CallExpression
   arguments: [Argument];
 };
@@ -344,10 +345,15 @@ enum EqualityMatcher {
   toStrictEqual = 'toStrictEqual',
 }
 
-export const isParsedEqualityMatcherCall = (
+export const isParsedEqualityMatcherCall = <
+  MatcherName extends EqualityMatcher = EqualityMatcher
+>(
   matcher: ParsedExpectMatcher,
-): matcher is ParsedEqualityMatcherCall =>
-  EqualityMatcher.hasOwnProperty(matcher.name) &&
+  name?: MatcherName,
+): matcher is ParsedEqualityMatcherCall<TSESTree.Expression, MatcherName> =>
+  (name
+    ? matcher.name === name
+    : EqualityMatcher.hasOwnProperty(matcher.name)) &&
   matcher.arguments !== null &&
   matcher.arguments.length === 1;
 


### PR DESCRIPTION
Allows `EqualityMatcher` to be more strictly typed to a specifically named matcher.