### PR TITLE
feat(valid-expect): warn on `await expect()` with no assertions

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -79,6 +79,7 @@ expect();
 expect().toEqual('something');
 expect('something', 'else');
 expect('something');
+await expect('something');
 expect(true).toBeDefined;
 expect(Promise.resolve('hello')).resolves;
 expect(Promise.resolve('hello')).resolves.toEqual('hello');

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -578,5 +578,11 @@ ruleTester.run('valid-expect', rule, {
         },
       ],
     },
+    {
+      code: `test("valid-expect", async () => {
+        await expect(Promise.resolve(1));
+      });`,
+      errors: [{ endColumn: 41, column: 15, messageId: 'noAssertions' }],
+    },
   ],
 });

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -90,6 +90,12 @@ const isAcceptableReturnNode = (
     AST_NODE_TYPES.AwaitExpression,
   ].includes(node.type);
 
+const isNoAssertionsParentNode = (node: TSESTree.Node): boolean =>
+  node.type === AST_NODE_TYPES.ExpressionStatement ||
+  (node.type === AST_NODE_TYPES.AwaitExpression &&
+    node.parent !== undefined &&
+    node.parent.type === AST_NODE_TYPES.ExpressionStatement);
+
 const promiseArrayExceptionKey = ({ start, end }: TSESTree.SourceLocation) =>
   `${start.line}:${start.column}-${end.line}:${end.column}`;
 
@@ -280,10 +286,7 @@ export default createRule<[{ alwaysAwait?: boolean }], MessageIds>({
 
       // nothing called on "expect()"
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (
-          isExpectCall(node) &&
-          node.parent.type === AST_NODE_TYPES.ExpressionStatement
-        ) {
+        if (isExpectCall(node) && isNoAssertionsParentNode(node.parent)) {
           context.report({ messageId: 'noAssertions', node });
         }
       },


### PR DESCRIPTION
Makes the following an error under the `valid-expect` rule:
```js
await expect('something'); // No assertion was called on expect().
```

## Rationale

As this plugin already has a rule for `expect`-with-no-assertions, I thought I'd add a similar one for `await expect`.

Speaking from recent experience, the simple mistake of awaiting the wrong thing (`await expect('something')` instead of `await 'something'`) can be a pain to track down and fix, as its effects are likely to be felt far from the line containing the actual mistake (which itself will never throw at runtime).