### PR TITLE
Enable `noImplicitReturns`

### DIFF
--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -50,4 +50,6 @@ function getPreferredNodeName(nodeName: string) {
   if (firstChar === 'x') {
     return `${nodeName.slice(1)}.skip`;
   }
+
+  return null;
 }

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -37,6 +37,8 @@ const isExpectCallPresentInFunction = (body: TSESTree.Node) => {
       if (line.type === AST_NODE_TYPES.ReturnStatement && line.argument) {
         return isFullExpectCall(line.argument);
       }
+
+      return false;
     });
   }
 
@@ -147,6 +149,8 @@ const verifyExpectWithReturn = (
         return true;
       }
     }
+
+    return false;
   });
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
+    "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
-    "moduleResolution": "node",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,
+    "noImplicitReturns": true,
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
I always forget this isn't enabled by `strict`.

I also enabled `forceConsistentCasingInFileNames` as it's a nice to have, and moved `moduleResolution` to be under `module` b/c of a very valid reason that's sadly classified.