### PR TITLE
feat(no-standalone-expect): support `additionalTestBlockFunctions`

### DIFF
--- a/docs/rules/no-standalone-expect.md
+++ b/docs/rules/no-standalone-expect.md
@@ -64,6 +64,36 @@ describe('a test', () => {
 thought the `expect` will not execute. Rely on a rule like no-unused-vars for
 this case.
 
+### Options
+
+#### `additionalTestBlockFunctions`
+
+This array can be used to specify the names of functions that should also be
+treated as test blocks:
+
+```json
+{
+  "rules": {
+    "jest/no-standalone-expect": [
+      "error",
+      { "additionalTestBlockFunctions": ["each.test"] }
+    ]
+  }
+}
+```
+
+The following is _correct_ when using the above configuration:
+
+```js
+each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+]).test('returns the result of adding %d to %d', (a, b, expected) => {
+  expect(a + b).toBe(expected);
+});
+```
+
 ## When Not To Use It
 
 Don't use this rule on non-jest test files.

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -34,8 +34,86 @@ ruleTester.run('no-standalone-expect', rule, {
     'it.only("an only", value => { expect(value).toBe(true); });',
     'it.concurrent("an concurrent", value => { expect(value).toBe(true); });',
     'describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });',
+    {
+      code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true));
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['t'] }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['each.test'] }],
+    },
   ],
   invalid: [
+    {
+      code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true));
+        });
+      `,
+      errors: [{ endColumn: 42, column: 30, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        describe('scenario', () => {
+          const t = Math.random() ? it.only : it;
+          t('testing', () => expect(true));
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: undefined }],
+      errors: [{ endColumn: 42, column: 30, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      errors: [{ endColumn: 24, column: 11, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['each'] }],
+      errors: [{ endColumn: 24, column: 11, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: `
+        each([
+          [1, 1, 2],
+          [1, 2, 3],
+          [2, 1, 3],
+        ]).test('returns the result of adding %d to %d', (a, b, expected) => {
+          expect(a + b).toBe(expected);
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['test'] }],
+      errors: [{ endColumn: 24, column: 11, messageId: 'unexpectedExpect' }],
+    },
     {
       code: 'describe("a test", () => { expect(1).toBe(1); });',
       errors: [{ endColumn: 37, column: 28, messageId: 'unexpectedExpect' }],


### PR DESCRIPTION
closes #551
closes #354

 I've attempted to make this rules implementation a bit nicer too, since it had a slowly growing `if` condition that I think at least reads a bit better now since it "flows" downwards a bit nicer (imo).

@SimenB would you object to adding `padding-line-between-statements` with the config used [here](https://github.com/ackama/eslint-config-ackama/blob/master/index.js#L128-L155)?

(it requires a newline to be before a `return`, and after assignment blocks i.e `const`).

I don't think we have any big offenders, but I find it makes things a lot more readable