### PR TITLE
fix: add `fail` to globals

### DIFF
--- a/src/globals.json
+++ b/src/globals.json
@@ -5,6 +5,7 @@
   "beforeEach": false,
   "describe": false,
   "expect": false,
+  "fail": false,
   "fit": false,
   "it": false,
   "jasmine": false,


### PR DESCRIPTION
This adds `fail` as a supported global.