### PR TITLE
feat: create `no-restricted-matchers` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ installations requiring long-term consistency.
 | [no-jest-import](docs/rules/no-jest-import.md)                         | Disallow importing Jest                                         | ![recommended][] |              |
 | [no-large-snapshots](docs/rules/no-large-snapshots.md)                 | disallow large snapshots                                        |                  |              |
 | [no-mocks-import](docs/rules/no-mocks-import.md)                       | Disallow manually importing from **mocks**                      | ![recommended][] |              |
+| [no-restricted-matchers](docs/rules/no-restricted-matchers.md)         | Disallow specific matchers & modifiers                          |                  |              |
 | [no-standalone-expect](docs/rules/no-standalone-expect.md)             | Prevents expects that are outside of an it or test block.       | ![recommended][] |              |
 | [no-test-callback](docs/rules/no-test-callback.md)                     | Avoid using a callback in asynchronous tests                    | ![recommended][] | ![fixable][] |
 | [no-test-prefixes](docs/rules/no-test-prefixes.md)                     | Use `.only` and `.skip` over `f` and `x`                        | ![recommended][] | ![fixable][] |

--- a/docs/rules/no-restricted-matchers.md
+++ b/docs/rules/no-restricted-matchers.md
@@ -1,0 +1,47 @@
+# Disallow specific matchers & modifiers (`no-restricted-matchers`)
+
+This rule bans specific matchers & modifiers from being used, and can suggest
+alternatives.
+
+## Rule Details
+
+Bans are expressed in the form of a map, with the value being either a string
+message to be shown, or `null` if the default rule message should be used.
+
+Both matchers, modifiers, and chains of the two are checked, allowing for
+specific variations of a matcher to be banned if desired.
+
+By default, this map is empty, meaning no matchers or modifiers are banned.
+
+For example:
+
+```json
+{
+  "jest/no-restricted-matchers": [
+    "error",
+    {
+      "toBeFalsy": null,
+      "resolves": "Use `expect(await promise)` instead.",
+      "not.toHaveBeenCalledWith": null
+    }
+  ]
+}
+```
+
+Examples of **incorrect** code for this rule with the above configuration
+
+```js
+it('is false', () => {
+  expect(a).toBeFalsy();
+});
+
+it('resolves', async () => {
+  await expect(myPromise()).resolves.toBe(true);
+});
+
+describe('when an error happens', () => {
+  it('does not upload the file', async () => {
+    expect(uploadFileMock).not.toHaveBeenCalledWith('file.name');
+  });
+});
+```

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -28,6 +28,7 @@ Object {
       "jest/no-jest-import": "error",
       "jest/no-large-snapshots": "error",
       "jest/no-mocks-import": "error",
+      "jest/no-restricted-matchers": "error",
       "jest/no-standalone-expect": "error",
       "jest/no-test-callback": "error",
       "jest/no-test-prefixes": "error",

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import plugin from '../';
 
 const ruleNames = Object.keys(plugin.rules);
-const numberOfRules = 41;
+const numberOfRules = 42;
 
 describe('rules', () => {
   it('should have a corresponding doc for each rule', () => {

--- a/src/rules/__tests__/no-restricted-matchers.test.ts
+++ b/src/rules/__tests__/no-restricted-matchers.test.ts
@@ -1,0 +1,185 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import resolveFrom from 'resolve-from';
+import rule from '../no-restricted-matchers';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parserOptions: {
+    ecmaVersion: 2017,
+  },
+});
+
+ruleTester.run('no-restricted-matchers', rule, {
+  valid: [
+    'expect(a).toHaveBeenCalled()',
+    'expect(a).not.toHaveBeenCalled()',
+    'expect(a).toHaveBeenCalledTimes()',
+    'expect(a).toHaveBeenCalledWith()',
+    'expect(a).toHaveBeenLastCalledWith()',
+    'expect(a).toHaveBeenNthCalledWith()',
+    'expect(a).toHaveReturned()',
+    'expect(a).toHaveReturnedTimes()',
+    'expect(a).toHaveReturnedWith()',
+    'expect(a).toHaveLastReturnedWith()',
+    'expect(a).toHaveNthReturnedWith()',
+    'expect(a).toThrow()',
+    'expect(a).rejects;',
+    'expect(a);',
+    {
+      code: 'expect(a).resolves',
+      options: [{ not: null }],
+    },
+    {
+      code: 'expect(a).toBe(b)',
+      options: [{ 'not.toBe': null }],
+    },
+    {
+      code: 'expect(a)["toBe"](b)',
+      options: [{ 'not.toBe': null }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'expect(a).toBe(b)',
+      options: [{ toBe: null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            chain: 'toBe',
+          },
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(a)["toBe"](b)',
+      options: [{ toBe: null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            chain: 'toBe',
+          },
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(a).not',
+      options: [{ not: null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            chain: 'not',
+          },
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(a).not.toBe(b)',
+      options: [{ not: null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            chain: 'not',
+          },
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(a).not.toBe(b)',
+      options: [{ 'not.toBe': null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            chain: 'not.toBe',
+          },
+          endColumn: 19,
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(a).toBe(b)',
+      options: [{ toBe: 'Prefer `toStrictEqual` instead' }],
+      errors: [
+        {
+          messageId: 'restrictedChainWithMessage',
+          data: {
+            message: 'Prefer `toStrictEqual` instead',
+            chain: 'toBe',
+          },
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: `
+        test('some test', async () => {
+          await expect(Promise.resolve(1)).resolves.toBe(1);
+         });
+      `,
+      options: [{ resolves: 'Use `expect(await promise)` instead.' }],
+      errors: [
+        {
+          messageId: 'restrictedChainWithMessage',
+          data: {
+            message: 'Use `expect(await promise)` instead.',
+            chain: 'resolves',
+          },
+          endColumn: 52,
+          column: 44,
+        },
+      ],
+    },
+    {
+      code: 'expect(Promise.resolve({})).rejects.toBeFalsy()',
+      options: [{ toBeFalsy: null }],
+      errors: [
+        {
+          messageId: 'restrictedChain',
+          data: {
+            message: null,
+            chain: 'toBeFalsy',
+          },
+          endColumn: 46,
+          column: 37,
+        },
+      ],
+    },
+    {
+      code: "expect(uploadFileMock).not.toHaveBeenCalledWith('file.name')",
+      options: [
+        { 'not.toHaveBeenCalledWith': 'Use not.toHaveBeenCalled instead' },
+      ],
+      errors: [
+        {
+          messageId: 'restrictedChainWithMessage',
+          data: {
+            message: 'Use not.toHaveBeenCalled instead',
+            chain: 'not.toHaveBeenCalledWith',
+          },
+          endColumn: 48,
+          column: 24,
+        },
+      ],
+    },
+  ],
+});

--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -1,0 +1,97 @@
+import { createRule, isExpectCall, parseExpectCall } from './utils';
+
+export default createRule<
+  [Record<string, string | null>],
+  'restrictedChain' | 'restrictedChainWithMessage'
+>({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Disallow specific matchers & modifiers',
+      recommended: false,
+    },
+    type: 'suggestion',
+    schema: [
+      {
+        type: 'object',
+        additionalProperties: {
+          type: ['string', 'null'],
+        },
+      },
+    ],
+    messages: {
+      restrictedChain: 'Use of `{{ chain }}` is disallowed',
+      restrictedChainWithMessage: '{{ message }}',
+    },
+  },
+  defaultOptions: [{}],
+  create(context, [restrictedChains]) {
+    return {
+      CallExpression(node) {
+        if (!isExpectCall(node)) {
+          return;
+        }
+
+        const { matcher, modifier } = parseExpectCall(node);
+
+        if (matcher) {
+          const chain = matcher.name;
+
+          if (chain in restrictedChains) {
+            const message = restrictedChains[chain];
+
+            context.report({
+              messageId: message
+                ? 'restrictedChainWithMessage'
+                : 'restrictedChain',
+              data: { message, chain },
+              node: matcher.node.property,
+            });
+
+            return;
+          }
+        }
+
+        if (modifier) {
+          const chain = modifier.name;
+
+          if (chain in restrictedChains) {
+            const message = restrictedChains[chain];
+
+            context.report({
+              messageId: message
+                ? 'restrictedChainWithMessage'
+                : 'restrictedChain',
+              data: { message, chain },
+              node: modifier.node.property,
+            });
+
+            return;
+          }
+        }
+
+        if (matcher && modifier) {
+          const chain = `${modifier.name}.${matcher.name}`;
+
+          if (chain in restrictedChains) {
+            const message = restrictedChains[chain];
+
+            context.report({
+              messageId: message
+                ? 'restrictedChainWithMessage'
+                : 'restrictedChain',
+              data: { message, chain },
+              loc: {
+                start: modifier.node.property.loc.start,
+                end: matcher.node.property.loc.end,
+              },
+            });
+
+            return;
+          }
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
This rule lets us deprecate & drop at least the following:
  * `no-truthy-falsy`
  * `no-expect-resolves`
  * `prefer-inline-snapshots`

In theory we could drop a few more, but I think they have their own context that makes them worth keeping:

* `prefer-called-with`: I've not come up with a nice syntax that lets you ban a matcher *unless* it has a modifier, so you could ban `toHaveBeenCalled` but that would also ban `not.toHaveBeenCalled`.
* `prefer-strict-equals`: while this can be handled by `ban-matchers`, I feel like this is one we want to recommend (so having its own rule gives it a name + specific documentation), and provide an autofix/suggestion for (more on this below)
* `no-alias-methods`: again as with the case of `prefer-strict-equals`, this has a fixer, and a history behind it.

### The case for syntax

This rule lets you ban `*.modifier.matcher` & `*.matcher` but not `expect.matcher`. The ability to ban just `modifier.matcher` comes naturally, but I couldn't come up with a nice way of letting you ban only a matcher without any modifiers; in saying that I don't think there's a lot of gain in being able to say 

### The case for naming

While this rule is called `ban-matchers`, it does let you ban modifiers as well, and in the code I've referred to the actual things that are banned as "chains".

I've named the rule `ban-matchers` as "matchers" I feel is a commonly understood and used name, and so unlikely to cause confusion - it also has the desired effect of gelling with its sister `@typescript-eslint` rule [`ban-types`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md)

(In saying that I realise the `Expect` page does refer to them all under the "methods" headers, and we do have `no-alias-methods`, so maybe "methods" is the better one to use - the more I type the more I think maybe thats the better name, except its a bit generic for what it's implying. "ban-expect-methods" maybe? 🤔)

At the very least, I struggled to come up with a more catch-all term for `not`, `resolves`, & `rejects` than "modifier", which I don't think it used a lot, and so felt it would just be overly confusing to try and pick an exact name.

### The case for `no-alias-methods`

Having looked over this rule, I think @SimenB a push should be made to deprecate & later remove the alias matchers from jest core. 

Here's my thinking:

* we include the rule in the `style` ruleset, which while not the same as being in the `recommended` rule set, still counts for something in my eyes i.e we don't have `no-truthy-falsy` or `prefer-called-with` - both rules that I personally think are Good, and help strengthen your tests, but didn't make the cut that `no-alias-methods` did (in saying that, maybe they should be in the `style` ruleset?)
* the rule itself uses "the canonical name" in both it's description & documentation, indicating the prefered names.
* jest itself is looking to slim down; while there aliases will be a small drop in the ocean, they're a drop nonetheless, and one that I believe can actually still be offered by use of `expect.extend` in a start script to restore the aliased matchers - taking that one further, you could publish it as a package on npm; jest could even do this as `@jest/expect-aliases` (or something better named - actually better yet they can be brought into `jest-extended`).
* finally, imo the canonical name is more grammatically correct (in the situations I've used & can think of - there might be edge cases I've not considered?); while it can be argued they're shorted, I don't think sacrificing readability (especially when you consider non-native speakers) for the sake of saving a few characters in your test files to be all that worth it.

I don't know the history behind the aliases, and happy to be schooled on them, but I know that jest has rejected a fair few matchers in the past to keep things lean and only include the batteries it needs.

This is conversation that definitely happen over at jest, and happy to port it over, but wanted to raise it here as I felt this rule + the addition of `no-deprecated-functions` provided a good launching point for kicking off this discussion.

Going down this path would mean folding `no-alias-methods` into `no-deprecated-functions`.

### The case for options

Currently we use the second options parameter as a map for the banned matchers, which takes either `null` or a string to be used as a custom message.

This means if we ever want to add options, we'd have to do a deprecation & migration.
This also means that if we wanted to recommend `ban-matchers`, it would be slightly more annoying for people to extend off.

As such, we could go the same vein as [`@typescript-eslint/ban-types`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md):

We have a `matchers` property that takes the map, and then can add additional properties i.e `extendDefaults` (with the "defaults" being any bans we recommend).

While I don't have any bans to recommend off the top of my head, this would *also* provide a way that we could collapse `no-alias-methods` into this rule, by having a `banAliasMethods` option.

### The case for fixing

`@typescript-eslint/ban-types` supports a `fixWith` option which it uses for providing its fixer.

I think having this is less important for us as jest has a far smaller number of matchers, and an even smaller number of matchers that can be swapped out without being a little dangerous.

In saying that, that's a good reason to look to use the suggestion api to provide a quick-fix.

We could take an object instead of a string for the value of the key-value pair:

```
interface BannedMatcher {
  message?: string | null;
  suggestedReplacement?: string;
}
```

This would let us fold in `prefer-strict-equal` into `ban-matchers (tho we'd still weaken the documentation).

This would increase the rules complexity, but still be relatively easy to do.

closes #330 
closes #545
closes #312
closes #234
closes #230