### PR TITLE
chore: replace scripts with single `prepack` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,8 @@
     "build": "babel --extensions .js,.ts src --out-dir lib --copy-files",
     "postbuild": "rimraf lib/__tests__ lib/**/__tests__",
     "lint": "eslint . --ignore-pattern '!.eslintrc.js' --ext js,ts",
-    "prepare": "yarn build && yarn postbuild",
-    "prepublishOnly": "yarn build",
+    "prepack": "yarn build",
     "prettylint": "prettylint docs/**/*.md README.md package.json",
-    "pretest": "yarn build",
     "test": "jest",
     "tools:generate-rules-table": "ts-node -T tools/generate-rules-table",
     "typecheck": "tsc -p ."


### PR DESCRIPTION
I suspect most of these were legacy from when the project was Javascript?

It's small fry, but still each build + remove takes around ~3 seconds, which is done after every install because of `prepare` (which itself calls `build` & then `postbuild`, which is already called by `build`). `prepare` is also called as part of the publishing scripts, as well as `prepublishOnly`; and then finally we call it before running our tests via `pretest`, which just isn't needed because the tests are run against `src` not `lib`.

`prepack` is called before packing the project which is done as part of publishing when `npm pack` is called; this means you can also run `pack` locally to check what'll be included in the published pack (vs using `prepublishOnly`).