### PR TITLE
fix(no-large-snapshots): run on files of any type

### DIFF
--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -42,11 +42,6 @@ ruleTester.run('no-large-snapshots', rule, {
       ),
     },
     {
-      // "it should return an empty object for non snapshot files"
-      filename: 'mock.jsx',
-      code: generateExpectInlineSnapsCode(50, 'toMatchInlineSnapshot'),
-    },
-    {
       filename: 'mock.jsx',
       code: generateExpectInlineSnapsCode(20, 'toMatchInlineSnapshot'),
       options: [

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -115,29 +115,24 @@ export default createRule<[RuleOptions], MessageId>({
           reportOnViolation(context, node, options);
         },
       };
-    } else if (context.getFilename().endsWith('.js')) {
-      return {
-        CallExpression(node) {
-          if (
-            'property' in node.callee &&
-            (isSupportedAccessor(
-              node.callee.property,
-              'toMatchInlineSnapshot',
-            ) ||
-              isSupportedAccessor(
-                node.callee.property,
-                'toThrowErrorMatchingInlineSnapshot',
-              ))
-          ) {
-            reportOnViolation(context, node, {
-              ...options,
-              maxSize: options.inlineMaxSize ?? options.maxSize,
-            });
-          }
-        },
-      };
     }
 
-    return {};
+    return {
+      CallExpression(node) {
+        if (
+          'property' in node.callee &&
+          (isSupportedAccessor(node.callee.property, 'toMatchInlineSnapshot') ||
+            isSupportedAccessor(
+              node.callee.property,
+              'toThrowErrorMatchingInlineSnapshot',
+            ))
+        ) {
+          reportOnViolation(context, node, {
+            ...options,
+            maxSize: options.inlineMaxSize ?? options.maxSize,
+          });
+        }
+      },
+    };
   },
 });


### PR DESCRIPTION
Adjusts `no-large-snapshots` so that it checks files of any type.

closes #370