### PR TITLE
chore: minor housekeeping

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
     'plugin:eslint-comments/recommended',
     'plugin:node/recommended',
     'plugin:@typescript-eslint/eslint-recommended',
-    'prettier',
+    'plugin:prettier/recommended',
+    'prettier/@typescript-eslint',
   ],
   plugins: [
     'eslint-plugin',
@@ -43,7 +44,6 @@ module.exports = {
       { VariableDeclarator: { array: true, object: true } },
     ],
     'sort-imports': ['error', { ignoreDeclarationSort: true }],
-    'prettier/prettier': 'error',
     // TS covers this
     'node/no-missing-import': 'off',
     'node/no-unsupported-features/es-syntax': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,12 +6,14 @@ module.exports = {
   parser: require.resolve('@typescript-eslint/parser'),
   extends: [
     'plugin:eslint-plugin/recommended',
+    'plugin:eslint-comments/recommended',
     'plugin:node/recommended',
     'plugin:@typescript-eslint/eslint-recommended',
     'prettier',
   ],
   plugins: [
     'eslint-plugin',
+    'eslint-comments',
     'node',
     'prettier',
     'import',

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
     "eslint": "^5.1.0 || ^6.0.0",
     "eslint-config-prettier": "^6.5.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-eslint-plugin": "^2.0.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-node": "^10.0.0",

--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -6,7 +6,7 @@ import { TestCaseName } from '../utils';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -8,7 +8,7 @@ import rule from '../expect-expect';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -6,7 +6,7 @@ import { DescribeAlias, TestCaseName } from '../utils';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-alias-methods.test.ts
+++ b/src/rules/__tests__/no-alias-methods.test.ts
@@ -26,7 +26,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toBeCalled', canonical: 'toHaveBeenCalled' },
+          data: { alias: 'toBeCalled', canonical: 'toHaveBeenCalled' },
           column: 11,
           line: 1,
         },
@@ -39,7 +39,7 @@ ruleTester.run('no-alias-methods', rule, {
         {
           messageId: 'replaceAlias',
           data: {
-            replace: 'toBeCalledTimes',
+            alias: 'toBeCalledTimes',
             canonical: 'toHaveBeenCalledTimes',
           },
           column: 11,
@@ -54,7 +54,7 @@ ruleTester.run('no-alias-methods', rule, {
         {
           messageId: 'replaceAlias',
           data: {
-            replace: 'toBeCalledWith',
+            alias: 'toBeCalledWith',
             canonical: 'toHaveBeenCalledWith',
           },
           column: 11,
@@ -69,7 +69,7 @@ ruleTester.run('no-alias-methods', rule, {
         {
           messageId: 'replaceAlias',
           data: {
-            replace: 'lastCalledWith',
+            alias: 'lastCalledWith',
             canonical: 'toHaveBeenLastCalledWith',
           },
           column: 11,
@@ -84,7 +84,7 @@ ruleTester.run('no-alias-methods', rule, {
         {
           messageId: 'replaceAlias',
           data: {
-            replace: 'nthCalledWith',
+            alias: 'nthCalledWith',
             canonical: 'toHaveBeenNthCalledWith',
           },
           column: 11,
@@ -98,7 +98,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toReturn', canonical: 'toHaveReturned' },
+          data: { alias: 'toReturn', canonical: 'toHaveReturned' },
           column: 11,
           line: 1,
         },
@@ -110,7 +110,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toReturnTimes', canonical: 'toHaveReturnedTimes' },
+          data: { alias: 'toReturnTimes', canonical: 'toHaveReturnedTimes' },
           column: 11,
           line: 1,
         },
@@ -122,7 +122,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toReturnWith', canonical: 'toHaveReturnedWith' },
+          data: { alias: 'toReturnWith', canonical: 'toHaveReturnedWith' },
           column: 11,
           line: 1,
         },
@@ -135,7 +135,7 @@ ruleTester.run('no-alias-methods', rule, {
         {
           messageId: 'replaceAlias',
           data: {
-            replace: 'lastReturnedWith',
+            alias: 'lastReturnedWith',
             canonical: 'toHaveLastReturnedWith',
           },
           column: 11,
@@ -150,7 +150,7 @@ ruleTester.run('no-alias-methods', rule, {
         {
           messageId: 'replaceAlias',
           data: {
-            replace: 'nthReturnedWith',
+            alias: 'nthReturnedWith',
             canonical: 'toHaveNthReturnedWith',
           },
           column: 11,
@@ -164,7 +164,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toThrowError', canonical: 'toThrow' },
+          data: { alias: 'toThrowError', canonical: 'toThrow' },
           column: 11,
           line: 1,
         },
@@ -176,7 +176,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toThrowError', canonical: 'toThrow' },
+          data: { alias: 'toThrowError', canonical: 'toThrow' },
           column: 20,
           line: 1,
         },
@@ -188,7 +188,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toThrowError', canonical: 'toThrow' },
+          data: { alias: 'toThrowError', canonical: 'toThrow' },
           column: 19,
           line: 1,
         },
@@ -200,7 +200,7 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { replace: 'toThrowError', canonical: 'toThrow' },
+          data: { alias: 'toThrowError', canonical: 'toThrow' },
           column: 15,
           line: 1,
         },

--- a/src/rules/__tests__/no-alias-methods.test.ts
+++ b/src/rules/__tests__/no-alias-methods.test.ts
@@ -26,7 +26,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toBeCalled', canonical: 'toHaveBeenCalled' },
+          data: {
+            alias: 'toBeCalled',
+            canonical: 'toHaveBeenCalled',
+          },
           column: 11,
           line: 1,
         },
@@ -98,7 +101,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toReturn', canonical: 'toHaveReturned' },
+          data: {
+            alias: 'toReturn',
+            canonical: 'toHaveReturned',
+          },
           column: 11,
           line: 1,
         },
@@ -110,7 +116,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toReturnTimes', canonical: 'toHaveReturnedTimes' },
+          data: {
+            alias: 'toReturnTimes',
+            canonical: 'toHaveReturnedTimes',
+          },
           column: 11,
           line: 1,
         },
@@ -122,7 +131,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toReturnWith', canonical: 'toHaveReturnedWith' },
+          data: {
+            alias: 'toReturnWith',
+            canonical: 'toHaveReturnedWith',
+          },
           column: 11,
           line: 1,
         },
@@ -164,7 +176,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toThrowError', canonical: 'toThrow' },
+          data: {
+            alias: 'toThrowError',
+            canonical: 'toThrow',
+          },
           column: 11,
           line: 1,
         },
@@ -176,7 +191,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toThrowError', canonical: 'toThrow' },
+          data: {
+            alias: 'toThrowError',
+            canonical: 'toThrow',
+          },
           column: 20,
           line: 1,
         },
@@ -188,7 +206,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toThrowError', canonical: 'toThrow' },
+          data: {
+            alias: 'toThrowError',
+            canonical: 'toThrow',
+          },
           column: 19,
           line: 1,
         },
@@ -200,7 +221,10 @@ ruleTester.run('no-alias-methods', rule, {
       errors: [
         {
           messageId: 'replaceAlias',
-          data: { alias: 'toThrowError', canonical: 'toThrow' },
+          data: {
+            alias: 'toThrowError',
+            canonical: 'toThrow',
+          },
           column: 15,
           line: 1,
         },

--- a/src/rules/__tests__/no-duplicate-hooks.test.ts
+++ b/src/rules/__tests__/no-duplicate-hooks.test.ts
@@ -5,7 +5,7 @@ import rule from '../no-duplicate-hooks';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-hooks.test.ts
+++ b/src/rules/__tests__/no-hooks.test.ts
@@ -6,7 +6,7 @@ import { HookName } from '../utils';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -5,7 +5,7 @@ import rule from '../no-identical-title';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -5,7 +5,7 @@ import rule from '../no-if';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-jest-import.test.ts
+++ b/src/rules/__tests__/no-jest-import.test.ts
@@ -5,7 +5,7 @@ import rule from '../no-jest-import';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-mocks-import.test.ts
+++ b/src/rules/__tests__/no-mocks-import.test.ts
@@ -5,7 +5,7 @@ import rule from '../no-mocks-import';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/no-test-callback.test.ts
+++ b/src/rules/__tests__/no-test-callback.test.ts
@@ -5,7 +5,7 @@ import rule from '../no-test-callback';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
   },
 });
 

--- a/src/rules/__tests__/no-try-expect.test.ts
+++ b/src/rules/__tests__/no-try-expect.test.ts
@@ -1,14 +1,13 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import resolveFrom from 'resolve-from';
 import rule from '../no-try-expect';
 
-const ruleTester = new TSESLint.RuleTester(
-  // @ts-ignore: https://github.com/typescript-eslint/typescript-eslint/pull/746
-  {
-    parserOptions: {
-      ecmaVersion: 2019,
-    },
+const ruleTester = new TSESLint.RuleTester({
+  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parserOptions: {
+    ecmaVersion: 2019,
   },
-);
+});
 
 ruleTester.run('no-try-catch', rule, {
   valid: [

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -5,7 +5,7 @@ import rule from '../prefer-expect-assertions';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -5,7 +5,7 @@ import rule from '../prefer-hooks-on-top';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -8,7 +8,7 @@ import rule from '../prefer-spy-on';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2015,
   },
 });
 

--- a/src/rules/__tests__/require-to-throw-message.test.ts
+++ b/src/rules/__tests__/require-to-throw-message.test.ts
@@ -5,7 +5,7 @@ import rule from '../require-to-throw-message';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
   },
 });
 

--- a/src/rules/__tests__/valid-describe.test.ts
+++ b/src/rules/__tests__/valid-describe.test.ts
@@ -5,7 +5,7 @@ import rule from '../valid-describe';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
   },
 });
 

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -5,7 +5,7 @@ import rule from '../valid-expect-in-promise';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
   },
 });
 

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -5,7 +5,7 @@ import rule from '../valid-expect';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
   },
 });
 

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -5,7 +5,7 @@ import rule from '../valid-title';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 8,
+    ecmaVersion: 2017,
   },
 });
 

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -9,7 +9,7 @@ export default createRule({
       recommended: 'warn',
     },
     messages: {
-      replaceAlias: `Replace {{ replace }}() with its canonical name of {{ canonical }}()`,
+      replaceAlias: `Replace {{ alias }}() with its canonical name of {{ canonical }}()`,
     },
     fixable: 'code',
     type: 'suggestion',
@@ -51,7 +51,7 @@ export default createRule({
           context.report({
             messageId: 'replaceAlias',
             data: {
-              replace: alias,
+              alias,
               canonical,
             },
             node: matcher.node.property,

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -17,22 +17,20 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    // The Jest methods which have aliases. The canonical name is the first
-    // index of each item.
-    // todo: replace w/ Map
-    const methodNames = [
-      ['toHaveBeenCalled', 'toBeCalled'],
-      ['toHaveBeenCalledTimes', 'toBeCalledTimes'],
-      ['toHaveBeenCalledWith', 'toBeCalledWith'],
-      ['toHaveBeenLastCalledWith', 'lastCalledWith'],
-      ['toHaveBeenNthCalledWith', 'nthCalledWith'],
-      ['toHaveReturned', 'toReturn'],
-      ['toHaveReturnedTimes', 'toReturnTimes'],
-      ['toHaveReturnedWith', 'toReturnWith'],
-      ['toHaveLastReturnedWith', 'lastReturnedWith'],
-      ['toHaveNthReturnedWith', 'nthReturnedWith'],
-      ['toThrow', 'toThrowError'],
-    ];
+    // The Jest methods which have aliases. The canonical name is the first index of each item.
+    const methodNames: Record<string, string> = {
+      toBeCalled: 'toHaveBeenCalled',
+      toBeCalledTimes: 'toHaveBeenCalledTimes',
+      toBeCalledWith: 'toHaveBeenCalledWith',
+      lastCalledWith: 'toHaveBeenLastCalledWith',
+      nthCalledWith: 'toHaveBeenNthCalledWith',
+      toReturn: 'toHaveReturned',
+      toReturnTimes: 'toHaveReturnedTimes',
+      toReturnWith: 'toHaveReturnedWith',
+      lastReturnedWith: 'toHaveLastReturnedWith',
+      nthReturnedWith: 'toHaveNthReturnedWith',
+      toThrowError: 'toThrow',
+    };
 
     return {
       CallExpression(node) {
@@ -46,20 +44,18 @@ export default createRule({
           return;
         }
 
-        // Check if the method used matches any of ours
-        const methodItem = methodNames.find(item => item[1] === matcher.name);
+        const alias = matcher.name;
+        if (alias in methodNames) {
+          const canonical = methodNames[alias];
 
-        if (methodItem) {
           context.report({
             messageId: 'replaceAlias',
             data: {
-              replace: methodItem[1],
-              canonical: methodItem[0],
+              replace: alias,
+              canonical,
             },
             node: matcher.node.property,
-            fix: fixer => [
-              fixer.replaceText(matcher.node.property, methodItem[0]),
-            ],
+            fix: fixer => [fixer.replaceText(matcher.node.property, canonical)],
           });
         }
       },

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -17,7 +17,7 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    // The Jest methods which have aliases. The canonical name is the first index of each item.
+    // map of jest matcher aliases & their canonical names
     const methodNames: Record<string, string> = {
       toBeCalled: 'toHaveBeenCalled',
       toBeCalledTimes: 'toHaveBeenCalledTimes',

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -10,24 +10,18 @@ const testFunctions = new Set<string>([
   TestCaseName.it,
 ]);
 
-const matchesTestFunction = (
-  object: TSESTree.LeftHandSideExpression | undefined,
-) =>
-  object &&
+const matchesTestFunction = (object: TSESTree.LeftHandSideExpression) =>
   'name' in object &&
   (object.name in TestCaseName || object.name in DescribeAlias);
 
-const isCallToFocusedTestFunction = (object: TSESTree.Identifier | undefined) =>
-  object &&
-  object.name.startsWith('f') &&
-  testFunctions.has(object.name.substring(1));
+const isCallToFocusedTestFunction = (object: TSESTree.Identifier) =>
+  object.name.startsWith('f') && testFunctions.has(object.name.substring(1));
 
 const isPropertyNamedOnly = (
-  property: TSESTree.Expression | TSESTree.Identifier | undefined,
+  property: TSESTree.Expression | TSESTree.Identifier,
 ) =>
-  property &&
-  (('name' in property && property.name === 'only') ||
-    ('value' in property && property.value === 'only'));
+  ('name' in property && property.name === 'only') ||
+  ('value' in property && property.value === 'only');
 
 const isCallToTestOnlyFunction = (callee: TSESTree.MemberExpression) =>
   matchesTestFunction(callee.object) && isPropertyNamedOnly(callee.property);

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -41,11 +41,9 @@ const isFirstLineExprStmt = (
   functionBody[0].type === AST_NODE_TYPES.ExpressionStatement;
 
 interface PreferExpectAssertionsCallExpression extends TSESTree.CallExpression {
-  // prettier-ignore
-  // WEB-40105
   arguments: [
     TSESTree.Expression,
-    TSESTree.ArrowFunctionExpression & { body: TSESTree.BlockStatement }
+    TSESTree.ArrowFunctionExpression & { body: TSESTree.BlockStatement },
   ];
 }
 

--- a/src/rules/require-to-throw-message.ts
+++ b/src/rules/require-to-throw-message.ts
@@ -14,7 +14,7 @@ export default createRule({
       recommended: false,
     },
     messages: {
-      addErrorMessage: 'Add an error message to {{ propertyName }}()',
+      addErrorMessage: 'Add an error message to {{ matcherName }}()',
     },
     type: 'suggestion',
     schema: [],

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -1,4 +1,3 @@
-// TODO: rename to utils.ts when TS migration is complete
 import { parse as parsePath } from 'path';
 import {
   AST_NODE_TYPES,

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -32,8 +32,7 @@ interface AsExpressionChain<
 interface TypeAssertionChain<
   Expression extends TSESTree.Expression = TSESTree.Expression
 > extends TSESTree.TSTypeAssertion {
-  // expression: TypeAssertionChain<Expression> | Expression;
-  expression: any; // todo: replace w/ above once typescript-eslint is updated to v2.0.0
+  expression: TypeAssertionChain<Expression> | Expression;
 }
 
 const isTypeCastExpression = <Expression extends TSESTree.Expression>(

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -119,12 +119,10 @@ const isParentThenOrPromiseReturned = (
   node.type === AST_NODE_TYPES.ReturnStatement ||
   isPromiseReturnedLater(node, testFunctionBody);
 
-// prettier-ignore
-// WEB-40105
 type PromiseCallbacks = [
   TSESTree.Expression | undefined,
-  TSESTree.Expression | undefined
-]
+  TSESTree.Expression | undefined,
+];
 
 const verifyExpectWithReturn = (
   promiseCallbacks: PromiseCallbacks,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,6 +2984,14 @@ eslint-plugin-es@^2.0.0:
     eslint-utils "^1.4.2"
     regexpp "^3.0.0"
 
+eslint-plugin-eslint-comments@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-eslint-plugin@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.1.0.tgz#a7a00f15a886957d855feacaafee264f039e62d5"
@@ -3974,7 +3982,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1:
+ignore@^5.0.5, ignore@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -6214,7 +6222,6 @@ npm@^6.10.3:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -6229,7 +6236,6 @@ npm@^6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.5"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -6248,14 +6254,8 @@ npm@^6.10.3:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
General house cleaning - removed some comments that are no longer needed, and chucked in `eslint-plugin-eslint-comments` b/c why not.

Also refactored `no-alias-methods` to use a map instead of an array, which is technically slightly faster, but also just generally nicer logic-wise.

Finally, fixed the message of `require-to-throw-message` to use the right data property :D
That also made me realise it could be a good candidate for the new suggestions api? provided it lets you take in user input.

@SimenB I adjusted the `eslint` config to use `eslint-config-prettier` - let me know if I've just refactored away a work around for something?