### PR TITLE
fix(expect-expect): stop reporting whole test body

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -109,7 +109,7 @@ export default createRule<
       },
       'Program:exit'() {
         unchecked.forEach(node =>
-          context.report({ messageId: 'noAssertions', node }),
+          context.report({ messageId: 'noAssertions', node: node.callee }),
         );
       },
     };


### PR DESCRIPTION
The expect-expect rule is quite annoying while you're writing a test, because until you put an assertion in it (often as the last thing you do), the entire test is marked as an error in IDEs which visually hides other lint/compiler errors. This makes the rule report on the `test`/`it` (callee) part rather than the whole `test('foo', () => {...})` expression.

Before:
![image](https://user-images.githubusercontent.com/15040698/83254593-0b40c700-a17d-11ea-91a6-d8f6762ab9af.png)

After:
![image](https://user-images.githubusercontent.com/15040698/83256748-00883100-a181-11ea-8a41-12a619b14db4.png)

Opening this as a draft because I imagine some tests will fail - I made this change via the GitHub UI, I'll see what goes red when opening as a PR.