### PR TITLE
fix(no-if): check both types of function expression

### DIFF
--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -13,15 +13,20 @@ const ruleTester = new TSESLint.RuleTester({
 ruleTester.run('conditional expressions', rule, {
   valid: [
     'const x = y ? 1 : 0',
-    {
-      code: dedent`
-        it('foo', () => {
-          const foo = function(bar) {
-            return foo ? bar : null;
-          };
-        });
-      `,
-    },
+    dedent`
+      it('foo', () => {
+        const foo = function (bar) {
+          return foo ? bar : null;
+        };
+      });
+    `,
+    dedent`
+      it('foo', function () {
+        const foo = function (bar) {
+          return foo ? bar : null;
+        };
+      });
+    `,
   ],
   invalid: [
     {
@@ -343,6 +348,19 @@ ruleTester.run('switch statements', rule, {
     },
     {
       code: dedent`
+        xtest('foo', function () {
+          switch('bar') {}
+        })
+      `,
+      errors: [
+        {
+          data: { condition: 'switch' },
+          messageId: 'conditionalInTest',
+        },
+      ],
+    },
+    {
+      code: dedent`
         describe('foo', () => {
           it('bar', () => {
         
@@ -576,6 +594,19 @@ ruleTester.run('if statements', rule, {
     {
       code: dedent`
         it.skip('foo', () => {
+          if('bar') {}
+        })
+      `,
+      errors: [
+        {
+          data: { condition: 'if' },
+          messageId: 'conditionalInTest',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it.skip('foo', function () {
           if('bar') {}
         })
       `,

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -23,7 +23,9 @@ const testCaseNames = new Set<string | null>([
   'fit.concurrent',
 ]);
 
-const isTestArrowFunction = (node: TSESTree.ArrowFunctionExpression) =>
+const isTestFunctionExpression = (
+  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+) =>
   node.parent !== undefined &&
   node.parent.type === AST_NODE_TYPES.CallExpression &&
   testCaseNames.has(getNodeName(node.parent.callee));
@@ -77,8 +79,8 @@ export default createRule({
           stack.push(true);
         }
       },
-      FunctionExpression() {
-        stack.push(false);
+      FunctionExpression(node) {
+        stack.push(isTestFunctionExpression(node));
       },
       FunctionDeclaration(node) {
         const declaredVariables = context.getDeclaredVariables(node);
@@ -89,7 +91,7 @@ export default createRule({
         stack.push(testCallExpressions.length > 0);
       },
       ArrowFunctionExpression(node) {
-        stack.push(isTestArrowFunction(node));
+        stack.push(isTestFunctionExpression(node));
       },
       IfStatement: validate,
       SwitchStatement: validate,


### PR DESCRIPTION
Fixes #670

@SimenB I've looked at the [original PR](https://github.com/jest-community/eslint-plugin-jest/pull/293) and there's no discussion around this, so I'm guessing it was working off the fact that you're meant to use arrow functions with jest?