### PR TITLE
feat: create `no-deprecated-functions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ installations requiring long-term consistency.
 | [lowercase-name][]             | Disallow capitalized test names                                   |                  | ![fixable-green][]  |
 | [no-alias-methods][]           | Disallow alias methods                                            | ![style][]       | ![fixable-green][]  |
 | [no-commented-out-tests][]     | Disallow commented out tests                                      | ![recommended][] |                     |
+| [no-deprecated-functions][]    | Disallow use of deprecated functions                              |                  | ![fixable-green][]  |
 | [no-disabled-tests][]          | Disallow disabled tests                                           | ![recommended][] |                     |
 | [no-duplicate-hooks][]         | Disallow duplicate hooks within a `describe` block                |                  |                     |
 | [no-expect-resolves][]         | Disallow using `expect().resolves`                                |                  |                     |
@@ -170,6 +171,7 @@ https://github.com/dangreenisrael/eslint-plugin-jest-formatting
 [lowercase-name]: docs/rules/lowercase-name.md
 [no-alias-methods]: docs/rules/no-alias-methods.md
 [no-commented-out-tests]: docs/rules/no-commented-out-tests.md
+[no-deprecated-functions]: docs/rules/no-deprecated-functions.md
 [no-disabled-tests]: docs/rules/no-disabled-tests.md
 [no-duplicate-hooks]: docs/rules/no-duplicate-hooks.md
 [no-expect-resolves]: docs/rules/no-expect-resolves.md

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -39,3 +39,8 @@ removal in Jest 27.
 
 This function was renamed to `advanceTimersByTime` in Jest 22, and is scheduled
 for removal in Jest 27.
+
+### `jest.genMockFromModule`
+
+This function was renamed to `createMockFromModule` in Jest 26, and is scheduled
+for removal in a future version of Jest.

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -1,4 +1,4 @@
-# Warns on usage of deprecated functions (no-deprecated-functions)
+# Disallow use of deprecated functions (no-deprecated-functions)
 
 Over the years Jest has accrued some debt in the form of functions that have
 either been renamed for clarity, or replaced with more powerful APIs.

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -1,6 +1,6 @@
 # Warns on usage of deprecated functions (no-deprecated-functions)
 
-Over the years jest has accrued some debt in the form of functions that have
+Over the years Jest has accrued some debt in the form of functions that have
 either been renamed for clarity, or replaced with more powerful APIs.
 
 While typically these deprecated functions are kept in the codebase for a number
@@ -13,31 +13,29 @@ what to replace them with.
 
 This rule can also autofix a number of these deprecations for you.
 
-### `require.requireActual.` & `require.requireMock`
+### `require.requireActual` & `require.requireMock`
 
-These functions were removed in Jest 26.
+These functions were replaced in Jest 21 and removed in Jest 26.
 
-Originally in the early days of jest, the `requireActual`& `requireMock`
-functions were placed onto the `require` function.
+Originally, the `requireActual` & `requireMock` the `requireActual`&
+`requireMock` functions were placed onto the `require` function.
 
-These functions were later moved onto the `jest` global, and their use via
-`require` deprecated. Finally, the release of Jest 26 saw them removed from the
-`require` function all together.
-
-The PR implementing the removal can be found
-[here](https://github.com/facebook/jest/pull/9854).
+These functions were later moved onto the `jest` object in order to be easier
+for type checkers to handle, and their use via `require` deprecated. Finally,
+the release of Jest 26 saw them removed from the `require` function all
+together.
 
 ### `jest.addMatchers`
 
-This function has been replaced with `expect.extend`, and will ideally be
-removed in Jest 27.
+This function was replaced with `expect.extend` in Jest 17, and is scheduled for
+removal in Jest 27.
 
 ### `jest.resetModuleRegistry`
 
-This function has been renamed to `resetModules`, and will ideally be removed in
-Jest 27.
+This function was renamed to `resetModules` in Jest 15, and is scheduled for
+removal in Jest 27.
 
 ### `jest.runTimersToTime`
 
-This function has been renamed to `advanceTimersByTime`, and will ideally be
-removed in Jest 27.
+This function was renamed to `advanceTimersByTime` in Jest 22, and is scheduled
+for removal in Jest 27.

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -1,0 +1,43 @@
+# Warns on usage of deprecated functions (no-deprecated-functions)
+
+Over the years jest has accrued some debt in the form of functions that have
+either been renamed for clarity, or replaced with more powerful APIs.
+
+While typically these deprecated functions are kept in the codebase for a number
+of majors, eventually they are removed completely.
+
+## Rule details
+
+This rule warns about calls to deprecated functions, and provides details on
+what to replace them with.
+
+This rule can also autofix a number of these deprecations for you.
+
+### `require.requireActual.` & `require.requireMock`
+
+These functions were removed in Jest 26.
+
+Originally in the early days of jest, the `requireActual`& `requireMock`
+functions were placed onto the `require` function.
+
+These functions were later moved onto the `jest` global, and their use via
+`require` deprecated. Finally, the release of Jest 26 saw them removed from the
+`require` function all together.
+
+The PR implementing the removal can be found
+[here](https://github.com/facebook/jest/pull/9854).
+
+### `jest.addMatchers`
+
+This function has been replaced with `expect.extend`, and will ideally be
+removed in Jest 27.
+
+### `jest.resetModuleRegistry`
+
+This function has been renamed to `resetModules`, and will ideally be removed in
+Jest 27.
+
+### `jest.runTimersToTime`
+
+This function has been renamed to `advanceTimersByTime`, and will ideally be
+removed in Jest 27.

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -15,6 +15,7 @@ Object {
       "jest/lowercase-name": "error",
       "jest/no-alias-methods": "error",
       "jest/no-commented-out-tests": "error",
+      "jest/no-deprecated-functions": "error",
       "jest/no-disabled-tests": "error",
       "jest/no-duplicate-hooks": "error",
       "jest/no-expect-resolves": "error",

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import plugin from '../';
 
 const ruleNames = Object.keys(plugin.rules);
-const numberOfRules = 40;
+const numberOfRules = 41;
 
 describe('rules', () => {
   it('should have a corresponding doc for each rule', () => {

--- a/src/rules/__tests__/no-deprecated-functions.ts
+++ b/src/rules/__tests__/no-deprecated-functions.ts
@@ -1,0 +1,48 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import rule from '../no-deprecated-functions';
+
+const ruleTester = new TSESLint.RuleTester();
+
+[
+  ['require.requireMock', 'jest.requireMock'],
+  ['require.requireActual', 'jest.requireActual'],
+  ['jest.addMatchers', 'expect.extend'],
+  ['jest.resetModuleRegistry', 'jest.resetModules'],
+  ['jest.runTimersToTime', 'jest.advanceTimersByTime'],
+].forEach(([deprecation, replacement]) => {
+  const [deprecatedName, deprecatedFunc] = deprecation.split('.');
+  const [replacementName, replacementFunc] = replacement.split('.');
+
+  ruleTester.run(`${deprecation} -> ${replacement}`, rule, {
+    valid: [
+      'jest',
+      'require("fs")',
+      `${replacement}()`,
+      replacement,
+      `${replacementName}['${replacementFunc}']()`,
+      `${replacementName}['${replacementFunc}']`,
+    ],
+    invalid: [
+      {
+        code: `${deprecation}()`,
+        output: `${replacement}()`,
+        errors: [
+          {
+            messageId: 'deprecatedFunction',
+            data: { deprecation, replacement },
+          },
+        ],
+      },
+      {
+        code: `${deprecatedName}['${deprecatedFunc}']()`,
+        output: `${replacementName}['${replacementFunc}']()`,
+        errors: [
+          {
+            messageId: 'deprecatedFunction',
+            data: { deprecation, replacement },
+          },
+        ],
+      },
+    ],
+  });
+});

--- a/src/rules/__tests__/no-deprecated-functions.ts
+++ b/src/rules/__tests__/no-deprecated-functions.ts
@@ -9,6 +9,7 @@ const ruleTester = new TSESLint.RuleTester();
   ['jest.addMatchers', 'expect.extend'],
   ['jest.resetModuleRegistry', 'jest.resetModules'],
   ['jest.runTimersToTime', 'jest.advanceTimersByTime'],
+  ['jest.genMockFromModule', 'jest.createMockFromModule'],
 ].forEach(([deprecation, replacement]) => {
   const [deprecatedName, deprecatedFunc] = deprecation.split('.');
   const [replacementName, replacementFunc] = replacement.split('.');

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -9,7 +9,7 @@ export default createRule({
   meta: {
     docs: {
       category: 'Best Practices',
-      description: 'Warns on usage of deprecated functions',
+      description: 'Disallow use of deprecated functions',
       recommended: false,
     },
     messages: {

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -1,0 +1,71 @@
+import {
+  AST_NODE_TYPES,
+  TSESTree,
+} from '@typescript-eslint/experimental-utils';
+import { createRule, getNodeName } from './utils';
+
+export default createRule({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Warns on usage of deprecated functions',
+      recommended: false,
+    },
+    messages: {
+      deprecatedFunction:
+        '`{{ deprecation }}` has been deprecated in favor of `{{ replacement }}`',
+    },
+    type: 'suggestion',
+    schema: [],
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    const deprecations: Record<string, string> = {
+      'require.requireMock': 'jest.requireMock',
+      'require.requireActual': 'jest.requireActual',
+      'jest.addMatchers': 'expect.extend',
+      'jest.resetModuleRegistry': 'jest.resetModules',
+      'jest.runTimersToTime': 'jest.advanceTimersByTime',
+    };
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (node.callee.type !== AST_NODE_TYPES.MemberExpression) {
+          return;
+        }
+
+        const deprecation = getNodeName(node);
+
+        if (!deprecation || !(deprecation in deprecations)) {
+          return;
+        }
+
+        const replacement = deprecations[deprecation];
+        const { callee } = node;
+
+        context.report({
+          messageId: 'deprecatedFunction',
+          data: {
+            deprecation,
+            replacement,
+          },
+          node,
+          fix(fixer) {
+            let [name, func] = replacement.split('.');
+
+            if (callee.property.type === AST_NODE_TYPES.Literal) {
+              func = `'${func}'`;
+            }
+
+            return [
+              fixer.replaceText(callee.object, name),
+              fixer.replaceText(callee.property, func),
+            ];
+          },
+        });
+      },
+    };
+  },
+});

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -28,6 +28,7 @@ export default createRule({
       'jest.addMatchers': 'expect.extend',
       'jest.resetModuleRegistry': 'jest.resetModules',
       'jest.runTimersToTime': 'jest.advanceTimersByTime',
+      'jest.genMockFromModule': 'jest.createMockFromModule',
     };
 
     return {


### PR DESCRIPTION
I've done for the simple route - hopefully jest won't have any big deprecations, but if so we can refactor.

closes #559 

/cc @cpojer - this should do as a codemod, tho I'm curious on if Facebook have any `x["y"]` syntax in your codebase 🤔