### PR TITLE
chore: simplify `getNodeName`

### DIFF
--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -604,14 +604,11 @@ export function getNodeName(node: TSESTree.Node): string | null {
     return a && b ? `${a}.${b}` : null;
   }
 
+  if (isSupportedAccessor(node)) {
+    return getAccessorValue(node);
+  }
+
   switch (node.type) {
-    case AST_NODE_TYPES.Identifier:
-      return node.name;
-    case AST_NODE_TYPES.Literal:
-      return `${node.value}`;
-    case AST_NODE_TYPES.TemplateLiteral:
-      if (node.expressions.length === 0) return node.quasis[0].value.cooked;
-      break;
     case AST_NODE_TYPES.MemberExpression:
       return joinNames(getNodeName(node.object), getNodeName(node.property));
     case AST_NODE_TYPES.NewExpression:

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -593,6 +593,9 @@ export type JestFunctionCallExpression<
   | JestFunctionCallExpressionWithMemberExpressionCallee<FunctionName>
   | JestFunctionCallExpressionWithIdentifierCallee<FunctionName>;
 
+const joinNames = (a: string | null, b: string | null): string | null =>
+  a && b ? `${a}.${b}` : null;
+
 export function getNodeName(
   node:
     | JestFunctionMemberExpression<JestFunctionName>
@@ -600,10 +603,6 @@ export function getNodeName(
 ): string;
 export function getNodeName(node: TSESTree.Node): string | null;
 export function getNodeName(node: TSESTree.Node): string | null {
-  function joinNames(a?: string | null, b?: string | null): string | null {
-    return a && b ? `${a}.${b}` : null;
-  }
-
   if (isSupportedAccessor(node)) {
     return getAccessorValue(node);
   }

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -612,7 +612,6 @@ export function getNodeName(node: TSESTree.Node): string | null {
     case AST_NODE_TYPES.MemberExpression:
       return joinNames(getNodeName(node.object), getNodeName(node.property));
     case AST_NODE_TYPES.NewExpression:
-      return getNodeName(node.callee);
     case AST_NODE_TYPES.CallExpression:
       return getNodeName(node.callee);
   }


### PR DESCRIPTION
Nothing major, but I realised two of the case returns were the same, and that it was duplicating the `AccessorNode` logic