### PR TITLE
fix(prefer-todo): ensure argument exists before trying to access it

### DIFF
--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -9,6 +9,7 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('prefer-todo', rule, {
   valid: [
+    'test()',
     'test.todo("i need to write this test");',
     'test(obj)',
     'fit("foo")',

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -76,7 +76,7 @@ export default createRule({
       CallExpression(node) {
         const [firstArg, secondArg] = node.arguments;
 
-        if (!isTargetedTestCase(node) || !isStringNode(firstArg)) {
+        if (!firstArg || !isTargetedTestCase(node) || !isStringNode(firstArg)) {
           return;
         }
 


### PR DESCRIPTION
This has been around since I converted everything to TypeScript, so surprised no one hit it before (including myself).