### PR TITLE
refactor(expect-expect): report test callee instead of call expression

### DIFF
--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -63,7 +63,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -72,7 +72,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -81,7 +81,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -90,7 +90,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -100,7 +100,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -110,7 +110,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -164,7 +164,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -174,7 +174,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -184,7 +184,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -194,7 +194,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -204,7 +204,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -111,7 +111,7 @@ export default createRule<
       },
       'Program:exit'() {
         unchecked.forEach(node =>
-          context.report({ messageId: 'noAssertions', node }),
+          context.report({ messageId: 'noAssertions', node: node.callee }),
         );
       },
     };


### PR DESCRIPTION
When one starts writing a test, they often start with something like the following:

![image](https://user-images.githubusercontent.com/779047/91656269-d1eb6080-eab7-11ea-90e6-f9e816f47e73.png)

This triggers the `jest/expect-expect` rule for a good reason, but it’s annoying, confusing even, when the entire test block has a red underline until an expect statement is added.

This changes the rule to report the callee, only. This limits the scope of the reported code, so the red lines that do appear while typing are more meaningful, i.e. `result` is unused:

![image](https://user-images.githubusercontent.com/779047/91656255-bd0ecd00-eab7-11ea-8773-38755dbe306f.png)
