### PR TITLE
docs(rules): expose the right options for exceptions option

### DIFF
--- a/docs/rules/lowercase-name.md
+++ b/docs/rules/lowercase-name.md
@@ -71,18 +71,18 @@ Example of **correct** code for the `{ "ignore": ["it"] }` option:
 it('Uppercase description');
 ```
 
-### `allow`
+### `allowedPrefixes`
 
 This array option whitelists prefixes that titles can start with with capitals.
 This can be useful when writing tests for api endpoints, where you'd like to
 prefix with the HTTP method.
 
-By default, nothing is allowed (the equivalent of `{ "allow": [] }`).
+By default, nothing is allowed (the equivalent of `{ "allowedPrefixes": [] }`).
 
-Example of **correct** code for the `{ "allow": ["GET"] }` option:
+Example of **correct** code for the `{ "allowedPrefixes": ["GET"] }` option:
 
 ```js
-/* eslint jest/lowercase-name: ["error", { "allow": ["GET"] }] */
+/* eslint jest/lowercase-name: ["error", { "allowedPrefixes": ["GET"] }] */
 
 describe('GET /live');
 ```


### PR DESCRIPTION
Looking at the latest version of the plugin code, the exception option looks to be `allowedPrefixes` not `allow`.
`allowPrefixes` works well on my project whereas `allow` was not doing the job.

Keep up the good work! 🃏
