### PR TITLE
feat(expect-expect): support glob patterns for assertFunctionNames (#471)

### DIFF
--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -42,7 +42,9 @@ it('should work with callbacks/async', () => {
 
 ### `assertFunctionNames`
 
-This array option whitelists the assertion function names to look for.
+This array option whitelists the assertion function names to look for. Function
+names can be a glob pattern like `request.*.expect` (see
+[micromatch](https://github.com/micromatch/micromatch) for syntax)
 
 Examples of **incorrect** code for the `{ "assertFunctionNames": ["expect"] }`
 option:
@@ -78,10 +80,10 @@ test('returns sum', () =>
 
 Examples of **correct** code for working with the HTTP assertions library
 [SuperTest](https://www.npmjs.com/package/supertest) with the
-`{ "assertFunctionNames": ["expect", "request.get.expect"] }` option:
+`{ "assertFunctionNames": ["expect", "request.*.expect"] }` option:
 
 ```js
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "request.get.expect"] }] */
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "request.*.expect"] }] */
 const request = require('supertest');
 const express = require('express');
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "typecheck": "tsc -p ."
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^2.5.0"
+    "@typescript-eslint/experimental-utils": "^2.5.0",
+    "micromatch": "^4.0.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -50,6 +51,7 @@
     "@semantic-release/git": "^7.0.17",
     "@types/eslint": "^6.1.3",
     "@types/jest": "^24.0.15",
+    "@types/micromatch": "^4.0.0",
     "@types/node": "^12.6.6",
     "@typescript-eslint/eslint-plugin": "^2.5.0",
     "@typescript-eslint/parser": "^2.5.0",

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -55,6 +55,22 @@ ruleTester.run('expect-expect', rule, {
       options: [{ assertFunctionNames: ['tester.foo.expect'] }],
     },
     {
+      code: `test('wildcard chained function', () => {
+                    class Foo {
+                      expect(k) {
+                        return k;
+                      }
+                    }
+                    let tester = {
+                        foo: function() {
+                            return new Foo()
+                        }
+                    }
+                    tester.foo().expect(123);
+                  });`,
+      options: [{ assertFunctionNames: ['tester.*.expect'] }],
+    },
+    {
       code: `test('verifies recursive expect method call', () => {
                     class Foo {
                       expect(k) {

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -7,6 +7,7 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
+import micromatch from 'micromatch';
 import {
   TestCaseName,
   createRule,
@@ -74,7 +75,7 @@ export default createRule<
         const name = getNodeName(node.callee);
         if (name === TestCaseName.it || name === TestCaseName.test) {
           unchecked.push(node);
-        } else if (name && assertFunctionNames.includes(name)) {
+        } else if (name && micromatch.isMatch(name, assertFunctionNames)) {
           // Return early in case of nested `it` statements.
           checkCallExpressionUsed(context.getAncestors());
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,6 +1221,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/braces@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
+  integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1289,6 +1294,13 @@
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
+"@types/micromatch@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.0.tgz#c57e0b11518c930465ce923f44342e1bb4bef309"
+  integrity sha512-bavSCssCRRlbUI639WG0Y30AOowkI5CdxyyrC5eVbsb0BJIbgS5ROfwlwDYHsOmgS59iYlre9sstIA5wfVNKBA==
+  dependencies:
+    "@types/braces" "*"
 
 "@types/minimatch@*":
   version "3.0.3"


### PR DESCRIPTION
Added support for glob patterns to specify assertion function names like `request.*.expect` (see
[micromatch](https://github.com/micromatch/micromatch) for syntax)

Implements #471

Examples of **correct** code for working with the HTTP assertions library
[SuperTest](https://www.npmjs.com/package/supertest) with the `{ "assertFunctionNames": ["expect", "request.*.expect"] }` option:

```js
/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "request.*.expect"] }] */
const request = require('supertest');
const express = require('express');

const app = express();

describe('GET /user', function() {
  it('responds with json', function(done) {
    request(app)
      .get('/user')
      .expect('Content-Type', /json/)
      .expect(200, done);
  });
});
```


