### PR TITLE
feat(prefer-expect-assertions): support `onlyFunctionsWithAsyncKeyword ` option

### DIFF
--- a/docs/rules/prefer-expect-assertions.md
+++ b/docs/rules/prefer-expect-assertions.md
@@ -55,3 +55,45 @@ test('my test', () => {
   expect(someThing()).toEqual('foo');
 });
 ```
+
+## Options
+
+#### `onlyFunctionsWithAsyncKeyword`
+
+When `true`, this rule will only warn for tests that use the `async` keyword.
+
+```json
+{
+  "rules": {
+    "jest/prefer-expect-assertions": [
+      "warn",
+      { "onlyFunctionsWithAsyncKeyword": true }
+    ]
+  }
+}
+```
+
+When `onlyFunctionsWithAsyncKeyword` option is set to `true`, the following
+pattern would be a warning:
+
+```js
+test('my test', async () => {
+  const result = await someAsyncFunc();
+  expect(result).toBe('foo');
+});
+```
+
+While the following patterns would not be considered warnings:
+
+```js
+test('my test', () => {
+  const result = someFunction();
+  expect(result).toBe('foo');
+});
+
+test('my test', async () => {
+  expect.assertions(1);
+  const result = await someAsyncFunc();
+  expect(result).toBe('foo');
+});
+```

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -6,7 +6,7 @@ import rule from '../prefer-expect-assertions';
 const ruleTester = new TSESLint.RuleTester({
   parser: resolveFrom(require.resolve('eslint'), 'espree'),
   parserOptions: {
-    ecmaVersion: 2015,
+    ecmaVersion: 2017,
   },
 });
 
@@ -205,6 +205,21 @@ ruleTester.run('prefer-expect-assertions', rule, {
         },
       ],
     },
+    {
+      code: dedent`
+        it("it1", async function() {
+          expect(someValue).toBe(true);
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
   ],
 
   valid: [
@@ -223,5 +238,27 @@ ruleTester.run('prefer-expect-assertions', rule, {
     'test("it1")',
     'itHappensToStartWithIt("foo", function() {})',
     'testSomething("bar", function() {})',
+    'it(async () => {expect.assertions(0);})',
+    {
+      code: dedent`
+        it("it1", async () => {
+          expect.assertions(1);
+          expect(someValue).toBe(true)
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: dedent`
+        it("it1", function() {
+          expect(someValue).toBe(true)
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: 'it("it1", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
   ],
 });


### PR DESCRIPTION
We would like to add this new option on the `prefer-expect-assertions` rule, so the rule only applies to `async` tests.
I hope this you like this idea. I'm open for suggestions.