### PR TITLE
Remove unneeded checks

### DIFF
--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -40,8 +40,7 @@ export default createRule({
         if (
           !matcher ||
           !isParsedEqualityMatcherCall(matcher) ||
-          !argument ||
-          argument.type !== AST_NODE_TYPES.MemberExpression ||
+          argument?.type !== AST_NODE_TYPES.MemberExpression ||
           !isSupportedAccessor(argument.property, 'length') ||
           argument.property.type !== AST_NODE_TYPES.Identifier
         ) {

--- a/src/rules/require-to-throw-message.ts
+++ b/src/rules/require-to-throw-message.ts
@@ -30,9 +30,7 @@ export default createRule({
         const { matcher, modifier } = parseExpectCall(node);
 
         if (
-          matcher &&
-          matcher.arguments &&
-          matcher.arguments.length === 0 &&
+          matcher?.arguments?.length === 0 &&
           ['toThrow', 'toThrowError'].includes(matcher.name) &&
           (!modifier ||
             !(modifier.name === ModifierName.not || modifier.negation))

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -300,11 +300,10 @@ interface ParsedExpectMember<
  * Represents a `MemberExpression` that comes after an `ExpectCall`.
  */
 interface ExpectMember<
-  PropertyName extends ExpectPropertyName = ExpectPropertyName,
-  Parent extends TSESTree.Node | undefined = TSESTree.Node | undefined
+  PropertyName extends ExpectPropertyName = ExpectPropertyName
 > extends KnownMemberExpression<PropertyName> {
   object: ExpectCall | ExpectMember;
-  parent: Parent;
+  parent: TSESTree.Node;
 }
 
 export const isExpectMember = <

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -325,7 +325,7 @@ export type ParsedEqualityMatcherCall<
   Argument extends TSESTree.Expression = TSESTree.Expression,
   Matcher extends EqualityMatcher = EqualityMatcher
 > = Omit<ParsedExpectMatcher<Matcher>, 'arguments'> & {
-  // todo: probs should also type node parent as CallExpression
+  parent: TSESTree.CallExpression;
   arguments: [Argument];
 };
 

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -249,7 +249,11 @@ export default createRule<
 
         const parentNode = matcher.node.parent;
 
-        if (!modifier || modifier.name === ModifierName.not) {
+        if (
+          !parentNode.parent ||
+          !modifier ||
+          modifier.name === ModifierName.not
+        ) {
           return;
         }
         /**
@@ -257,7 +261,7 @@ export default createRule<
          * for the array object, not for each individual assertion.
          */
         const isParentArrayExpression =
-          parentNode.parent?.type === AST_NODE_TYPES.ArrayExpression;
+          parentNode.parent.type === AST_NODE_TYPES.ArrayExpression;
         const orReturned = alwaysAwait ? '' : ' or returned';
         /**
          * An async assertion can be chained with `then` or `catch` statements.

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -250,9 +250,8 @@ export default createRule<
         const parentNode = matcher.node.parent;
 
         if (
+          !parentNode?.parent ||
           !modifier ||
-          !parentNode ||
-          !parentNode.parent ||
           modifier.name === ModifierName.not
         ) {
           return;
@@ -262,7 +261,7 @@ export default createRule<
          * for the array object, not for each individual assertion.
          */
         const isParentArrayExpression =
-          parentNode.parent.type === AST_NODE_TYPES.ArrayExpression;
+          parentNode.parent?.type === AST_NODE_TYPES.ArrayExpression;
         const orReturned = alwaysAwait ? '' : ' or returned';
         /**
          * An async assertion can be chained with `then` or `catch` statements.

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -230,7 +230,7 @@ export default createRule<
           return;
         }
 
-        if (matcher.node.parent && isExpectMember(matcher.node.parent)) {
+        if (isExpectMember(matcher.node.parent)) {
           context.report({
             messageId: 'modifierUnknown',
             data: { modifierName: matcher.name },
@@ -249,11 +249,7 @@ export default createRule<
 
         const parentNode = matcher.node.parent;
 
-        if (
-          !parentNode?.parent ||
-          !modifier ||
-          modifier.name === ModifierName.not
-        ) {
+        if (!modifier || modifier.name === ModifierName.not) {
           return;
         }
         /**


### PR DESCRIPTION
Spotted this while doing #637 - it's impossible to craft an AST tree where a Node is both an `ExpectMember` & does not have a parent.

Also found a few conditions that can be simplified using optional chaining 🎉 