### PR TITLE
feat(expect-expect): support chained function names (#471)

### DIFF
--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -76,22 +76,23 @@ test('returns sum', () =>
 );
 ```
 
-Examples of **correct** code for deep assertion functions with the
-`{ "assertFunctionNames": ["expect", "tester.foo.expect"] }` option:
+Examples of **correct** code for working with the HTTP assertions library
+[SuperTest](https://www.npmjs.com/package/supertest) with the
+`{ "assertFunctionNames": ["expect", "request.get.expect"] }` option:
 
 ```js
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "tester.foo.expect"] }] */
-test('nested expect method call', () => {
-  class Foo {
-    expect(k) {
-      return k;
-    }
-  }
-  let tester = {
-    foo: function() {
-      return new Foo();
-    },
-  };
-  tester.foo().expect(123);
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "request.get.expect"] }] */
+const request = require('supertest');
+const express = require('express');
+
+const app = express();
+
+describe('GET /user', function() {
+  it('responds with json', function(done) {
+    request(app)
+      .get('/user')
+      .expect('Content-Type', /json/)
+      .expect(200, done);
+  });
 });
 ```

--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -75,3 +75,23 @@ test('returns sum', () =>
     .run();
 );
 ```
+
+Examples of **correct** code for deep assertion functions with the
+`{ "assertFunctionNames": ["expect", "tester.foo.expect"] }` option:
+
+```js
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "tester.foo.expect"] }] */
+test('nested expect method call', () => {
+  class Foo {
+    expect(k) {
+      return k;
+    }
+  }
+  let tester = {
+    foo: function() {
+      return new Foo();
+    },
+  };
+  tester.foo().expect(123);
+});
+```

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -54,6 +54,25 @@ ruleTester.run('expect-expect', rule, {
       options: [{ assertFunctionNames: ['tester.foo.expect'] }],
     },
     {
+      code: `test('verifies recursive expect method call', () => {
+                    class Foo {
+                      expect(k) {
+                        return this;
+                      }
+                      bar() {
+                          return this;
+                      }
+                    }
+                    let tester = {
+                        foo: function() {
+                            return new Foo()
+                        }
+                    }
+                    tester.foo().bar().expect(456);
+                  });`,
+      options: [{ assertFunctionNames: ['tester.foo.bar.expect'] }],
+    },
+    {
       code: [
         'test("verifies the function call", () => {',
         '  td.verify(someFunctionCall())',

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -27,6 +27,33 @@ ruleTester.run('expect-expect', rule, {
       options: [{ assertFunctionNames: ['expectSaga'] }],
     },
     {
+      code: `test('verifies expect method call', () => {
+        class Foo {
+          expect(k) {
+            return k;
+          }
+        }
+        new Foo().expect(123);
+      });`,
+      options: [{ assertFunctionNames: ['Foo.expect'] }],
+    },
+    {
+      code: `test('verifies deep expect method call', () => {
+              class Foo {
+                expect(k) {
+                  return k;
+                }
+              }
+              let tester = {
+                  foo: function() {
+                      return new Foo()
+                  }
+              }
+              tester.foo().expect(123);
+            });`,
+      options: [{ assertFunctionNames: ['tester.foo.expect'] }],
+    },
+    {
       code: [
         'test("verifies the function call", () => {',
         '  td.verify(someFunctionCall())',

--- a/src/rules/__tests__/no-jasmine-globals.test.ts
+++ b/src/rules/__tests__/no-jasmine-globals.test.ts
@@ -13,6 +13,7 @@ ruleTester.run('no-jasmine-globals', rule, {
     'test("foo", function () {})',
     'foo()',
     `require('foo')('bar')`,
+    '(function(){})()',
     'function callback(fail) { fail() }',
     'var spyOn = require("actions"); spyOn("foo")',
     'function callback(pending) { pending() }',

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -614,6 +614,10 @@ export function getNodeName(node: TSESTree.Node): string | null {
       break;
     case AST_NODE_TYPES.MemberExpression:
       return joinNames(getNodeName(node.object), getNodeName(node.property));
+    case AST_NODE_TYPES.NewExpression:
+      return getNodeName(node.callee);
+    case AST_NODE_TYPES.CallExpression:
+      return getNodeName(node.callee);
   }
 
   return null;


### PR DESCRIPTION
Added support for chained assertion function names and method calls. (see also #471)

This makes it easy to support 3rd party assertion libraries like [SuperTest](https://www.npmjs.com/package/supertest) with the option `{ "assertFunctionNames": ["expect", "request.get.expect"] }`

Examples of **correct** code for deep assertion functions with the
`{ "assertFunctionNames": ["expect", "tester.foo.expect"] }` option:

```js
/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "tester.foo.expect"] }] */
test('nested expect method call', () => {
  class Foo {
    expect(k) {
      return k;
    }
  }
  let tester = {
    foo: function() {
      return new Foo();
    },
  };
  tester.foo().expect(123);
});
```