### PR TITLE
feat(rules): add .concurrent support

### DIFF
--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -25,6 +25,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
       options: [{ fn: TestCaseName.test }],
     },
     {
+      code: 'test.concurrent("foo")',
+      options: [{ fn: TestCaseName.test }],
+    },
+    {
       code: 'xtest("foo")',
       options: [{ fn: TestCaseName.test }],
     },
@@ -91,6 +95,20 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
       output: 'test.skip("foo")',
     },
     {
+      code: 'it.concurrent("foo")',
+      options: [{ fn: TestCaseName.test }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testKeyword: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+        },
+      ],
+      output: 'test.concurrent("foo")',
+    },
+    {
       code: 'it.only("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
@@ -144,6 +162,10 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
       options: [{ fn: TestCaseName.it }],
     },
     {
+      code: 'it.concurrent("foo")',
+      options: [{ fn: TestCaseName.it }],
+    },
+    {
       code: 'describe("suite", () => { it("foo") })',
       options: [{ fn: TestCaseName.it }],
     },
@@ -192,6 +214,20 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
       output: 'it.skip("foo")',
     },
     {
+      code: 'test.concurrent("foo")',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testKeyword: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+        },
+      ],
+      output: 'it.concurrent("foo")',
+    },
+    {
       code: 'test.only("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
@@ -234,6 +270,10 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
     },
     {
       code: 'test.skip("foo")',
+      options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
+    },
+    {
+      code: 'test.concurrent("foo")',
       options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
     },
     {
@@ -302,6 +342,20 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
       ],
       output: 'describe("suite", () => { it.skip("foo") })',
     },
+    {
+      code: 'describe("suite", () => { test.concurrent("foo") })',
+      options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethodWithinDescribe',
+          data: {
+            testKeywordWithinDescribe: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+        },
+      ],
+      output: 'describe("suite", () => { it.concurrent("foo") })',
+    },
   ],
 });
 
@@ -317,6 +371,10 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
     },
     {
       code: 'it.skip("foo")',
+      options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
+    },
+    {
+      code: 'it.concurrent("foo")',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
     },
     {
@@ -384,6 +442,20 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
         },
       ],
       output: 'describe("suite", () => { test.skip("foo") })',
+    },
+    {
+      code: 'describe("suite", () => { it.concurrent("foo") })',
+      options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
+      errors: [
+        {
+          messageId: 'consistentMethodWithinDescribe',
+          data: {
+            testKeywordWithinDescribe: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+        },
+      ],
+      output: 'describe("suite", () => { test.concurrent("foo") })',
     },
   ],
 });

--- a/src/rules/__tests__/no-commented-out-tests.test.ts
+++ b/src/rules/__tests__/no-commented-out-tests.test.ts
@@ -17,8 +17,10 @@ ruleTester.run('no-commented-out-tests', rule, {
     'it("foo", function () {})',
     'describe.only("foo", function () {})',
     'it.only("foo", function () {})',
+    'it.concurrent("foo", function () {})',
     'test("foo", function () {})',
     'test.only("foo", function () {})',
+    'test.concurrent("foo", function () {})',
     'var appliedSkip = describe.skip; appliedSkip.apply(describe)',
     'var calledSkip = it.skip; calledSkip.call(it)',
     '({ f: function () {} }).f()',
@@ -81,11 +83,19 @@ ruleTester.run('no-commented-out-tests', rule, {
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
+      code: '// it.concurrent("foo", function () {})',
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
+    },
+    {
       code: '// it["skip"]("foo", function () {})',
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
       code: '// test.skip("foo", function () {})',
+      errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
+    },
+    {
+      code: '// test.concurrent("foo", function () {})',
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {

--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -16,8 +16,10 @@ ruleTester.run('no-disabled-tests', rule, {
     'it("foo", function () {})',
     'describe.only("foo", function () {})',
     'it.only("foo", function () {})',
+    'it.concurrent("foo", function () {})',
     'test("foo", function () {})',
     'test.only("foo", function () {})',
+    'test.concurrent("foo", function () {})',
     'describe[`${"skip"}`]("foo", function () {})',
     'var appliedSkip = describe.skip; appliedSkip.apply(describe)',
     'var calledSkip = it.skip; calledSkip.call(it)',
@@ -74,11 +76,19 @@ ruleTester.run('no-disabled-tests', rule, {
       errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
+      code: 'it.concurrent.skip("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
       code: 'it["skip"]("foo", function () {})',
       errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
       code: 'test.skip("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'test.concurrent.skip("foo", function () {})',
       errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -15,8 +15,10 @@ ruleTester.run('no-focused-tests', rule, {
     'it()',
     'describe.skip()',
     'it.skip()',
+    'it.concurrent.skip()',
     'test()',
     'test.skip()',
+    'test.concurrent.skip()',
     'var appliedOnly = describe.only; appliedOnly.apply(describe)',
     'var calledOnly = it.only; calledOnly.call(it)',
     'it.each()()',
@@ -47,6 +49,10 @@ ruleTester.run('no-focused-tests', rule, {
       errors: [{ messageId: 'focusedTest', column: 4, line: 1 }],
     },
     {
+      code: 'it.concurrent.only()',
+      errors: [{ messageId: 'focusedTest', column: 4, line: 1 }],
+    },
+    {
       code: 'it.only.each()',
       errors: [{ messageId: 'focusedTest', column: 4, line: 1 }],
     },
@@ -60,6 +66,10 @@ ruleTester.run('no-focused-tests', rule, {
     },
     {
       code: 'test.only()',
+      errors: [{ messageId: 'focusedTest', column: 6, line: 1 }],
+    },
+    {
+      code: 'test.concurrent.only()',
       errors: [{ messageId: 'focusedTest', column: 6, line: 1 }],
     },
     {

--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -25,10 +25,22 @@ ruleTester.run('no-identical-title', rule, {
       '});',
     ].join('\n'),
     ['it("it1", function() {});', 'it("it2", function() {});'].join('\n'),
+    [
+      'it.concurrent("it1", function() {});',
+      'it.concurrent("it2", function() {});',
+    ].join('\n'),
     ['it.only("it1", function() {});', 'it("it2", function() {});'].join('\n'),
     ['it.only("it1", function() {});', 'it.only("it2", function() {});'].join(
       '\n',
     ),
+    [
+      'it.concurrent.only("it1", function() {});',
+      'it.concurrent("it2", function() {});',
+    ].join('\n'),
+    [
+      'it.concurrent.only("it1", function() {});',
+      'it.concurrent.only("it2", function() {});',
+    ].join('\n'),
     ['describe("title", function() {});', 'it("title", function() {});'].join(
       '\n',
     ),
@@ -120,10 +132,24 @@ ruleTester.run('no-identical-title', rule, {
     },
     {
       code: [
+        'it.concurrent("it1", function() {});',
+        'it.concurrent("it1", function() {});',
+      ].join('\n'),
+      errors: [{ messageId: 'multipleTestTitle', column: 15, line: 2 }],
+    },
+    {
+      code: [
         'it.only("it1", function() {});',
         'it("it1", function() {});',
       ].join('\n'),
       errors: [{ messageId: 'multipleTestTitle', column: 4, line: 2 }],
+    },
+    {
+      code: [
+        'it.concurrent.only("it1", function() {});',
+        'it.concurrent("it1", function() {});',
+      ].join('\n'),
+      errors: [{ messageId: 'multipleTestTitle', column: 15, line: 2 }],
     },
     {
       code: ['fit("it1", function() {});', 'it("it1", function() {});'].join(
@@ -137,6 +163,13 @@ ruleTester.run('no-identical-title', rule, {
         'it.only("it1", function() {});',
       ].join('\n'),
       errors: [{ messageId: 'multipleTestTitle', column: 9, line: 2 }],
+    },
+    {
+      code: [
+        'it.concurrent.only("it1", function() {});',
+        'it.concurrent.only("it1", function() {});',
+      ].join('\n'),
+      errors: [{ messageId: 'multipleTestTitle', column: 20, line: 2 }],
     },
     {
       code: [

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -191,7 +191,27 @@ ruleTester.run('no-if', rule, {
       ],
     },
     {
+      code: `it.concurrent.skip('foo', () => {
+        if('bar') {}
+      })`,
+      errors: [
+        {
+          messageId: 'noIf',
+        },
+      ],
+    },
+    {
       code: `it.only('foo', () => {
+        if('bar') {}
+      })`,
+      errors: [
+        {
+          messageId: 'noIf',
+        },
+      ],
+    },
+    {
+      code: `it.concurrent.only('foo', () => {
         if('bar') {}
       })`,
       errors: [
@@ -221,6 +241,16 @@ ruleTester.run('no-if', rule, {
       ],
     },
     {
+      code: `fit.concurrent('foo', () => {
+        if('bar') {}
+      })`,
+      errors: [
+        {
+          messageId: 'noIf',
+        },
+      ],
+    },
+    {
       code: `test('foo', () => {
         if('bar') {}
       })`,
@@ -231,7 +261,7 @@ ruleTester.run('no-if', rule, {
       ],
     },
     {
-      code: `test.skip('foo', () => {
+      code: `test.concurrent.skip('foo', () => {
         if('bar') {}
       })`,
       errors: [
@@ -241,7 +271,7 @@ ruleTester.run('no-if', rule, {
       ],
     },
     {
-      code: `test.only('foo', () => {
+      code: `test.concurrent.only('foo', () => {
         if('bar') {}
       })`,
       errors: [

--- a/src/rules/__tests__/no-standalone-expect-test.ts
+++ b/src/rules/__tests__/no-standalone-expect-test.ts
@@ -32,6 +32,7 @@ ruleTester.run('no-standalone-expect', rule, {
     });
     `,
     'it.only("an only", value => { expect(value).toBe(true); });',
+    'it.concurrent("an concurrent", value => { expect(value).toBe(true); });',
     'describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });',
   ],
   invalid: [

--- a/src/rules/__tests__/no-test-prefixes.test.ts
+++ b/src/rules/__tests__/no-test-prefixes.test.ts
@@ -7,13 +7,19 @@ ruleTester.run('no-test-prefixes', rule, {
   valid: [
     'describe("foo", function () {})',
     'it("foo", function () {})',
+    'it.concurrent("foo", function () {})',
     'test("foo", function () {})',
+    'test.concurrent("foo", function () {})',
     'describe.only("foo", function () {})',
     'it.only("foo", function () {})',
+    'it.concurrent.only("foo", function () {})',
     'test.only("foo", function () {})',
+    'test.concurrent.only("foo", function () {})',
     'describe.skip("foo", function () {})',
     'it.skip("foo", function () {})',
+    'it.concurrent.skip("foo", function () {})',
     'test.skip("foo", function () {})',
+    'test.concurrent.skip("foo", function () {})',
     'foo()',
     '[1,2,3].forEach()',
   ],
@@ -41,6 +47,18 @@ ruleTester.run('no-test-prefixes', rule, {
         },
       ],
       output: 'it.only("foo", function () {})',
+    },
+    {
+      code: 'fit.concurrent("foo", function () {})',
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'it.concurrent.only' },
+          column: 1,
+          line: 1,
+        },
+      ],
+      output: 'it.concurrent.only("foo", function () {})',
     },
     {
       code: 'xdescribe("foo", function () {})',

--- a/src/rules/__tests__/no-try-expect.test.ts
+++ b/src/rules/__tests__/no-try-expect.test.ts
@@ -28,6 +28,12 @@ ruleTester.run('no-try-catch', rule, {
     } catch {
       expect('foo').toEqual('foo');
     }`,
+    `it.concurrent.skip('foo');
+    try {
+
+    } catch {
+      expect('foo').toEqual('foo');
+    }`,
   ],
   invalid: [
     {

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -10,11 +10,15 @@ const ruleTester = new TSESLint.RuleTester({
 ruleTester.run('prefer-todo', rule, {
   valid: [
     'test()',
+    'test.concurrent()',
     'test.todo("i need to write this test");',
     'test(obj)',
+    'test.concurrent(obj)',
     'fit("foo")',
+    'fit.concurrent("foo")',
     'xit("foo")',
     'test("stub", () => expect(1).toBe(1));',
+    'test.concurrent("stub", () => expect(1).toBe(1));',
     `
       supportsDone && params.length < test.length
         ? done => test(...params, done)

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -56,11 +56,31 @@ ruleTester.run('title-must-be-string', rule, {
       ],
     },
     {
+      code: 'it.concurrent(123, () => {});',
+      errors: [
+        {
+          messageId: 'titleMustBeString',
+          column: 15,
+          line: 1,
+        },
+      ],
+    },
+    {
       code: 'it(1 + 2 + 3, () => {});',
       errors: [
         {
           messageId: 'titleMustBeString',
           column: 4,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'it.concurrent(1 + 2 + 3, () => {});',
+      errors: [
+        {
+          messageId: 'titleMustBeString',
+          column: 15,
           line: 1,
         },
       ],
@@ -72,6 +92,17 @@ ruleTester.run('title-must-be-string', rule, {
         {
           messageId: 'titleMustBeString',
           column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'test.concurrent.skip(123, () => {});',
+      options: [{ ignoreTypeOfDescribeName: true }],
+      errors: [
+        {
+          messageId: 'titleMustBeString',
+          column: 22,
           line: 1,
         },
       ],
@@ -147,9 +178,13 @@ ruleTester.run('no-empty-title', rule, {
     'describe("foo", function () {})',
     'describe("foo", function () { it("bar", function () {}) })',
     'test("foo", function () {})',
+    'test.concurrent("foo", function () {})',
     'test(`foo`, function () {})',
+    'test.concurrent(`foo`, function () {})',
     'test(`${foo}`, function () {})',
+    'test.concurrent(`${foo}`, function () {})',
     "it('foo', function () {})",
+    "it.concurrent('foo', function () {})",
     "xdescribe('foo', function () {})",
     "xit('foo', function () {})",
     "xtest('foo', function () {})",
@@ -189,6 +224,17 @@ ruleTester.run('no-empty-title', rule, {
       ],
     },
     {
+      code: 'it.concurrent("", function () {})',
+      errors: [
+        {
+          messageId: 'emptyTitle',
+          column: 1,
+          line: 1,
+          data: { jestFunctionName: 'test' },
+        },
+      ],
+    },
+    {
       code: 'test("", function () {})',
       errors: [
         {
@@ -200,7 +246,29 @@ ruleTester.run('no-empty-title', rule, {
       ],
     },
     {
+      code: 'test.concurrent("", function () {})',
+      errors: [
+        {
+          messageId: 'emptyTitle',
+          column: 1,
+          line: 1,
+          data: { jestFunctionName: 'test' },
+        },
+      ],
+    },
+    {
       code: 'test(``, function () {})',
+      errors: [
+        {
+          messageId: 'emptyTitle',
+          column: 1,
+          line: 1,
+          data: { jestFunctionName: 'test' },
+        },
+      ],
+    },
+    {
+      code: 'test.concurrent(``, function () {})',
       errors: [
         {
           messageId: 'emptyTitle',
@@ -249,15 +317,19 @@ ruleTester.run('no-empty-title', rule, {
 ruleTester.run('no-accidental-space', rule, {
   valid: [
     'it()',
+    'it.concurrent()',
     'describe()',
     'it.each()()',
     'describe("foo", function () {})',
     'fdescribe("foo", function () {})',
     'xdescribe("foo", function () {})',
     'it("foo", function () {})',
+    'it.concurrent("foo", function () {})',
     'fit("foo", function () {})',
+    'fit.concurrent("foo", function () {})',
     'xit("foo", function () {})',
     'test("foo", function () {})',
+    'test.concurrent("foo", function () {})',
     'xtest("foo", function () {})',
     'xtest(`foo`, function () {})',
     'someFn("foo", function () {})',
@@ -304,14 +376,29 @@ ruleTester.run('no-accidental-space', rule, {
       output: 'it("foo", function () {})',
     },
     {
+      code: 'it.concurrent(" foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 15, line: 1 }],
+      output: 'it.concurrent("foo", function () {})',
+    },
+    {
       code: 'fit(" foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
       output: 'fit("foo", function () {})',
     },
     {
+      code: 'fit.concurrent(" foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 16, line: 1 }],
+      output: 'fit.concurrent("foo", function () {})',
+    },
+    {
       code: 'fit("foo ", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
       output: 'fit("foo", function () {})',
+    },
+    {
+      code: 'fit.concurrent("foo ", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 16, line: 1 }],
+      output: 'fit.concurrent("foo", function () {})',
     },
     {
       code: 'xit(" foo", function () {})',
@@ -324,9 +411,19 @@ ruleTester.run('no-accidental-space', rule, {
       output: 'test("foo", function () {})',
     },
     {
+      code: 'test.concurrent(" foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
+      output: 'test.concurrent("foo", function () {})',
+    },
+    {
       code: 'test(` foo`, function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
       output: 'test(`foo`, function () {})',
+    },
+    {
+      code: 'test.concurrent(` foo`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
+      output: 'test.concurrent(`foo`, function () {})',
     },
     {
       code: 'test(` foo bar bang`, function () {})',
@@ -334,9 +431,19 @@ ruleTester.run('no-accidental-space', rule, {
       output: 'test(`foo bar bang`, function () {})',
     },
     {
+      code: 'test.concurrent(` foo bar bang`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
+      output: 'test.concurrent(`foo bar bang`, function () {})',
+    },
+    {
       code: 'test(` foo bar bang  `, function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
       output: 'test(`foo bar bang`, function () {})',
+    },
+    {
+      code: 'test.concurrent(` foo bar bang  `, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
+      output: 'test.concurrent(`foo bar bang`, function () {})',
     },
     {
       code: 'xtest(" foo", function () {})',

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -45,7 +45,9 @@ export default createRule({
             break;
 
           case 'it.skip':
+          case 'it.concurrent.skip':
           case 'test.skip':
+          case 'test.concurrent.skip':
             context.report({ messageId: 'skippedTest', node });
             break;
         }

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -7,9 +7,14 @@ import {
 const testCaseNames = new Set<string | null>([
   ...Object.keys(TestCaseName),
   'it.only',
+  'it.concurrent.only',
   'it.skip',
+  'it.concurrent.skip',
   'test.only',
+  'test.concurrent.only',
   'test.skip',
+  'test.concurrent.skip',
+  'fit.concurrent',
 ]);
 
 const isTestArrowFunction = (node: TSESTree.ArrowFunctionExpression) =>

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -542,6 +542,7 @@ export enum DescribeProperty {
 
 export enum TestCaseProperty {
   'each' = 'each',
+  'concurrent' = 'concurrent',
   'only' = 'only',
   'skip' = 'skip',
   'todo' = 'todo',
@@ -631,6 +632,22 @@ export const isHook = (
   );
 };
 
+const isConcurrentTestCase = (
+  node: TSESTree.CallExpression,
+): node is JestFunctionCallExpression<TestCaseName> => {
+  console.log(node);
+  return (
+    node.callee.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.object.type === AST_NODE_TYPES.MemberExpression &&
+    TestCaseName.hasOwnProperty(
+      ((node.callee.object as TSESTree.MemberExpression)
+        .object as TSESTree.Identifier).name,
+    ) &&
+    node.callee.property.type === AST_NODE_TYPES.Identifier &&
+    TestCaseProperty.hasOwnProperty(node.callee.property.name)
+  );
+};
+
 export const isTestCase = (
   node: TSESTree.CallExpression,
 ): node is JestFunctionCallExpression<TestCaseName> => {
@@ -641,7 +658,8 @@ export const isTestCase = (
       node.callee.object.type === AST_NODE_TYPES.Identifier &&
       TestCaseName.hasOwnProperty(node.callee.object.name) &&
       node.callee.property.type === AST_NODE_TYPES.Identifier &&
-      TestCaseProperty.hasOwnProperty(node.callee.property.name))
+      TestCaseProperty.hasOwnProperty(node.callee.property.name)) ||
+    isConcurrentTestCase(node)
   );
 };
 


### PR DESCRIPTION
# Refers to #432 

## Key points
- Maybe a little over test, but i tried to main the same logic for test scenarios.
- In some places i cheat in `ts` typing, i miss a TSTree definition for `.concurrent` call expression. Mainly in two files above.
  - [src/rules/no-focused-tests.ts](https://github.com/leonardovillela/eslint-plugin-jest/blob/5527d002b3459a646c58da8a4febfffa0c09c78c/src/rules/no-focused-tests.ts#L38)
  - [src/rules/utils.ts](https://github.com/leonardovillela/eslint-plugin-jest/blob/5527d002b3459a646c58da8a4febfffa0c09c78c/src/rules/utils.ts#L635)
- `xit` don't support use of `.concurrent`, so i don't change the rules for it.
  - This one i opened a [issue](https://github.com/facebook/jest/issues/9354) on jest, just to check if it's a valid behavior.
- `xtest` don't support use of `.concurrent`, so i don't change the rules for it.
- `.todo` don't support use of `.concurrent`, so i don't change the rules for it.