### PR TITLE
feat(no-focused-tests): check focused tests using .each with table format

### DIFF
--- a/docs/rules/no-focused-tests.md
+++ b/docs/rules/no-focused-tests.md
@@ -32,6 +32,12 @@ test['only']('bar', () => {});
 fdescribe('foo', () => {});
 fit('foo', () => {});
 ftest('bar', () => {});
+fit.each`
+  table
+`();
+ftest.each`
+  table
+`();
 ```
 
 These patterns would not be considered warnings:
@@ -43,4 +49,12 @@ describe.skip('bar', () => {});
 it.skip('bar', () => {});
 test('foo', () => {});
 test.skip('bar', () => {});
+it.each()();
+it.each`
+  table
+`();
+test.each()();
+test.each`
+  table
+`();
 ```

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -1,7 +1,11 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import rule from '../no-focused-tests';
 
-const ruleTester = new TSESLint.RuleTester();
+const ruleTester = new TSESLint.RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
 
 ruleTester.run('no-focused-tests', rule, {
   valid: [
@@ -13,6 +17,10 @@ ruleTester.run('no-focused-tests', rule, {
     'test.skip()',
     'var appliedOnly = describe.only; appliedOnly.apply(describe)',
     'var calledOnly = it.only; calledOnly.call(it)',
+    'it.each()()',
+    'it.each`table`()',
+    'test.each()()',
+    'test.each`table`()',
   ],
 
   invalid: [
@@ -62,6 +70,14 @@ ruleTester.run('no-focused-tests', rule, {
     },
     {
       code: 'fit.each()',
+      errors: [{ messageId: 'focusedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'fit.each`table`()',
+      errors: [{ messageId: 'focusedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'ftest.each`table`()',
       errors: [{ messageId: 'focusedTest', column: 1, line: 1 }],
     },
   ],

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -84,6 +84,16 @@ export default createRule({
       ) {
         context.report({ messageId: 'focusedTest', node: callee });
       }
+
+      if (
+        callee.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+        callee.tag.type === AST_NODE_TYPES.MemberExpression &&
+        callee.tag.object &&
+        callee.tag.object.type === AST_NODE_TYPES.Identifier &&
+        isCallToFocusedTestFunction(callee.tag.object)
+      ) {
+        context.report({ messageId: 'focusedTest', node: callee });
+      }
     },
   }),
 });


### PR DESCRIPTION
[Jest allows to focus tests using `.each` with table format too](https://jestjs.io/docs/en/api#testonlyeachtable-name-fn) so this PR aims to include this variant in `no-focused-tests` rule.