### PR TITLE
Add `jest/no-mocks-import` to recommended rule set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,7 @@ export = {
         'jest/no-focused-tests': 'error',
         'jest/no-identical-title': 'error',
         'jest/no-jest-import': 'error',
-        // 'jest/no-mocks-import': 'error',
+        'jest/no-mocks-import': 'error',
         'jest/no-jasmine-globals': 'warn',
         'jest/no-test-prefixes': 'error',
         'jest/valid-describe': 'error',


### PR DESCRIPTION
@SimenB suggested adding this at a later point: https://github.com/jest-community/eslint-plugin-jest/pull/246#discussion_r277167611

Could that be now?