### PR TITLE
chore: build recommended ruleset based on rules meta doc property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
+import { TSESLint } from '@typescript-eslint/experimental-utils';
 import globals from './globals.json';
 import * as snapshotProcessor from './processors/snapshot-processor';
+
+type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
+  meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
+};
 
 // can be removed once we've on v3: https://github.com/typescript-eslint/typescript-eslint/issues/2060
 declare module '@typescript-eslint/experimental-utils/dist/ts-eslint/Rule' {
@@ -25,50 +30,38 @@ const excludedFiles = ['__tests__', 'utils'];
 const rules = readdirSync(rulesDir)
   .map(rule => parse(rule).name)
   .filter(rule => !excludedFiles.includes(rule))
-  .reduce(
-    (acc, curr) =>
-      Object.assign(acc, { [curr]: importDefault(join(rulesDir, curr)) }),
+  .reduce<Record<string, RuleModule>>(
+    (acc, curr) => ({
+      ...acc,
+      [curr]: importDefault(join(rulesDir, curr)) as RuleModule,
+    }),
     {},
   );
 
-const allRules = Object.keys(rules).reduce<Record<string, string>>(
-  (rules, key) => ({ ...rules, [`jest/${key}`]: 'error' }),
-  {},
-);
+const recommendedRules = Object.entries(rules)
+  .filter(([, rule]) => rule.meta.docs.recommended)
+  .reduce(
+    (acc, [name, rule]) => ({
+      ...acc,
+      [`jest/${name}`]: rule.meta.docs.recommended,
+    }),
+    {},
+  );
+
+const allRules = Object.keys(rules).reduce<
+  Record<string, TSESLint.Linter.RuleLevel>
+>((rules, key) => ({ ...rules, [`jest/${key}`]: 'error' }), {});
+
+const createConfig = (rules: Record<string, TSESLint.Linter.RuleLevel>) => ({
+  plugins: ['jest'],
+  env: { 'jest/globals': true },
+  rules,
+});
 
 export = {
   configs: {
-    all: {
-      plugins: ['jest'],
-      env: {
-        'jest/globals': true,
-      },
-      rules: allRules,
-    },
-    recommended: {
-      plugins: ['jest'],
-      env: {
-        'jest/globals': true,
-      },
-      rules: {
-        'jest/expect-expect': 'warn',
-        'jest/no-commented-out-tests': 'warn',
-        'jest/no-disabled-tests': 'warn',
-        'jest/no-export': 'error',
-        'jest/no-focused-tests': 'error',
-        'jest/no-identical-title': 'error',
-        'jest/no-jest-import': 'error',
-        'jest/no-mocks-import': 'error',
-        'jest/no-jasmine-globals': 'warn',
-        'jest/no-standalone-expect': 'error',
-        'jest/no-test-callback': 'error',
-        'jest/no-test-prefixes': 'error',
-        'jest/no-try-expect': 'error',
-        'jest/valid-describe': 'error',
-        'jest/valid-expect': 'error',
-        'jest/valid-expect-in-promise': 'error',
-      },
-    },
+    all: createConfig(allRules),
+    recommended: createConfig(recommendedRules),
     style: {
       plugins: ['jest'],
       rules: {

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -49,7 +49,7 @@ export default createRule<
     docs: {
       category: 'Best Practices',
       description: 'Enforce assertion to be made in a test body',
-      recommended: false,
+      recommended: 'warn',
     },
     messages: {
       noAssertions: 'Test has no assertions',

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -6,7 +6,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow alias methods',
-      recommended: 'warn',
+      recommended: false,
     },
     messages: {
       replaceAlias: `Replace {{ alias }}() with its canonical name of {{ canonical }}()`,

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -13,7 +13,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow commented out tests',
-      recommended: false,
+      recommended: 'warn',
     },
     messages: {
       commentedTests: 'Some tests seem to be commented',

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -6,7 +6,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow disabled tests',
-      recommended: false,
+      recommended: 'warn',
     },
     messages: {
       missingFunction: 'Test is missing function argument',

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -10,7 +10,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Prevent exporting from test files',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       unexpectedExport: `Do not export from a test file.`,

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -48,7 +48,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow focused tests',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       focusedTest: 'Unexpected focused test.',

--- a/src/rules/no-jasmine-globals.ts
+++ b/src/rules/no-jasmine-globals.ts
@@ -12,7 +12,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow Jasmine globals',
-      recommended: 'error',
+      recommended: 'warn',
     },
     messages: {
       illegalGlobal:

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -66,7 +66,7 @@ export default createRule<
     docs: {
       category: 'Best Practices',
       description: 'Prevents expects that are outside of an it or test block.',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       unexpectedExpect: 'Expect must be inside of a test block.',

--- a/src/rules/no-test-callback.ts
+++ b/src/rules/no-test-callback.ts
@@ -7,7 +7,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Avoid using a callback in asynchronous tests',
-      recommended: false,
+      recommended: 'error',
       suggestion: true,
     },
     messages: {

--- a/src/rules/no-try-expect.ts
+++ b/src/rules/no-try-expect.ts
@@ -12,7 +12,7 @@ export default createRule({
     docs: {
       description: 'Prefer using toThrow for exception tests',
       category: 'Best Practices',
-      recommended: false,
+      recommended: 'error',
     },
     deprecated: true,
     replacedBy: ['no-conditional-expect'],

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -29,7 +29,7 @@ export default createRule({
     docs: {
       category: 'Possible Errors',
       description: 'Enforce valid `describe()` callback',
-      recommended: 'warn',
+      recommended: 'error',
     },
     messages: {
       nameAndCallback: 'Describe requires name and callback arguments',

--- a/tools/generate-rules-table.ts
+++ b/tools/generate-rules-table.ts
@@ -14,7 +14,9 @@ interface RuleDetails {
   fixable: FixType | false;
 }
 
-type RuleModule = TSESLint.RuleModule<string, unknown[]>;
+type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
+  meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
+};
 
 const staticElements = {
   listHeaderRow: ['Rule', 'Description', 'Configurations', 'Fixable'],
@@ -97,10 +99,10 @@ const details: RuleDetails[] = Object.keys(config.configs.all.rules)
   .map(
     ([name, rule]): RuleDetails => ({
       name,
-      description: rule.meta.docs?.description ?? '',
+      description: rule.meta.docs.description,
       fixable: rule.meta.fixable
         ? 'fixable'
-        : rule.meta.docs?.suggestion
+        : rule.meta.docs.suggestion
         ? 'suggest'
         : false,
     }),


### PR DESCRIPTION
While we don't change the recommended ruleset often, this ensures we'll keep the right properties up to date.

Looking over our tests I think some might be a bit overkill - I don't mind per say, but am conscientious of how many places changes have to happen i.e snapshotting + updating the rule count constant. 