### PR TITLE
test: ensure `cwd` is restored after each test

### DIFF
--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -10,6 +10,11 @@ import rule, {
 
 const ruleTester = new TSESLint.RuleTester();
 
+// pin the original cwd so that we can restore it after each test
+const projectDir = process.cwd();
+
+afterEach(() => process.chdir(projectDir));
+
 /**
  * Makes a new temp directory, prefixed with `eslint-plugin-jest-`
  *


### PR DESCRIPTION
fixes #591

I'm really curious to why this only failed on Node 8 & 10 - my guess is that `Module.createRequire` behaviour works slightly differently than the fallback methods, but haven't tested that in full.