### PR TITLE
Update recommended ruleset

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ installations requiring long-term consistency.
 | [no-hooks](docs/rules/no-hooks.md)                                           | Disallow setup and teardown hooks                               |                  |              |
 | [no-identical-title](docs/rules/no-identical-title.md)                       | Disallow identical titles                                       | ![recommended][] |              |
 | [no-if](docs/rules/no-if.md)                                                 | Disallow conditional logic                                      |                  |              |
-| [no-interpolation-in-snapshots](docs/rules/no-interpolation-in-snapshots.md) | Disallow string interpolation inside snapshots                  |                  |              |
+| [no-interpolation-in-snapshots](docs/rules/no-interpolation-in-snapshots.md) | Disallow string interpolation inside snapshots                  | ![recommended][] |              |
 | [no-jasmine-globals](docs/rules/no-jasmine-globals.md)                       | Disallow Jasmine globals                                        | ![recommended][] | ![fixable][] |
 | [no-jest-import](docs/rules/no-jest-import.md)                               | Disallow importing Jest                                         | ![recommended][] |              |
 | [no-large-snapshots](docs/rules/no-large-snapshots.md)                       | disallow large snapshots                                        |                  |              |

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ installations requiring long-term consistency.
 | [valid-describe](docs/rules/valid-describe.md)                               | Enforce valid `describe()` callback                             | ![recommended][] |              |
 | [valid-expect](docs/rules/valid-expect.md)                                   | Enforce valid `expect()` usage                                  | ![recommended][] |              |
 | [valid-expect-in-promise](docs/rules/valid-expect-in-promise.md)             | Enforce having return statement when testing with promises      | ![recommended][] |              |
-| [valid-title](docs/rules/valid-title.md)                                     | Enforce valid titles                                            |                  | ![fixable][] |
+| [valid-title](docs/rules/valid-title.md)                                     | Enforce valid titles                                            | ![recommended][] | ![fixable][] |
 
 <!-- end rules list -->
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ installations requiring long-term consistency.
 | [lowercase-name](docs/rules/lowercase-name.md)                               | Enforce lowercase test names                                    |                  | ![fixable][] |
 | [no-alias-methods](docs/rules/no-alias-methods.md)                           | Disallow alias methods                                          | ![style][]       | ![fixable][] |
 | [no-commented-out-tests](docs/rules/no-commented-out-tests.md)               | Disallow commented out tests                                    | ![recommended][] |              |
-| [no-conditional-expect](docs/rules/no-conditional-expect.md)                 | Prevent calling `expect` conditionally                          |                  |              |
+| [no-conditional-expect](docs/rules/no-conditional-expect.md)                 | Prevent calling `expect` conditionally                          | ![recommended][] |              |
 | [no-deprecated-functions](docs/rules/no-deprecated-functions.md)             | Disallow use of deprecated functions                            | ![recommended][] | ![fixable][] |
 | [no-disabled-tests](docs/rules/no-disabled-tests.md)                         | Disallow disabled tests                                         | ![recommended][] |              |
 | [no-duplicate-hooks](docs/rules/no-duplicate-hooks.md)                       | Disallow duplicate setup and teardown hooks                     |                  |              |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ installations requiring long-term consistency.
 | [no-alias-methods](docs/rules/no-alias-methods.md)                           | Disallow alias methods                                          | ![style][]       | ![fixable][] |
 | [no-commented-out-tests](docs/rules/no-commented-out-tests.md)               | Disallow commented out tests                                    | ![recommended][] |              |
 | [no-conditional-expect](docs/rules/no-conditional-expect.md)                 | Prevent calling `expect` conditionally                          |                  |              |
-| [no-deprecated-functions](docs/rules/no-deprecated-functions.md)             | Disallow use of deprecated functions                            |                  | ![fixable][] |
+| [no-deprecated-functions](docs/rules/no-deprecated-functions.md)             | Disallow use of deprecated functions                            | ![recommended][] | ![fixable][] |
 | [no-disabled-tests](docs/rules/no-disabled-tests.md)                         | Disallow disabled tests                                         | ![recommended][] |              |
 | [no-duplicate-hooks](docs/rules/no-duplicate-hooks.md)                       | Disallow duplicate setup and teardown hooks                     |                  |              |
 | [no-export](docs/rules/no-export.md)                                         | Disallow using `exports` in files containing tests              | ![recommended][] |              |

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -70,7 +70,7 @@ Object {
       "jest/no-export": "error",
       "jest/no-focused-tests": "error",
       "jest/no-identical-title": "error",
-      "jest/no-jasmine-globals": "warn",
+      "jest/no-jasmine-globals": "error",
       "jest/no-jest-import": "error",
       "jest/no-mocks-import": "error",
       "jest/no-standalone-expect": "error",

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -80,6 +80,7 @@ Object {
       "jest/valid-describe": "error",
       "jest/valid-expect": "error",
       "jest/valid-expect-in-promise": "error",
+      "jest/valid-title": "error",
     },
   },
   "style": Object {

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -71,6 +71,7 @@ Object {
       "jest/no-export": "error",
       "jest/no-focused-tests": "error",
       "jest/no-identical-title": "error",
+      "jest/no-interpolation-in-snapshots": "error",
       "jest/no-jasmine-globals": "error",
       "jest/no-jest-import": "error",
       "jest/no-mocks-import": "error",

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -66,6 +66,7 @@ Object {
     "rules": Object {
       "jest/expect-expect": "warn",
       "jest/no-commented-out-tests": "warn",
+      "jest/no-deprecated-functions": "error",
       "jest/no-disabled-tests": "warn",
       "jest/no-export": "error",
       "jest/no-focused-tests": "error",

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -66,6 +66,7 @@ Object {
     "rules": Object {
       "jest/expect-expect": "warn",
       "jest/no-commented-out-tests": "warn",
+      "jest/no-conditional-expect": "error",
       "jest/no-deprecated-functions": "error",
       "jest/no-disabled-tests": "warn",
       "jest/no-export": "error",

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -12,7 +12,7 @@ export default createRule({
     docs: {
       description: 'Prevent calling `expect` conditionally',
       category: 'Best Practices',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       conditionalExpect: 'Avoid calling `expect` conditionally`',

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -66,7 +66,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow use of deprecated functions',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       deprecatedFunction:

--- a/src/rules/no-interpolation-in-snapshots.ts
+++ b/src/rules/no-interpolation-in-snapshots.ts
@@ -7,7 +7,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow string interpolation inside snapshots',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       noInterpolation: 'Do not use string interpolation inside of snapshots',

--- a/src/rules/no-jasmine-globals.ts
+++ b/src/rules/no-jasmine-globals.ts
@@ -12,7 +12,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow Jasmine globals',
-      recommended: 'warn',
+      recommended: 'error',
     },
     messages: {
       illegalGlobal:

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -81,7 +81,7 @@ export default createRule<[Options], MessageIds>({
     docs: {
       category: 'Best Practices',
       description: 'Enforce valid titles',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       titleMustBeString: 'Title must be a string',


### PR DESCRIPTION
Let the games begin! 🎉 

The following rules are not in the recommended:
consistent-test-it
lowercase-name
no-alias-methods*
no-duplicate-hooks
no-expect-resolves
no-hooks
no-if
no-large-snapshots
no-test-return-statement
no-truthy-falsy
prefer-called-with
prefer-expect-assertions
prefer-hooks-on-top
prefer-inline-snapshots
prefer-spy-on
prefer-strict-equal
prefer-to-be-null*
prefer-to-be-undefined*
prefer-to-contain*
prefer-to-have-length*
prefer-todo
require-top-level-describe
require-to-throw-message
valid-title

*: in `style` ruleset

I think we should have `valid-title` as a recommended.
I wouldn't mind having `prefer-strict-equal` as recommended too, but don't think it's as important.