### PR TITLE
fix(no-deprecated-functions): do not throw error when jest is missing

### DIFF
--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -190,7 +190,7 @@ describe('the rule', () => {
       return true;
     });
 
-    ruleTester.run('explict jest version', rule, {
+    ruleTester.run('explicit jest version', rule, {
       valid: [
         'jest',
         'require("fs")',
@@ -234,7 +234,7 @@ describe('the rule', () => {
         process.chdir(tempDir);
       });
 
-      it('requires the version to be set explicitly', () => {
+      it('does not require the version to be set explicitly', () => {
         expect(() => {
           const linter = new TSESLint.Linter();
 
@@ -243,16 +243,14 @@ describe('the rule', () => {
           linter.verify('jest.resetModuleRegistry()', {
             rules: { 'no-deprecated-functions': 'error' },
           });
-        }).toThrow(
-          'Unable to detect Jest version - please ensure jest package is installed, or otherwise set version explicitly',
-        );
+        }).not.toThrow();
       });
     });
 
     describe('when the jest package.json is not found', () => {
       beforeEach(async () => process.chdir(await makeTempDir()));
 
-      it('requires the version to be set explicitly', () => {
+      it('does not require the version to be set explicitly', () => {
         expect(() => {
           const linter = new TSESLint.Linter();
 
@@ -261,9 +259,7 @@ describe('the rule', () => {
           linter.verify('jest.resetModuleRegistry()', {
             rules: { 'no-deprecated-functions': 'error' },
           });
-        }).toThrow(
-          'Unable to detect Jest version - please ensure jest package is installed, or otherwise set version explicitly',
-        );
+        }).not.toThrow();
       });
     });
   });

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -35,7 +35,7 @@ let cachedJestVersion: JestVersion | null = null;
 /** @internal */
 export const _clearCachedJestVersion = () => (cachedJestVersion = null);
 
-const detectJestVersion = (): JestVersion => {
+const detectJestVersion = (): JestVersion | null => {
   if (cachedJestVersion) {
     return cachedJestVersion;
   }
@@ -55,9 +55,7 @@ const detectJestVersion = (): JestVersion => {
     }
   } catch {}
 
-  throw new Error(
-    'Unable to detect Jest version - please ensure jest package is installed, or otherwise set version explicitly',
-  );
+  return (cachedJestVersion = null);
 };
 
 export default createRule({
@@ -81,6 +79,8 @@ export default createRule({
     const jestVersion =
       (context.settings as ContextSettings)?.jest?.version ||
       detectJestVersion();
+
+    if (jestVersion === null) return {};
 
     const deprecations: Record<string, string> = {
       ...(jestVersion >= 15 && {


### PR DESCRIPTION
Throwing error causes trouble on my general eslint config because it means to be used in project with jest or not. Jest is not listed as `peerDependencies` of this package too, so I think it makes sense not to enforce it.