### PR TITLE
chore: backport non-breaking changes from next

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,12 @@ module.exports = {
       { blankLine: 'always', prev: 'directive', next: '*' },
       { blankLine: 'any', prev: 'directive', next: 'directive' },
     ],
+
+    // todo: pulled from v3 of @typescript-eslint's eslint-recommended config
+    'prefer-spread': 'error',
+    'prefer-rest-params': 'error',
+    'prefer-const': 'error',
+    'no-var': 'error',
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     ]
   },
   "prettier": {
+    "arrowParens": "avoid",
+    "endOfLine": "auto",
     "proseWrap": "always",
     "singleQuote": true,
     "trailingComma": "all"

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "lockFileMaintenance": { "enabled": true },
   "rangeStrategy": "replace",
   "ignorePresets": ["group:semantic-releaseMonorepo"]

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -19,6 +19,10 @@ ruleTester.run('disallowedWords option', rule, {
         { ignoreTypeOfDescribeName: false, disallowedWords: ['correct'] },
       ],
     },
+    {
+      code: 'it("correctly sets the value", () => {});',
+      options: [{ disallowedWords: undefined }],
+    },
   ],
   invalid: [
     {

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -124,6 +124,7 @@ export default createRule({
           },
           node,
           fix(fixer) {
+            // eslint-disable-next-line prefer-const
             let [name, func] = replacement.split('.');
 
             if (callee.property.type === AST_NODE_TYPES.Literal) {

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -150,19 +150,21 @@ export default createRule<[], MessageIds>({
         }
 
         if (!hasOnlyOneArgument(testFuncFirstLine)) {
-          const report: TSESLint.ReportDescriptor<MessageIds> = {
-            messageId: 'assertionsRequiresOneArgument',
-            loc: testFuncFirstLine.callee.property.loc,
-          };
+          let { loc } = testFuncFirstLine.callee.property;
+          const suggest: TSESLint.ReportSuggestionArray<MessageIds> = [];
 
           if (testFuncFirstLine.arguments.length) {
-            report.loc = testFuncFirstLine.arguments[1].loc;
-            report.suggest = [
+            loc = testFuncFirstLine.arguments[1].loc;
+            suggest.push(
               suggestRemovingExtraArguments(testFuncFirstLine.arguments, 1),
-            ];
+            );
           }
 
-          context.report(report);
+          context.report({
+            messageId: 'assertionsRequiresOneArgument',
+            suggest,
+            loc,
+          });
 
           return;
         }

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -37,7 +37,17 @@ const quoteStringValue = (node: StringNode): string =>
     ? `\`${node.quasis[0].value.raw}\``
     : node.raw;
 
-export default createRule({
+type MessageIds =
+  | 'titleMustBeString'
+  | 'emptyTitle'
+  | 'duplicatePrefix'
+  | 'accidentalSpace'
+  | 'disallowedWord';
+
+export default createRule<
+  [{ ignoreTypeOfDescribeName?: boolean; disallowedWords?: string[] }],
+  MessageIds
+>({
   name: __filename,
   meta: {
     docs: {
@@ -64,7 +74,6 @@ export default createRule({
           disallowedWords: {
             type: 'array',
             items: { type: 'string' },
-            default: [],
           },
         },
         additionalProperties: false,
@@ -73,7 +82,7 @@ export default createRule({
     fixable: 'code',
   },
   defaultOptions: [{ ignoreTypeOfDescribeName: false, disallowedWords: [] }],
-  create(context, [{ ignoreTypeOfDescribeName, disallowedWords }]) {
+  create(context, [{ ignoreTypeOfDescribeName, disallowedWords = [] }]) {
     const disallowedWordsRegexp = new RegExp(
       `\\b(${disallowedWords.join('|')})\\b`,
       'iu',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,


### PR DESCRIPTION
Does what it says in the title. Reduces the diff between `master` & `next` - the main ones I wanted were the eslint rules, `tsconfig` target change, and code restructures, but figured I'd bring a few things along just to reduce the diff further.