### PR TITLE
fix: remove tests from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pretest": "yarn build",
     "test": "jest",
     "build": "babel --extensions .js,.ts src --out-dir lib --copy-files",
-    "postbuild": "rimraf lib/**/__tests__/**",
+    "postbuild": "rimraf lib/__tests__ lib/**/__tests__",
     "typecheck": "tsc -p ."
   },
   "dependencies": {


### PR DESCRIPTION
Discovered this while setting up `eslint-plugin-jest-extended` - turns out we're shipping a whole extra 8kb 😱😱😱

```
.
├── docs
│   └── rules
└── lib
    ├── __tests__
    │   └── __snapshots__
    ├── processors
    └── rules

7 directories
```

I've taken swift action to rectify this asap 🚓👮 