### PR TITLE
Fix 463

### DIFF
--- a/src/rules/__tests__/valid-describe.test.ts
+++ b/src/rules/__tests__/valid-describe.test.ts
@@ -16,6 +16,7 @@ ruleTester.run('valid-describe', rule, {
     'describe["each"](() => {})("foo")',
     'describe["each"]()(() => {})',
     'describe["each"]("foo")(() => {})',
+    'describe.each([1, 2, 3])("%s", (a, b) => {});',
     'describe("foo", function() {})',
     'describe("foo", () => {})',
     'describe(`foo`, () => {})',

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -550,6 +550,7 @@ export enum TestCaseProperty {
 }
 
 export type JestFunctionName = DescribeAlias | TestCaseName | HookName;
+export type JestPropertyName = DescribeProperty | TestCaseProperty;
 
 export interface JestFunctionIdentifier<FunctionName extends JestFunctionName>
   extends TSESTree.Identifier {
@@ -557,15 +558,24 @@ export interface JestFunctionIdentifier<FunctionName extends JestFunctionName>
 }
 
 export interface JestFunctionMemberExpression<
-  FunctionName extends JestFunctionName
-> extends TSESTree.MemberExpression {
+  FunctionName extends JestFunctionName,
+  PropertyName extends JestPropertyName = JestPropertyName
+> extends KnownMemberExpression<PropertyName> {
+  object: JestFunctionIdentifier<FunctionName>;
+}
+
+export interface JestFunctionMemberExpression<
+  FunctionName extends JestFunctionName,
+  PropertyName extends JestPropertyName = JestPropertyName
+> extends KnownMemberExpression<PropertyName> {
   object: JestFunctionIdentifier<FunctionName>;
 }
 
 export interface JestFunctionCallExpressionWithMemberExpressionCallee<
-  FunctionName extends JestFunctionName
+  FunctionName extends JestFunctionName,
+  PropertyName extends JestPropertyName = JestPropertyName
 > extends TSESTree.CallExpression {
-  callee: JestFunctionMemberExpression<FunctionName>;
+  callee: JestFunctionMemberExpression<FunctionName, PropertyName>;
 }
 
 export interface JestFunctionCallExpressionWithIdentifierCallee<
@@ -650,6 +660,21 @@ export const isDescribe = (
       DescribeProperty.hasOwnProperty(node.callee.property.name))
   );
 };
+
+/**
+ * Checks if the given `describe` is a call to `describe.each`.
+ *
+ * @param {JestFunctionCallExpression<DescribeAlias>} node
+ * @return {node is JestFunctionCallExpression<DescribeAlias, DescribeProperty.each>}
+ */
+export const isDescribeEach = (
+  node: JestFunctionCallExpression<DescribeAlias>,
+): node is JestFunctionCallExpressionWithMemberExpressionCallee<
+  DescribeAlias,
+  DescribeProperty.each
+> =>
+  node.callee.type === AST_NODE_TYPES.MemberExpression &&
+  isSupportedAccessor(node.callee.property, DescribeProperty.each);
 
 /**
  * Gets the arguments of the given `JestFunctionCallExpression`.

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -6,6 +6,7 @@ import {
   createRule,
   getJestFunctionArguments,
   isDescribe,
+  isDescribeEach,
   isFunction,
 } from './utils';
 
@@ -85,7 +86,7 @@ export default createRule({
           });
         }
 
-        if (callback.params.length) {
+        if (!isDescribeEach(node) && callback.params.length) {
           context.report({
             messageId: 'unexpectedDescribeArgument',
             loc: paramsLocation(callback.params),


### PR DESCRIPTION
We can later refactor `isDescribe` to be overloaded w/ a `property` argument, but for now this'll fix the specific issue w/ `each`.