### PR TITLE
fix(config): lint only test files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,9 +53,12 @@ const allRules = Object.keys(rules).reduce<
 >((rules, key) => ({ ...rules, [`jest/${key}`]: 'error' }), {});
 
 const createConfig = (rules: Record<string, TSESLint.Linter.RuleLevel>) => ({
-  plugins: ['jest'],
-  env: { 'jest/globals': true },
-  rules,
+  overrides: [
+    files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[tj]s?(x)"],
+    plugins: ['jest'],
+    env: { 'jest/globals': true },
+    rules,
+  ],
 });
 
 export = {


### PR DESCRIPTION
It matches the behavior of jest when it's looking for files to test
https://github.com/facebook/jest/blob/96097ade1794bfe21c6207e080aa4a7192d93041/packages/jest-config/src/Defaults.ts#L60