### PR TITLE
Always check if template literal is complex

### DIFF
--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -1,6 +1,6 @@
 import {
   createRule,
-  getAccessorValue,
+  getStringValue,
   isDescribe,
   isStringNode,
   isTestCase,
@@ -46,7 +46,9 @@ export default createRule({
         if (!argument || !isStringNode(argument)) {
           return;
         }
-        const title = getAccessorValue(argument);
+
+        const title = getStringValue(argument);
+
         if (isTestCase(node)) {
           if (currentLayer.testTitles.includes(title)) {
             context.report({ messageId: 'multipleTestTitle', node });

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -3,7 +3,6 @@ import {
   getAccessorValue,
   isDescribe,
   isStringNode,
-  isTemplateLiteral,
   isTestCase,
 } from './utils';
 
@@ -44,11 +43,7 @@ export default createRule({
           contexts.push(newDescribeContext());
         }
         const [argument] = node.arguments;
-        if (
-          !argument ||
-          !isStringNode(argument) ||
-          (isTemplateLiteral(argument) && argument.expressions.length > 0)
-        ) {
+        if (!argument || !isStringNode(argument)) {
           return;
         }
         const title = getAccessorValue(argument);

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -105,9 +105,8 @@ export const isTemplateLiteral = <V extends string>(
   value?: V,
 ): node is TemplateLiteral<V> =>
   node.type === AST_NODE_TYPES.TemplateLiteral &&
-  (value === undefined ||
-    (node.quasis.length === 1 && // bail out if not simple
-      node.quasis[0].value.raw === value));
+  node.quasis.length === 1 && // bail out if not simple
+  (value === undefined || node.quasis[0].value.raw === value);
 
 type StringNode<S extends string = string> =
   | StringLiteral<S>


### PR DESCRIPTION
For some reason I had `isTemplateLiteral` only check if a literal was "simple" if we were checking for a specific string.

While in theory it makes sense, it also doesn't as we can't (/don't want to try to) process literals w/ expressions in them. This lets us remove a template literal related check from `no-identical-title`, and also fixes a failing test that resulted when merging `no-empty-title` w/ `valid-title` in `next`.

Also changed `no-identical-title` to use `getStringValue` instead of `getAccessorValue`, b/c it's the slightly more correct method to use and eliminates a redundant check that always get called.