### PR TITLE
chore(no-standalone-expect): mark option as optional

### DIFF
--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -58,7 +58,7 @@ const isEach = (node: TSESTree.CallExpression): boolean =>
 type BlockType = 'test' | 'function' | 'describe' | 'arrow' | 'template';
 
 export default createRule<
-  [{ additionalTestBlockFunctions: string[] }],
+  [{ additionalTestBlockFunctions?: string[] }],
   'unexpectedExpect'
 >({
   name: __filename,


### PR DESCRIPTION
ESLint won't stop you from passing in `undefined`, and considers it a value that exists when checking if it should use the default value rules can set.

This actually should have been a TS error, but I believe the types for `@typescript-eslint` meant it didn't have the full picture? This in turn meant when upgrading in `next` we changed a test to not pass `undefined`, thus losing a point of coverage.

Programming is weird.