### PR TITLE
docs: fix `valid-title` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ installations requiring long-term consistency.
 | [valid-describe][]             | Enforce valid `describe()` callback                               | ![recommended][] |                     |
 | [valid-expect-in-promise][]    | Enforce having return statement when testing with promises        | ![recommended][] |                     |
 | [valid-expect][]               | Enforce valid `expect()` usage                                    | ![recommended][] |                     |
+| [valid-title][]                | Disallow invalid `describe`/`test` titles                         |                  |                     |
 
 ## Credit
 

--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -1,4 +1,4 @@
-# Disallow duplicate setup and teardown hooks (no-duplicate-hooks)
+# describe/test titles should be valid (valid-title)
 
 A describe/ test block should not contain accidentalSpace or duplicatePrefix.
 


### PR DESCRIPTION
Adds it to README and fixes copy-paste issue with `valid-title` docs.