### PR TITLE
fix(no-large-snapshots): actually compare allowed name strings to name

### DIFF
--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -217,6 +217,27 @@ ruleTester.run('no-large-snapshots', rule, {
         },
       ],
     },
+    {
+      // "should not report whitelisted large snapshots based on regexp"
+      filename: '/mock-component.jsx.snap',
+      code: [
+        generateExportsSnapshotString(58, 'a big component w/ text'),
+        generateExportsSnapshotString(58, 'a big component 2'),
+      ].join('\n\n'),
+      options: [
+        {
+          whitelistedSnapshots: {
+            '/mock-component.jsx.snap': ['a big component 2'],
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'tooLongSnapshots',
+          data: { lineLimit: 50, lineCount: 58 },
+        },
+      ],
+    },
   ],
 });
 

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -58,7 +58,7 @@ const reportOnViolation = (
           return name.test(snapshotName);
         }
 
-        return snapshotName;
+        return snapshotName === name;
       });
     }
   }


### PR DESCRIPTION
Turns out when I converted this rule to TypeScript, I dropped the actual comparator, which apparently no ones noticed 😅

Came across this while doing #624, as I realised we're accepting RegExp instances from `.eslintrc.js` which isn't strictly wrong, but I think it might be worth deprecating in favor of just always taking RegExp strings as that's easy and reduces the chance [of being broken by a minor version of ESLint](https://github.com/eslint/eslint/pull/13034).

~The migration would be that people just add `^` & `$` to the start and end of their strings respectively, and then add `.source` to their RegExps.~

Edit: actually because we're accepting RegExp instances, we're getting both the source and flags, so we could do this change without it being breaking as we'd just wrap the strings in `new RegExp(^`${name}$`).

That means the breaking change would be no longer allowing devs to set RegExp flags used in matching, which shouldn't cause too much trouble as `i` would be the main useful flag, which you can implement long hand 🤔 

I mention this here as technically the behaviour is broken already, so it could be argued to be a breaking bugfix?