### PR TITLE
feat(rules): add support for function declaration as test case

### DIFF
--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -17,6 +17,7 @@ ruleTester.run('expect-expect', rule, {
     'it("should pass", () => expect(true).toBeDefined())',
     'test("should pass", () => expect(true).toBeDefined())',
     'it("should pass", () => somePromise().then(() => expect(true).toBeDefined()))',
+    'it("should pass", myTest); function myTest() { expect(true).toBeDefined() }',
     {
       code:
         'test("should pass", () => { expect(true).toBeDefined(); foo(true).toBe(true); })',
@@ -43,6 +44,15 @@ ruleTester.run('expect-expect', rule, {
   invalid: [
     {
       code: 'it("should fail", () => {});',
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+    },
+    {
+      code: 'it("should fail", myTest); function myTest() {}',
       errors: [
         {
           messageId: 'noAssertions',

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -18,6 +18,9 @@ ruleTester.run('no-if', rule, {
       code: `it('foo', () => {})`,
     },
     {
+      code: `it('foo', () => {}); function myTest() { if('bar') {} }`,
+    },
+    {
       code: `foo('bar', () => {
         if(baz) {}
       })`,
@@ -296,6 +299,14 @@ ruleTester.run('no-if', rule, {
           if('bar') {}
         })
       })`,
+      errors: [
+        {
+          messageId: 'noIf',
+        },
+      ],
+    },
+    {
+      code: `it('foo', myTest); function myTest() { if ('bar') {} }`,
       errors: [
         {
           messageId: 'noIf',

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -23,6 +23,16 @@ ruleTester.run('no-test-prefixes', rule, {
       expect(1).toBe(1);
     });
     `,
+    `
+    it("one", myTest);
+    function myTest() {
+      expect(1).toBe(1);
+    }
+    `,
+    `
+    it("one", () => expect(1).toBe(1));
+    function myHelper() {}
+    `,
   ],
   invalid: [
     {
@@ -40,6 +50,15 @@ ruleTester.run('no-test-prefixes', rule, {
       });
       `,
       errors: [{ messageId: 'noReturnValue', column: 9, line: 3 }],
+    },
+    {
+      code: `
+        it("one", myTest);
+        function myTest () {
+          return expect(1).toBe(1);
+        }
+      `,
+      errors: [{ messageId: 'noReturnValue', column: 11, line: 4 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-try-expect.test.ts
+++ b/src/rules/__tests__/no-try-expect.test.ts
@@ -14,17 +14,21 @@ ruleTester.run('no-try-catch', rule, {
     `it('foo', () => {
         expect('foo').toEqual('foo');
     })`,
+    `it('foo', () => {})
+    function myTest() {
+      try {
+      } catch {
+      }
+    }`,
     `it('foo', () => {
       expect('bar').toEqual('bar');
     });
     try {
-
     } catch {
       expect('foo').toEqual('foo');
     }`,
     `it.skip('foo');
     try {
-
     } catch {
       expect('foo').toEqual('foo');
     }`,
@@ -44,6 +48,22 @@ ruleTester.run('no-try-catch', rule, {
           expect(err).toMatch('Error');
         }
       })`,
+      errors: [
+        {
+          messageId: 'noTryExpect',
+        },
+      ],
+    },
+    {
+      code: `it('foo', myTest)
+      function myTest() {
+        try {
+
+        } catch (err) {
+          expect(err).toMatch('Error');
+        }
+      }
+      `,
       errors: [
         {
           messageId: 'noTryExpect',

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -2,7 +2,13 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
-import { TestCaseName, createRule, getNodeName, isTestCase } from './utils';
+import {
+  TestCaseName,
+  createRule,
+  getNodeName,
+  getTestCallExpressionsFromDeclaredVariables,
+  isTestCase,
+} from './utils';
 
 const testCaseNames = new Set<string | null>([
   ...Object.keys(TestCaseName),
@@ -68,8 +74,13 @@ export default createRule({
       FunctionExpression() {
         stack.push(false);
       },
-      FunctionDeclaration() {
-        stack.push(false);
+      FunctionDeclaration(node) {
+        const declaredVariables = context.getDeclaredVariables(node);
+        const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
+          declaredVariables,
+        );
+
+        stack.push(testCallExpressions.length > 0);
       },
       ArrowFunctionExpression(node) {
         stack.push(isTestArrowFunction(node));

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -9,7 +9,6 @@ import {
   isTestCase,
 } from './utils';
 
-const RETURN_STATEMENT = 'ReturnStatement';
 const getBody = (args: TSESTree.Expression[]) => {
   const [, secondArg] = args;
 
@@ -59,7 +58,7 @@ export default createRule({
         if (testCallExpressions.length === 0) return;
 
         const returnStmt = node.body.body.find(
-          t => t.type === RETURN_STATEMENT,
+          t => t.type === AST_NODE_TYPES.ReturnStatement,
         );
         if (!returnStmt) return;
 

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -633,6 +633,27 @@ export const isHook = (
   node.callee.type === AST_NODE_TYPES.Identifier &&
   HookName.hasOwnProperty(node.callee.name);
 
+export const getTestCallExpressionsFromDeclaredVariables = (
+  declaredVaiables: TSESLint.Scope.Variable[],
+): Array<JestFunctionCallExpression<TestCaseName>> => {
+  return declaredVaiables.reduce<
+    Array<JestFunctionCallExpression<TestCaseName>>
+  >(
+    (acc, { references }) =>
+      acc.concat(
+        references
+          .map(({ identifier }) => identifier.parent)
+          .filter(
+            (node): node is JestFunctionCallExpression<TestCaseName> =>
+              !!node &&
+              node.type === AST_NODE_TYPES.CallExpression &&
+              isTestCase(node),
+          ),
+      ),
+    [],
+  );
+};
+
 export const isTestCase = (
   node: TSESTree.CallExpression,
 ): node is JestFunctionCallExpression<TestCaseName> =>


### PR DESCRIPTION
Add support for the following test file structure.

```js
test('my test', myTest)

function myTest() {
  expect(true).toBe(true)
}
```

Methods that are directly referenced will be ananalyzed for the
following rules `expect-expect` `no-if` `no-test-return-statement`,
`no-try-expect`