### PR TITLE
chore(lint): enable `require-unicode-regexp` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
       { VariableDeclarator: { array: true, object: true } },
     ],
     'sort-imports': ['error', { ignoreDeclarationSort: true }],
+    'require-unicode-regexp': 'error',
     // TS covers this
     'node/no-missing-import': 'off',
     'node/no-unsupported-features/es-syntax': 'off',

--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -131,7 +131,7 @@ ruleTester.run('no-large-snapshots', rule, {
       options: [
         {
           whitelistedSnapshots: {
-            '/another-mock-component.jsx.snap': [/a big component \d+/],
+            '/another-mock-component.jsx.snap': [/a big component \d+/u],
           },
         },
       ],
@@ -152,7 +152,7 @@ ruleTester.run('no-large-snapshots', rule, {
       options: [
         {
           whitelistedSnapshots: {
-            '/mock-component.jsx.snap': [/a big component \d+/],
+            '/mock-component.jsx.snap': [/a big component \d+/u],
           },
         },
       ],
@@ -186,7 +186,7 @@ describe('no-large-snapshots', () => {
         options: [
           {
             whitelistedSnapshots: {
-              'mock-component.jsx.snap': [/a big component \d+/],
+              'mock-component.jsx.snap': [/a big component \d+/u],
             },
           },
         ],

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -2,7 +2,7 @@ import { TSESTree } from '@typescript-eslint/experimental-utils';
 import { createRule } from './utils';
 
 function hasTests(node: TSESTree.Comment) {
-  return /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/m.test(
+  return /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/mu.test(
     node.value,
   );
 }

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -62,7 +62,7 @@ export default createRule({
           'name' in object &&
           object.name === 'module' &&
           property.type === AST_NODE_TYPES.Identifier &&
-          /^exports?$/.test(property.name)
+          /^exports?$/u.test(property.name)
         ) {
           exportNodes.push(node);
         }

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -121,8 +121,8 @@ export default createRule({
                 fixer.replaceTextRange(
                   argument.range,
                   stringValue
-                    .replace(/^([`'"]) +?/, '$1')
-                    .replace(/ +?([`'"])$/, '$1'),
+                    .replace(/^([`'"]) +?/u, '$1')
+                    .replace(/ +?([`'"])$/u, '$1'),
                 ),
               ];
             },
@@ -145,7 +145,7 @@ export default createRule({
               return [
                 fixer.replaceTextRange(
                   argument.range,
-                  stringValue.replace(/^([`'"]).+? /, '$1'),
+                  stringValue.replace(/^([`'"]).+? /u, '$1'),
                 ),
               ];
             },


### PR DESCRIPTION
It's meant to be better & safer :)