### PR TITLE
Add fixers for valid title

### DIFF
--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -125,33 +125,66 @@ ruleTester.run('no-duplicate-prefix ft describe', rule, {
     'describe("foo", function () {})',
     'fdescribe("foo", function () {})',
     'xdescribe("foo", function () {})',
+    'xdescribe(`foo`, function () {})',
   ],
   invalid: [
     {
       code: 'describe("describe foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
+      output: 'describe("foo", function () {})',
     },
     {
       code: 'fdescribe("describe foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
+      output: 'fdescribe("foo", function () {})',
     },
     {
       code: 'xdescribe("describe foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
+      output: 'xdescribe("foo", function () {})',
+    },
+    {
+      code: "describe('describe foo', function () {})",
+      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
+      output: "describe('foo', function () {})",
+    },
+    {
+      code: 'fdescribe(`describe foo`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
+      output: 'fdescribe(`foo`, function () {})',
     },
   ],
 });
 
 ruleTester.run('no-duplicate-prefix ft test', rule, {
-  valid: ['test("foo", function () {})', 'xtest("foo", function () {})'],
+  valid: [
+    'test("foo", function () {})',
+    "test('foo', function () {})",
+    'xtest("foo", function () {})',
+    'xtest(`foo`, function () {})',
+    'test("foo test", function () {})',
+    'xtest("foo test", function () {})',
+  ],
   invalid: [
     {
       code: 'test("test foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
+      output: 'test("foo", function () {})',
     },
     {
       code: 'xtest("test foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 7, line: 1 }],
+      output: 'xtest("foo", function () {})',
+    },
+    {
+      code: 'test(`test foo`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
+      output: 'test(`foo`, function () {})',
+    },
+    {
+      code: 'test(`test foo test`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
+      output: 'test(`foo test`, function () {})',
     },
   ],
 });
@@ -161,19 +194,29 @@ ruleTester.run('no-duplicate-prefix ft it', rule, {
     'it("foo", function () {})',
     'fit("foo", function () {})',
     'xit("foo", function () {})',
+    'xit(`foo`, function () {})',
+    'it("foos it correctly", function () {})',
   ],
   invalid: [
     {
       code: 'it("it foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
+      output: 'it("foo", function () {})',
     },
     {
       code: 'fit("it foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
+      output: 'fit("foo", function () {})',
     },
     {
       code: 'xit("it foo", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
+      output: 'xit("foo", function () {})',
+    },
+    {
+      code: 'it("it foos it correctly", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
+      output: 'it("foos it correctly", function () {})',
     },
   ],
 });
@@ -181,24 +224,55 @@ ruleTester.run('no-duplicate-prefix ft it', rule, {
 ruleTester.run('no-duplicate-prefix ft nested', rule, {
   valid: [
     `
-      describe('foo', () => {
-        it('bar', () => {})
-      })`,
+    describe('foo', () => {
+      it('bar', () => {})
+    })
+    `,
+    `
+    describe('foo', () => {
+      it('describes things correctly', () => {})
+    })
+    `,
   ],
   invalid: [
     {
       code: `
       describe('describe foo', () => {
         it('bar', () => {})
-      })`,
+      })
+      `,
       errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
+      output: `
+      describe('foo', () => {
+        it('bar', () => {})
+      })
+      `,
+    },
+    {
+      code: `
+      describe('describe foo', () => {
+        it('describes things correctly', () => {})
+      })
+      `,
+      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
+      output: `
+      describe('foo', () => {
+        it('describes things correctly', () => {})
+      })
+      `,
     },
     {
       code: `
       describe('foo', () => {
         it('it bar', () => {})
-      })`,
+      })
+      `,
       errors: [{ messageId: 'duplicatePrefix', column: 12, line: 3 }],
+      output: `
+      describe('foo', () => {
+        it('bar', () => {})
+      })
+      `,
     },
   ],
 });

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -22,6 +22,7 @@ ruleTester.run('no-accidental-space', rule, {
     'xit("foo", function () {})',
     'test("foo", function () {})',
     'xtest("foo", function () {})',
+    'xtest(`foo`, function () {})',
     'someFn("foo", function () {})',
     `
     describe('foo', () => {
@@ -33,34 +34,62 @@ ruleTester.run('no-accidental-space', rule, {
     {
       code: 'describe(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
+      output: 'describe("foo", function () {})',
+    },
+    {
+      code: 'describe(" foo foe fum", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
+      output: 'describe("foo foe fum", function () {})',
     },
     {
       code: 'fdescribe(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
+      output: 'fdescribe("foo", function () {})',
+    },
+    {
+      code: "fdescribe(' foo', function () {})",
+      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
+      output: "fdescribe('foo', function () {})",
     },
     {
       code: 'xdescribe(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
+      output: 'xdescribe("foo", function () {})',
     },
     {
       code: 'it(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 4, line: 1 }],
+      output: 'it("foo", function () {})',
     },
     {
       code: 'fit(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
+      output: 'fit("foo", function () {})',
     },
     {
       code: 'xit(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
+      output: 'xit("foo", function () {})',
     },
     {
       code: 'test(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
+      output: 'test("foo", function () {})',
+    },
+    {
+      code: 'test(` foo`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
+      output: 'test(`foo`, function () {})',
+    },
+    {
+      code: 'test(` foo bar bang`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
+      output: 'test(`foo bar bang`, function () {})',
     },
     {
       code: 'xtest(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 7, line: 1 }],
+      output: 'xtest("foo", function () {})',
     },
     {
       code: `
@@ -69,6 +98,11 @@ ruleTester.run('no-accidental-space', rule, {
       })
       `,
       errors: [{ messageId: 'accidentalSpace', column: 16, line: 2 }],
+      output: `
+      describe('foo', () => {
+        it('bar', () => {})
+      })
+      `,
     },
     {
       code: `
@@ -77,6 +111,11 @@ ruleTester.run('no-accidental-space', rule, {
       })
       `,
       errors: [{ messageId: 'accidentalSpace', column: 12, line: 3 }],
+      output: `
+      describe('foo', () => {
+        it('bar', () => {})
+      })
+      `,
     },
   ],
 });

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -1,4 +1,7 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
 import {
   createRule,
   getNodeName,
@@ -25,6 +28,7 @@ export default createRule({
     },
     type: 'suggestion',
     schema: [],
+    fixable: 'code',
   },
   defaultOptions: [],
   create(context) {
@@ -50,6 +54,19 @@ export default createRule({
           context.report({
             messageId: 'accidentalSpace',
             node: argument,
+            fix(fixer) {
+              const stringValue =
+                argument.type === AST_NODE_TYPES.TemplateLiteral
+                  ? `\`${argument.quasis[0].value.raw}\``
+                  : argument.raw;
+
+              return [
+                fixer.replaceTextRange(
+                  argument.range,
+                  stringValue.replace(/^([`'"]) +?/, '$1'),
+                ),
+              ];
+            },
           });
         }
 

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -77,6 +77,19 @@ export default createRule({
           context.report({
             messageId: 'duplicatePrefix',
             node: argument,
+            fix(fixer) {
+              const stringValue =
+                argument.type === AST_NODE_TYPES.TemplateLiteral
+                  ? `\`${argument.quasis[0].value.raw}\``
+                  : argument.raw;
+
+              return [
+                fixer.replaceTextRange(
+                  argument.range,
+                  stringValue.replace(/^([`'"]).+? /, '$1'),
+                ),
+              ];
+            },
           });
         }
       },


### PR DESCRIPTION
Turns out `eslint` doesn't provide a decent way to get the quote type that is being used for string literals, which is annoying.