### PR TITLE
docs(readme): add note about `jest/globals` being set by configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ doing:
 }
 ```
 
+This is included in all configs shared by this plugin, so can be omitted if
+extending them.
+
 The behaviour of some rules (specifically `no-deprecated-functions`) change
 depending on the version of `jest` being used.
 


### PR DESCRIPTION
Fixes #658

I've not included a similar note for `plugin: ["jest"]` because that's actually an ESLint feature: when you extend a config from a plugin it'll enable that plugin - it actually isn't needed in our configs.