### PR TITLE
fix: get correct ruleName without specifying file extension

### DIFF
--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -1,5 +1,5 @@
 // TODO: rename to utils.ts when TS migration is complete
-import path from 'path';
+import { parse as parsePath } from 'path';
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -11,7 +11,7 @@ import { version } from '../../package.json';
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 
 export const createRule = ESLintUtils.RuleCreator(name => {
-  const ruleName = path.parse(name).name;
+  const ruleName = parsePath(name).name;
   return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
 });
 

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -1,5 +1,5 @@
 // TODO: rename to utils.ts when TS migration is complete
-import { basename } from 'path';
+import path from 'path';
 import {
   AST_NODE_TYPES,
   ESLintUtils,
@@ -11,7 +11,7 @@ import { version } from '../../package.json';
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';
 
 export const createRule = ESLintUtils.RuleCreator(name => {
-  const ruleName = basename(name, '.ts');
+  const ruleName = path.parse(name).name;
   return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
 });
 


### PR DESCRIPTION
In my own VSCode current version of forming url to a rule is [incorrect](https://github.com/jest-community/eslint-plugin-jest/blob/v23.0.3/docs/rules/prefer-expect-assertions.js.md). 
Because of after transformation from TypeScript to JavaScript all **.ts file extensions become **.js and hence the below statement is invalid now:
https://github.com/jest-community/eslint-plugin-jest/blob/b4868becf70e162aabcce14910d84947b48a83f8/src/rules/utils.ts#L14

I suggest version that is independent on an extension.
