### PR TITLE
NEW RULE - Require test case titles to have a hashtag

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ installations requiring long-term consistency.
 | [prefer-to-contain](docs/rules/prefer-to-contain.md)                   | Suggest using `toContain()`                                     | ![style][]       | ![fixable][] |
 | [prefer-to-have-length](docs/rules/prefer-to-have-length.md)           | Suggest using `toHaveLength()`                                  | ![style][]       | ![fixable][] |
 | [prefer-todo](docs/rules/prefer-todo.md)                               | Suggest using `test.todo`                                       |                  | ![fixable][] |
+| [require-hashtag-title](docs/rules/require-hashtag-title.md)           | Enforce the usage of hashtag on the test cases title            |                  |              |
 | [require-to-throw-message](docs/rules/require-to-throw-message.md)     | Require a message for `toThrow()`                               |                  |              |
 | [require-top-level-describe](docs/rules/require-top-level-describe.md) | Prevents test cases and hooks to be outside of a describe block |                  |              |
 | [valid-describe](docs/rules/valid-describe.md)                         | Enforce valid `describe()` callback                             | ![recommended][] |              |

--- a/docs/rules/require-hashtag-title.md
+++ b/docs/rules/require-hashtag-title.md
@@ -1,0 +1,64 @@
+# Enforce the usage of hashtag on the test cases title (`require-hashtag-title`)
+
+Checks that the title of `it()` blocks are valid by ensuring that titles have at
+least one hashtag to mark it. This is a best practice in JS testing as mentioned
+[here](https://github.com/goldbergyoni/javascript-testing-best-practices#-%EF%B8%8F-111-tag-your-tests).
+
+## Rule Details
+
+Giving your test cases a tag make your life easier when your project grew bigger
+and/or you have many different types of tests. When your tests have tags, you
+can easily choose which kind or context of tests you want to run simply
+[telling Jest what is the pattern](https://jestjs.io/docs/en/cli.html#testnamepattern-regex).
+But also it is hard sometimes to remember to tag your test cases, and that is
+why this rule was made for.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('no tag at all', function() {});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it('#test', function() {});
+
+it('#test in the beginning', function() {});
+
+it('in the end #test', function() {});
+
+it('in the #test middle', function() {});
+
+it('many #different #tags', function() {});
+```
+
+## Options
+
+```ts
+interface {
+  allowedHashtags?: string[];
+}
+```
+
+#### `allowedHashtags`
+
+Default: `[]`
+
+A string array of words that are the only allowed to be used in test titles.
+Matching is not case-sensitive, and looks for complete words. If an empty array
+(default value) is provided, it will accept any word as a valid tag:
+
+Examples of **incorrect** code using `allowedHashtags`:
+
+```js
+// with allowedHashtags: ['unit', 'sanity']
+it("another #different tag", function () {}),
+```
+
+Examples of **correct** code when using `allowedHashtags`:
+
+```js
+// with allowedHashtags: ['unit', 'sanity', 'happy_path']
+it("should return the correct value #unit #happy_path", function () {}),
+```

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -46,6 +46,7 @@ Object {
       "jest/prefer-to-contain": "error",
       "jest/prefer-to-have-length": "error",
       "jest/prefer-todo": "error",
+      "jest/require-hashtag-title": "error",
       "jest/require-to-throw-message": "error",
       "jest/require-top-level-describe": "error",
       "jest/valid-describe": "error",

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import plugin from '../';
 
 const ruleNames = Object.keys(plugin.rules);
-const numberOfRules = 42;
+const numberOfRules = 43;
 
 describe('rules', () => {
   it('should have a corresponding doc for each rule', () => {

--- a/src/rules/__tests__/require-hashtag-title.test.ts
+++ b/src/rules/__tests__/require-hashtag-title.test.ts
@@ -1,0 +1,74 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import resolveFrom from 'resolve-from';
+import rule from '../require-hashtag-title';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parserOptions: {
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run('require-hashtag-title', rule, {
+  valid: [
+    'randomFunction()',
+    'foo.bar()',
+    'it()',
+    'it(42, function () {})',
+    'it("#test")',
+    'it("#test", function () {})',
+    'it("#test in the beginning", function () {})',
+    'it("in the end #test", function () {})',
+    'it("in the #test middle", function () {})',
+  ],
+  invalid: [
+    {
+      code: 'it("no tag at all", function () {})',
+      errors: [
+        {
+          messageId: 'noTagFound',
+        },
+      ],
+    },
+    {
+      code: 'it("", function () {})',
+      errors: [
+        {
+          messageId: 'noTagFound',
+        },
+      ],
+    },
+    {
+      code: 'it("# wrong tag", function () {})',
+      errors: [
+        {
+          messageId: 'noTagFound',
+        },
+      ],
+    },
+    {
+      code: 'it("wrong tag again #", function () {})',
+      errors: [
+        {
+          messageId: 'noTagFound',
+        },
+      ],
+    },
+    {
+      code: 'it("wrong # tag", function () {})',
+      errors: [
+        {
+          messageId: 'noTagFound',
+        },
+      ],
+    },
+    {
+      code: 'it("#", function () {})',
+      errors: [
+        {
+          messageId: 'noTagFound',
+        },
+      ],
+    },
+  ],
+});

--- a/src/rules/__tests__/require-hashtag-title.test.ts
+++ b/src/rules/__tests__/require-hashtag-title.test.ts
@@ -110,8 +110,13 @@ ruleTester.run(
         options: [{ allowedHashtags: ['unit', 'smoke'] }],
       },
       {
-        code: 'it("uppet cased tag #Unit #SMOKE", function () {})',
+        code: 'it("upper cased tag #Unit #SMOKE", function () {})',
         options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code:
+          'it("should return the correct value #unit #happy-path", function () {})',
+        options: [{ allowedHashtags: ['unit', 'happy-path', 'smoke'] }],
       },
     ],
     invalid: [

--- a/src/rules/__tests__/require-hashtag-title.test.ts
+++ b/src/rules/__tests__/require-hashtag-title.test.ts
@@ -20,6 +20,7 @@ ruleTester.run('require-hashtag-title', rule, {
     'it("#test in the beginning", function () {})',
     'it("in the end #test", function () {})',
     'it("in the #test middle", function () {})',
+    'it("many #different #tags", function () {})',
   ],
   invalid: [
     {
@@ -72,3 +73,143 @@ ruleTester.run('require-hashtag-title', rule, {
     },
   ],
 });
+
+ruleTester.run(
+  'require-hashtag-title with allowedHashtags=["unit", "smoke"]',
+  rule,
+  {
+    valid: [
+      {
+        code: 'randomFunction()',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      { code: 'foo.bar()', options: [{ allowedHashtags: ['unit', 'smoke'] }] },
+      { code: 'it()', options: [{ allowedHashtags: ['unit', 'smoke'] }] },
+      {
+        code: 'it(42, function () {})',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("#unit")',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("#unit #smoke")',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("#unit in the beginning", function () {})',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("in the end #smoke", function () {})',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("in the #unit middle", function () {})',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("uppet cased tag #Unit #SMOKE", function () {})',
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+    ],
+    invalid: [
+      {
+        code: 'it("no tag at all", function () {})',
+        errors: [
+          {
+            messageId: 'noTagFound',
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("", function () {})',
+        errors: [
+          {
+            messageId: 'noTagFound',
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("# wrong tag", function () {})',
+        errors: [
+          {
+            messageId: 'noTagFound',
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("wrong tag again #", function () {})',
+        errors: [
+          {
+            messageId: 'noTagFound',
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("wrong # tag", function () {})',
+        errors: [
+          {
+            messageId: 'noTagFound',
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("#", function () {})',
+        errors: [
+          {
+            messageId: 'noTagFound',
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("#another tag", function () {})',
+        errors: [
+          {
+            messageId: 'disallowedTag',
+            data: { tag: 'another' },
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("another #different tag", function () {})',
+        errors: [
+          {
+            messageId: 'disallowedTag',
+            data: { tag: 'different' },
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+      {
+        code: 'it("another different #tag", function () {})',
+        errors: [
+          {
+            messageId: 'disallowedTag',
+            data: { tag: 'tag' },
+          },
+        ],
+        options: [{ allowedHashtags: ['unit', 'smoke'] }],
+      },
+
+      {
+        code: 'it("one #wrong and one #ok", function () {})',
+        errors: [
+          {
+            messageId: 'disallowedTag',
+            data: { tag: 'wrong' },
+          },
+        ],
+        options: [{ allowedHashtags: ['ok'] }],
+      },
+    ],
+  },
+);

--- a/src/rules/require-hashtag-title.ts
+++ b/src/rules/require-hashtag-title.ts
@@ -12,8 +12,7 @@ export default createRule({
   meta: {
     docs: {
       category: 'Best Practices',
-      description:
-        'Enforce the usage of hashtag (#something) on the test cases title',
+      description: 'Enforce the usage of hashtag on the test cases title',
       recommended: false,
     },
     messages: {
@@ -38,8 +37,8 @@ export default createRule({
   defaultOptions: [{ allowedHashtags: [] }],
   create(context, [{ allowedHashtags }]) {
     const words = `(${allowedHashtags.join('|')})`;
-    const checkAllowedHashtagsRegex = new RegExp(`.*#${words}\\s`, 'ui');
-    const checkHashtagsRegex = new RegExp(`.*#\\w+`, 'ui');
+    const checkAllowedHashtagsRegex = new RegExp(`.*#${words}(\\s|$)`, 'ui');
+    const checkHashtagsRegex = new RegExp(`.*#(\\w+)`, 'ui');
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
@@ -66,7 +65,6 @@ export default createRule({
 
         const matches = checkHashtagsRegex.exec(title);
         if (matches) {
-          console.log(matches[0], matches[1]);
           if (allowedHashtags.length === 0) {
             return;
           }

--- a/src/rules/require-hashtag-title.ts
+++ b/src/rules/require-hashtag-title.ts
@@ -66,6 +66,7 @@ export default createRule({
         }
 
         const [argument] = getJestFunctionArguments(node);
+
         if (!argument) {
           return;
         }
@@ -75,6 +76,7 @@ export default createRule({
         }
 
         const title = getStringValue(argument);
+
         if (checkHashtagsRegex.test(title)) {
           if (sanitized.length > 0) {
             checkHashtagsRegex.lastIndex = 0;

--- a/src/rules/require-hashtag-title.ts
+++ b/src/rules/require-hashtag-title.ts
@@ -7,6 +7,24 @@ import {
   isTestCase,
 } from './utils';
 
+const getAllTags = (title: string, regex: RegExp): string[] => {
+  const tags: string[] = [];
+  let match = regex.exec(title);
+
+  while (match) {
+    const tag = match[0]
+      .trim()
+      .toLowerCase()
+      .replace('#', '');
+
+    tags.push(tag);
+
+    match = regex.exec(title);
+  }
+
+  return tags;
+};
+
 export default createRule({
   name: __filename,
   meta: {
@@ -36,9 +54,10 @@ export default createRule({
   },
   defaultOptions: [{ allowedHashtags: [] }],
   create(context, [{ allowedHashtags }]) {
-    const words = `(${allowedHashtags.join('|')})`;
-    const checkAllowedHashtagsRegex = new RegExp(`.*#${words}(\\s|$)`, 'ui');
-    const checkHashtagsRegex = new RegExp(`.*#(\\w+)`, 'ui');
+    const sanitized = allowedHashtags
+      .filter((s: string) => /^\w+/iu.test(s))
+      .map((s: string) => s.toLowerCase().trim());
+    const checkHashtagsRegex = /(?:\s|^)#[A-Za-z0-9-._]+(?:\s|$)/giu;
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
@@ -56,30 +75,29 @@ export default createRule({
         }
 
         const title = getStringValue(argument);
-        if (
-          allowedHashtags.length > 0 &&
-          checkAllowedHashtagsRegex.test(title)
-        ) {
-          return;
-        }
+        if (checkHashtagsRegex.test(title)) {
+          if (sanitized.length > 0) {
+            checkHashtagsRegex.lastIndex = 0;
+            const tags = getAllTags(title, checkHashtagsRegex);
 
-        const matches = checkHashtagsRegex.exec(title);
-        if (matches) {
-          if (allowedHashtags.length === 0) {
-            return;
+            for (const tag of tags) {
+              if (!sanitized.includes(tag)) {
+                context.report({
+                  messageId: 'disallowedTag',
+                  data: {
+                    tag,
+                  },
+                  node: argument,
+                  loc: argument.loc,
+                });
+              }
+            }
           }
-
-          context.report({
-            messageId: 'disallowedTag',
-            data: {
-              tag: matches[1],
-            },
-            node: argument,
-          });
         } else {
           context.report({
             messageId: 'noTagFound',
             node: argument,
+            loc: argument.loc,
           });
         }
       },

--- a/src/rules/require-hashtag-title.ts
+++ b/src/rules/require-hashtag-title.ts
@@ -1,0 +1,90 @@
+import { TSESTree } from '@typescript-eslint/experimental-utils';
+import {
+  createRule,
+  getJestFunctionArguments,
+  getStringValue,
+  isStringNode,
+  isTestCase,
+} from './utils';
+
+export default createRule({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description:
+        'Enforce the usage of hashtag (#something) on the test cases title',
+      recommended: false,
+    },
+    messages: {
+      noTagFound: 'Title must contain at least one hashtag',
+      disallowedTag: '"#{{ tag }}" is not an allowed hashtag.',
+    },
+    type: 'problem',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowedHashtags: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [{ allowedHashtags: [] }],
+  create(context, [{ allowedHashtags }]) {
+    const words = `(${allowedHashtags.join('|')})`;
+    const checkAllowedHashtagsRegex = new RegExp(`.*#${words}\\s`, 'ui');
+    const checkHashtagsRegex = new RegExp(`.*#\\w+`, 'ui');
+
+    return {
+      CallExpression(node: TSESTree.CallExpression) {
+        if (!isTestCase(node)) {
+          return;
+        }
+
+        const [argument] = getJestFunctionArguments(node);
+        if (!argument) {
+          return;
+        }
+
+        if (!isStringNode(argument)) {
+          return;
+        }
+
+        const title = getStringValue(argument);
+        if (
+          allowedHashtags.length > 0 &&
+          checkAllowedHashtagsRegex.test(title)
+        ) {
+          return;
+        }
+
+        const matches = checkHashtagsRegex.exec(title);
+        if (matches) {
+          console.log(matches[0], matches[1]);
+          if (allowedHashtags.length === 0) {
+            return;
+          }
+
+          context.report({
+            messageId: 'disallowedTag',
+            data: {
+              tag: matches[1],
+            },
+            node: argument,
+          });
+        } else {
+          context.report({
+            messageId: 'noTagFound',
+            node: argument,
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
Hello all, I got an idea about a new rule, as the title says, to require the title of the `it()` blocks to have at least one hashtag (e.g. this is a **#unit** test). In the projects that I work, I always try to keep consistency and give a hashtag to all of my tests, to make it easy for me to choose which kind of tests I want to run, or maybe the context of the tests that I want to be run. But it is fairly easy to forget to put the hashtag on every test, especially when you create a lot of tests as on the TDD approach.

Also, I added an option to set the only allowed hashtags, to help to keep a more strict consistency between the tests:
```js
{
    "allowedHasgtags": ["unit", "integration", "e2e"]
}
```

As I am a little forgot guy, I would love to have such a rule to help me when I am writing my test cases. Hope you guys like it :smiley: 