### PR TITLE
feat(rules): prefer-hooks-on-top

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ installations requiring long-term consistency.
 | [no-try-expect][]              | Prevent `catch` assertions in tests                               |                  |                     |
 | [prefer-called-with][]         | Suggest using `toBeCalledWith()` OR `toHaveBeenCalledWith()`      |                  |                     |
 | [prefer-expect-assertions][]   | Suggest using `expect.assertions()` OR `expect.hasAssertions()`   |                  |                     |
+| [prefer-hooks-on-top][]        | Suggest to have all hooks at top-level before tests               |                  |                     |
 | [prefer-inline-snapshots][]    | Suggest using `toMatchInlineSnapshot()`                           |                  | ![fixable-green][]  |
 | [prefer-spy-on][]              | Suggest using `jest.spyOn()`                                      |                  | ![fixable-green][]  |
 | [prefer-strict-equal][]        | Suggest using `toStrictEqual()`                                   |                  | ![fixable-green][]  |
@@ -191,6 +192,7 @@ https://github.com/dangreenisrael/eslint-plugin-jest-formatting
 [prefer-called-with]: docs/rules/prefer-called-with.md
 [prefer-expect-assertions]: docs/rules/prefer-expect-assertions.md
 [prefer-inline-snapshots]: docs/rules/prefer-inline-snapshots.md
+[prefer-hooks-on-top]: docs/rules/prefer-hooks-on-top.md
 [prefer-spy-on]: docs/rules/prefer-spy-on.md
 [prefer-strict-equal]: docs/rules/prefer-strict-equal.md
 [prefer-to-be-null]: docs/rules/prefer-to-be-null.md

--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -64,7 +64,7 @@ describe("foo" () => {
   beforeEach(() => {
     //some hook code
   });
-  
+
   // Not affected by rule
   someSetup();
 

--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -1,0 +1,96 @@
+# Suggest to have all hooks at top-level before tests (prefer-hooks-on-top)
+
+All hooks should be defined before the start of the tests
+
+## Rule Details
+
+Examples of **incorrect** code for this rule
+
+```js
+/* eslint jest/prefer-hooks-on-top: "error" */
+
+describe("foo" () => {
+  beforeEach(() => {
+    //some hook code
+  });
+  test("bar" () => {
+    some_fn();
+  });
+  beforeAll(() => {
+    //some hook code
+  });
+  test("bar" () => {
+    some_fn();
+  });
+});
+
+// Nested describe scenario
+describe("foo" () => {
+  beforeAll(() => {
+    //some hook code
+  });
+  test("bar" () => {
+    some_fn();
+  });
+  describe("inner_foo" () => {
+    beforeEach(() => {
+      //some hook code
+    });
+    test("inner bar" () => {
+      some_fn();
+    });
+    test("inner bar" () => {
+      some_fn();
+    });
+    beforeAll(() => {
+      //some hook code
+    });
+    afterAll(() => {
+      //some hook code
+    });
+    test("inner bar" () => {
+      some_fn();
+    });
+  });
+});
+```
+
+Examples of **correct** code for this rule
+
+```js
+/* eslint jest/prefer-hooks-on-top: "error" */
+
+describe("foo" () => {
+  beforeEach(() => {
+    //some hook code
+  });
+  
+  // Not affected by rule
+  someSetup();
+
+  afterEach(() => {
+    //some hook code
+  });
+  test("bar" () => {
+    some_fn();
+  });
+});
+
+// Nested describe scenario
+describe("foo" () => {
+  beforeEach(() => {
+    //some hook code
+  });
+  test("bar" () => {
+    some_fn();
+  });
+  describe("inner_foo" () => {
+    beforeEach(() => {
+      //some hook code
+    });
+    test("inner bar" () => {
+      some_fn();
+    });
+  });
+});
+```

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import plugin from '../';
 
 const ruleNames = Object.keys(plugin.rules);
-const numberOfRules = 39;
+const numberOfRules = 40;
 
 describe('rules', () => {
   it('should have a corresponding doc for each rule', () => {

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -9,13 +9,13 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('basic describe block', rule, {
   valid: [
-    `describe("foo" () => {
+    `describe("foo", () => {
         beforeEach(() => {
         });
         someSetupFn();
         afterEach(() => {
         });
-        test("bar" () => {
+        test("bar", () => {
           some_fn();
         });
       });`,
@@ -37,7 +37,7 @@ ruleTester.run('basic describe block', rule, {
       errors: [
         {
           messageId: 'noHookOnTop',
-          column: 3,
+          column: 11,
           line: 7,
         },
       ],
@@ -47,19 +47,19 @@ ruleTester.run('basic describe block', rule, {
 
 ruleTester.run('multiple describe blocks', rule, {
   valid: [
-    `describe.skip("foo" () => {
+    `describe.skip("foo", () => {
         beforeEach(() => {
         });
         beforeAll(() => {
         });
-        test("bar" () => {
+        test("bar", () => {
           some_fn();
         });
       });
-      describe("foo" () => {
+      describe("foo", () => {
         beforeEach(() => {
         });
-        test("bar" () => {
+        test("bar", () => {
           some_fn();
         });
       });`,
@@ -67,31 +67,31 @@ ruleTester.run('multiple describe blocks', rule, {
 
   invalid: [
     {
-      code: `describe.skip("foo" () => {
+      code: `describe.skip("foo", () => {
           beforeEach(() => {
           });
-          test("bar" () => {
+          test("bar", () => {
             some_fn();
           });
           beforeAll(() => {
           });
-          test("bar" () => {
+          test("bar", () => {
             some_fn();
           });
         });
-        describe("foo" () => {
+        describe("foo", () => {
           beforeEach(() => {
           });
           beforeEach(() => {
           });
           beforeAll(() => {
           });
-          test("bar" () => {
+          test("bar", () => {
             some_fn();
           });
         });
-        describe("foo" () => {
-          test("bar" () => {
+        describe("foo", () => {
+          test("bar", () => {
             some_fn();
           });
           beforeEach(() => {
@@ -104,22 +104,22 @@ ruleTester.run('multiple describe blocks', rule, {
       errors: [
         {
           messageId: 'noHookOnTop',
-          column: 3,
+          column: 11,
           line: 7,
         },
         {
           messageId: 'noHookOnTop',
-          column: 3,
+          column: 11,
           line: 28,
         },
         {
           messageId: 'noHookOnTop',
-          column: 3,
+          column: 11,
           line: 30,
         },
         {
           messageId: 'noHookOnTop',
-          column: 3,
+          column: 11,
           line: 32,
         },
       ],
@@ -129,16 +129,16 @@ ruleTester.run('multiple describe blocks', rule, {
 
 ruleTester.run('nested describe blocks', rule, {
   valid: [
-    `describe("foo" () => {
+    `describe("foo", () => {
         beforeEach(() => {
         });
-        test("bar" () => {
+        test("bar", () => {
           some_fn();
         });
-        describe("inner_foo" () => {
+        describe("inner_foo" , () => {
           beforeEach(() => {
           });
-          test("inner bar" () => {
+          test("inner bar", () => {
             some_fn();
           });
         });
@@ -147,26 +147,26 @@ ruleTester.run('nested describe blocks', rule, {
 
   invalid: [
     {
-      code: `describe("foo" () => {
+      code: `describe("foo", () => {
           beforeAll(() => {
           });
-          test("bar" () => {
+          test("bar", () => {
             some_fn();
           });
-          describe("inner_foo" () => {
+          describe("inner_foo" , () => {
             beforeEach(() => {
             });
-            test("inner bar" () => {
+            test("inner bar", () => {
               some_fn();
             });
-            test("inner bar" () => {
+            test("inner bar", () => {
               some_fn();
             });
             beforeAll(() => {
             });
             afterAll(() => {
             });
-            test("inner bar" () => {
+            test("inner bar", () => {
               some_fn();
             });
           });
@@ -174,12 +174,12 @@ ruleTester.run('nested describe blocks', rule, {
       errors: [
         {
           messageId: 'noHookOnTop',
-          column: 5,
+          column: 13,
           line: 16,
         },
         {
           messageId: 'noHookOnTop',
-          column: 5,
+          column: 13,
           line: 18,
         },
       ],

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -9,35 +9,31 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('basic describe block', rule, {
   valid: [
-    [
-      'describe("foo", () => {',
-      '  beforeEach(() => {',
-      '  });',
-      '  someSetupFn();',
-      '  afterEach(() => {',
-      '  });',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  });',
-      '});',
-    ].join('\n'),
+    `describe("foo" () => {
+        beforeEach(() => {
+        });
+        someSetupFn();
+        afterEach(() => {
+        });
+        test("bar" () => {
+          some_fn();
+        });
+      });`,
   ],
   invalid: [
     {
-      code: [
-        'describe("foo", () => {',
-        '  beforeEach(() => {',
-        '  });',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '  beforeAll(() => {',
-        '  });',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '});',
-      ].join('\n'),
+      code: `describe("foo", () => {
+          beforeEach(() => {
+          });
+          test("bar", () => {
+            some_fn();
+          });
+          beforeAll(() => {
+          });
+          test("bar", () => {
+            some_fn();
+          });
+        });`,
       errors: [
         {
           messageId: 'noHookOnTop',
@@ -51,64 +47,60 @@ ruleTester.run('basic describe block', rule, {
 
 ruleTester.run('multiple describe blocks', rule, {
   valid: [
-    [
-      'describe.skip("foo", () => {',
-      '  beforeEach(() => {',
-      '  });',
-      '  beforeAll(() => {',
-      '  });',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  });',
-      '});',
-      'describe("foo", () => {',
-      '  beforeEach(() => {',
-      '  });',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  });',
-      '});',
-    ].join('\n'),
+    `describe.skip("foo" () => {
+        beforeEach(() => {
+        });
+        beforeAll(() => {
+        });
+        test("bar" () => {
+          some_fn();
+        });
+      });
+      describe("foo" () => {
+        beforeEach(() => {
+        });
+        test("bar" () => {
+          some_fn();
+        });
+      });`,
   ],
 
   invalid: [
     {
-      code: [
-        'describe.skip("foo", () => {',
-        '  beforeEach(() => {',
-        '  });',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '  beforeAll(() => {',
-        '  });',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '});',
-        'describe("foo", () => {',
-        '  beforeEach(() => {',
-        '  });',
-        '  beforeEach(() => {',
-        '  });',
-        '  beforeAll(() => {',
-        '  });',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '});',
-        'describe("foo", () => {',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '  beforeEach(() => {',
-        '  });',
-        '  beforeEach(() => {',
-        '  });',
-        '  beforeAll(() => {',
-        '  });',
-        '});',
-      ].join('\n'),
+      code: `describe.skip("foo" () => {
+          beforeEach(() => {
+          });
+          test("bar" () => {
+            some_fn();
+          });
+          beforeAll(() => {
+          });
+          test("bar" () => {
+            some_fn();
+          });
+        });
+        describe("foo" () => {
+          beforeEach(() => {
+          });
+          beforeEach(() => {
+          });
+          beforeAll(() => {
+          });
+          test("bar" () => {
+            some_fn();
+          });
+        });
+        describe("foo" () => {
+          test("bar" () => {
+            some_fn();
+          });
+          beforeEach(() => {
+          });
+          beforeEach(() => {
+          });
+          beforeAll(() => {
+          });
+        });`,
       errors: [
         {
           messageId: 'noHookOnTop',
@@ -137,52 +129,48 @@ ruleTester.run('multiple describe blocks', rule, {
 
 ruleTester.run('nested describe blocks', rule, {
   valid: [
-    [
-      'describe("foo", () => {',
-      '  beforeEach(() => {',
-      '  });',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  });',
-      '  describe("inner_foo", () => {',
-      '    beforeEach(() => {',
-      '    });',
-      '    test("inner bar", () => {',
-      '      some_fn();',
-      '    });',
-      '  });',
-      '});',
-    ].join('\n'),
+    `describe("foo" () => {
+        beforeEach(() => {
+        });
+        test("bar" () => {
+          some_fn();
+        });
+        describe("inner_foo" () => {
+          beforeEach(() => {
+          });
+          test("inner bar" () => {
+            some_fn();
+          });
+        });
+      });`,
   ],
 
   invalid: [
     {
-      code: [
-        'describe("foo", () => {',
-        '  beforeAll(() => {',
-        '  });',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  });',
-        '  describe("inner_foo", () => {',
-        '    beforeEach(() => {',
-        '    });',
-        '    test("inner bar", () => {',
-        '      some_fn();',
-        '    });',
-        '    test("inner bar", () => {',
-        '      some_fn();',
-        '    });',
-        '    beforeAll(() => {',
-        '    });',
-        '    afterAll(() => {',
-        '    });',
-        '    test("inner bar", () => {',
-        '      some_fn();',
-        '    });',
-        '  });',
-        '});',
-      ].join('\n'),
+      code: `describe("foo" () => {
+          beforeAll(() => {
+          });
+          test("bar" () => {
+            some_fn();
+          });
+          describe("inner_foo" () => {
+            beforeEach(() => {
+            });
+            test("inner bar" () => {
+              some_fn();
+            });
+            test("inner bar" () => {
+              some_fn();
+            });
+            beforeAll(() => {
+            });
+            afterAll(() => {
+            });
+            test("inner bar" () => {
+              some_fn();
+            });
+          });
+        });`,
       errors: [
         {
           messageId: 'noHookOnTop',

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -1,0 +1,200 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import rule from '../prefer-hooks-on-top';
+
+const ruleTester = new TSESLint.RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+ruleTester.run('basic describe block', rule, {
+  valid: [
+    [
+      'describe("foo", () => {',
+      '  beforeEach(() => {',
+      '  });',
+      '  someSetupFn();',
+      '  afterEach(() => {',
+      '  });',
+      '  test("bar", () => {',
+      '    some_fn();',
+      '  });',
+      '});',
+    ].join('\n'),
+  ],
+  invalid: [
+    {
+      code: [
+        'describe("foo", () => {',
+        '  beforeEach(() => {',
+        '  });',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '  beforeAll(() => {',
+        '  });',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '});',
+      ].join('\n'),
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 7,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('multiple describe blocks', rule, {
+  valid: [
+    [
+      'describe.skip("foo", () => {',
+      '  beforeEach(() => {',
+      '  });',
+      '  beforeAll(() => {',
+      '  });',
+      '  test("bar", () => {',
+      '    some_fn();',
+      '  });',
+      '});',
+      'describe("foo", () => {',
+      '  beforeEach(() => {',
+      '  });',
+      '  test("bar", () => {',
+      '    some_fn();',
+      '  });',
+      '});',
+    ].join('\n'),
+  ],
+
+  invalid: [
+    {
+      code: [
+        'describe.skip("foo", () => {',
+        '  beforeEach(() => {',
+        '  });',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '  beforeAll(() => {',
+        '  });',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '});',
+        'describe("foo", () => {',
+        '  beforeEach(() => {',
+        '  });',
+        '  beforeEach(() => {',
+        '  });',
+        '  beforeAll(() => {',
+        '  });',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '});',
+        'describe("foo", () => {',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '  beforeEach(() => {',
+        '  });',
+        '  beforeEach(() => {',
+        '  });',
+        '  beforeAll(() => {',
+        '  });',
+        '});',
+      ].join('\n'),
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 7,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 28,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 30,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 32,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('nested describe blocks', rule, {
+  valid: [
+    [
+      'describe("foo", () => {',
+      '  beforeEach(() => {',
+      '  });',
+      '  test("bar", () => {',
+      '    some_fn();',
+      '  });',
+      '  describe("inner_foo", () => {',
+      '    beforeEach(() => {',
+      '    });',
+      '    test("inner bar", () => {',
+      '      some_fn();',
+      '    });',
+      '  });',
+      '});',
+    ].join('\n'),
+  ],
+
+  invalid: [
+    {
+      code: [
+        'describe("foo", () => {',
+        '  beforeAll(() => {',
+        '  });',
+        '  test("bar", () => {',
+        '    some_fn();',
+        '  });',
+        '  describe("inner_foo", () => {',
+        '    beforeEach(() => {',
+        '    });',
+        '    test("inner bar", () => {',
+        '      some_fn();',
+        '    });',
+        '    test("inner bar", () => {',
+        '      some_fn();',
+        '    });',
+        '    beforeAll(() => {',
+        '    });',
+        '    afterAll(() => {',
+        '    });',
+        '    test("inner bar", () => {',
+        '      some_fn();',
+        '    });',
+        '  });',
+        '});',
+      ].join('\n'),
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 5,
+          line: 16,
+        },
+        {
+          messageId: 'noHookOnTop',
+          column: 5,
+          line: 18,
+        },
+      ],
+    },
+  ],
+});

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -1,0 +1,38 @@
+import { createRule, isHook, isTestCase } from './utils';
+
+export default createRule({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Suggest to have all hooks at top level',
+      recommended: false,
+    },
+    messages: {
+      noHookOnTop: 'Move all hooks before test cases',
+    },
+    schema: [],
+    type: 'suggestion',
+  },
+  defaultOptions: [],
+  create(context) {
+    const hooksContext = [false];
+    return {
+      CallExpression(node) {
+        if (!isHook(node) && isTestCase(node)) {
+          hooksContext[hooksContext.length - 1] = true;
+        }
+        if (hooksContext[hooksContext.length - 1] && isHook(node)) {
+          context.report({
+            messageId: 'noHookOnTop',
+            node,
+          });
+        }
+        hooksContext.push(false);
+      },
+      'CallExpression:exit'() {
+        hooksContext.pop();
+      },
+    };
+  },
+});


### PR DESCRIPTION
Fixes #356 

Approach is to maintain a stack of `boolean` which gets marked as `true` when a hook is not before a test

Also an edge case
```js
describe("foo" () => {
  beforeEach(() => {
    //some hook code
  });
  
  // Not affected by rule
  someSetup();

  afterEach(() => {
    //some hook code
  });
  test("bar" () => {
    some_fn();
  });
});
```