### PR TITLE
chore: enable `eslint-plugin/test-case-property-ordering` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,7 +74,6 @@ module.exports = {
       { blankLine: 'any', prev: 'directive', next: 'directive' },
     ],
 
-    // todo: pulled from v3 of @typescript-eslint's eslint-recommended config
     'prefer-spread': 'error',
     'prefer-rest-params': 'error',
     'prefer-const': ['error', { destructuring: 'all' }],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     '@typescript-eslint/ban-types': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
     'eslint-comments/no-unused-disable': 'error',
+    'eslint-plugin/test-case-property-ordering': 'error',
     'no-else-return': 'error',
     'no-negated-condition': 'error',
     eqeqeq: ['error', 'smart'],

--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -40,6 +40,7 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
   invalid: [
     {
       code: 'it("foo")',
+      output: 'test("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -50,10 +51,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'test("foo")',
     },
     {
       code: 'xit("foo")',
+      output: 'xtest("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -64,10 +65,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'xtest("foo")',
     },
     {
       code: 'fit("foo")',
+      output: 'test.only("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -78,10 +79,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'test.only("foo")',
     },
     {
       code: 'it.skip("foo")',
+      output: 'test.skip("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -92,10 +93,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'test.skip("foo")',
     },
     {
       code: 'it.concurrent("foo")',
+      output: 'test.concurrent("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -106,10 +107,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'test.concurrent("foo")',
     },
     {
       code: 'it.only("foo")',
+      output: 'test.only("foo")',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -120,10 +121,10 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'test.only("foo")',
     },
     {
       code: 'describe("suite", () => { it("foo") })',
+      output: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.test }],
       errors: [
         {
@@ -134,7 +135,6 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { test("foo") })',
     },
   ],
 });
@@ -173,6 +173,7 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
   invalid: [
     {
       code: 'test("foo")',
+      output: 'it("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -183,10 +184,10 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           },
         },
       ],
-      output: 'it("foo")',
     },
     {
       code: 'xtest("foo")',
+      output: 'xit("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -197,10 +198,10 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           },
         },
       ],
-      output: 'xit("foo")',
     },
     {
       code: 'test.skip("foo")',
+      output: 'it.skip("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -211,10 +212,10 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           },
         },
       ],
-      output: 'it.skip("foo")',
     },
     {
       code: 'test.concurrent("foo")',
+      output: 'it.concurrent("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -225,10 +226,10 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           },
         },
       ],
-      output: 'it.concurrent("foo")',
     },
     {
       code: 'test.only("foo")',
+      output: 'it.only("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -239,10 +240,10 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           },
         },
       ],
-      output: 'it.only("foo")',
     },
     {
       code: 'describe("suite", () => { test("foo") })',
+      output: 'describe("suite", () => { it("foo") })',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {
@@ -253,7 +254,6 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it("foo") })',
     },
   ],
 });
@@ -288,6 +288,7 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
   invalid: [
     {
       code: 'describe("suite", () => { test("foo") })',
+      output: 'describe("suite", () => { it("foo") })',
       options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -298,10 +299,10 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it("foo") })',
     },
     {
       code: 'describe("suite", () => { test.only("foo") })',
+      output: 'describe("suite", () => { it.only("foo") })',
       options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -312,10 +313,10 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it.only("foo") })',
     },
     {
       code: 'describe("suite", () => { xtest("foo") })',
+      output: 'describe("suite", () => { xit("foo") })',
       options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -326,10 +327,10 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { xit("foo") })',
     },
     {
       code: 'describe("suite", () => { test.skip("foo") })',
+      output: 'describe("suite", () => { it.skip("foo") })',
       options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -340,10 +341,10 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it.skip("foo") })',
     },
     {
       code: 'describe("suite", () => { test.concurrent("foo") })',
+      output: 'describe("suite", () => { it.concurrent("foo") })',
       options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -354,7 +355,6 @@ ruleTester.run('consistent-test-it with fn=test and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it.concurrent("foo") })',
     },
   ],
 });
@@ -389,6 +389,7 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
   invalid: [
     {
       code: 'describe("suite", () => { it("foo") })',
+      output: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -399,10 +400,10 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { test("foo") })',
     },
     {
       code: 'describe("suite", () => { it.only("foo") })',
+      output: 'describe("suite", () => { test.only("foo") })',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -413,10 +414,10 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { test.only("foo") })',
     },
     {
       code: 'describe("suite", () => { xit("foo") })',
+      output: 'describe("suite", () => { xtest("foo") })',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -427,10 +428,10 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { xtest("foo") })',
     },
     {
       code: 'describe("suite", () => { it.skip("foo") })',
+      output: 'describe("suite", () => { test.skip("foo") })',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -441,10 +442,10 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { test.skip("foo") })',
     },
     {
       code: 'describe("suite", () => { it.concurrent("foo") })',
+      output: 'describe("suite", () => { test.concurrent("foo") })',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -455,7 +456,6 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=test ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { test.concurrent("foo") })',
     },
   ],
 });
@@ -477,6 +477,7 @@ ruleTester.run(
     invalid: [
       {
         code: 'describe("suite", () => { it("foo") })',
+        output: 'describe("suite", () => { test("foo") })',
         options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.test }],
         errors: [
           {
@@ -487,10 +488,10 @@ ruleTester.run(
             },
           },
         ],
-        output: 'describe("suite", () => { test("foo") })',
       },
       {
         code: 'it("foo")',
+        output: 'test("foo")',
         options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.test }],
         errors: [
           {
@@ -501,7 +502,6 @@ ruleTester.run(
             },
           },
         ],
-        output: 'test("foo")',
       },
     ],
   },
@@ -521,6 +521,7 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=it ', rule, {
   invalid: [
     {
       code: 'describe("suite", () => { test("foo") })',
+      output: 'describe("suite", () => { it("foo") })',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -531,10 +532,10 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it("foo") })',
     },
     {
       code: 'test("foo")',
+      output: 'it("foo")',
       options: [{ fn: TestCaseName.it, withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -545,7 +546,6 @@ ruleTester.run('consistent-test-it with fn=it and withinDescribe=it ', rule, {
           },
         },
       ],
-      output: 'it("foo")',
     },
   ],
 });
@@ -559,6 +559,7 @@ ruleTester.run('consistent-test-it defaults without config object', rule, {
   invalid: [
     {
       code: 'describe("suite", () => { test("foo") })',
+      output: 'describe("suite", () => { it("foo") })',
       errors: [
         {
           messageId: 'consistentMethodWithinDescribe',
@@ -568,7 +569,6 @@ ruleTester.run('consistent-test-it defaults without config object', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it("foo") })',
     },
   ],
 });
@@ -587,6 +587,7 @@ ruleTester.run('consistent-test-it with withinDescribe=it', rule, {
   invalid: [
     {
       code: 'it("foo")',
+      output: 'test("foo")',
       options: [{ withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -597,10 +598,10 @@ ruleTester.run('consistent-test-it with withinDescribe=it', rule, {
           },
         },
       ],
-      output: 'test("foo")',
     },
     {
       code: 'describe("suite", () => { test("foo") })',
+      output: 'describe("suite", () => { it("foo") })',
       options: [{ withinDescribe: TestCaseName.it }],
       errors: [
         {
@@ -611,7 +612,6 @@ ruleTester.run('consistent-test-it with withinDescribe=it', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { it("foo") })',
     },
   ],
 });
@@ -630,6 +630,7 @@ ruleTester.run('consistent-test-it with withinDescribe=test', rule, {
   invalid: [
     {
       code: 'it("foo")',
+      output: 'test("foo")',
       options: [{ withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -640,10 +641,10 @@ ruleTester.run('consistent-test-it with withinDescribe=test', rule, {
           },
         },
       ],
-      output: 'test("foo")',
     },
     {
       code: 'describe("suite", () => { it("foo") })',
+      output: 'describe("suite", () => { test("foo") })',
       options: [{ withinDescribe: TestCaseName.test }],
       errors: [
         {
@@ -654,7 +655,6 @@ ruleTester.run('consistent-test-it with withinDescribe=test', rule, {
           },
         },
       ],
-      output: 'describe("suite", () => { test("foo") })',
     },
   ],
 });

--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -291,8 +291,8 @@ ruleTester.run('lowercase-name with ignoreTopLevelDescribe', rule, {
   invalid: [
     {
       code: 'it("Works!", () => {});',
-      options: [{ ignoreTopLevelDescribe: true }],
       output: 'it("works!", () => {});',
+      options: [{ ignoreTopLevelDescribe: true }],
       errors: [
         {
           messageId: 'unexpectedLowercase',
@@ -312,7 +312,6 @@ ruleTester.run('lowercase-name with ignoreTopLevelDescribe', rule, {
           });
         });
       `,
-      options: [{ ignoreTopLevelDescribe: true }],
       output: dedent`
         describe('MyClass', () => {
           describe('myMethod', () => {
@@ -322,6 +321,7 @@ ruleTester.run('lowercase-name with ignoreTopLevelDescribe', rule, {
           });
         });
       `,
+      options: [{ ignoreTopLevelDescribe: true }],
       errors: [
         {
           messageId: 'unexpectedLowercase',
@@ -347,7 +347,6 @@ ruleTester.run('lowercase-name with ignoreTopLevelDescribe', rule, {
           });
         });
       `,
-      options: [{ ignoreTopLevelDescribe: false }],
       output: dedent`
         describe('myClass', () => {
           describe('myMethod', () => {
@@ -357,6 +356,7 @@ ruleTester.run('lowercase-name with ignoreTopLevelDescribe', rule, {
           });
         });
       `,
+      options: [{ ignoreTopLevelDescribe: false }],
       errors: [
         {
           messageId: 'unexpectedLowercase',

--- a/src/rules/__tests__/no-alias-methods.test.ts
+++ b/src/rules/__tests__/no-alias-methods.test.ts
@@ -23,6 +23,7 @@ ruleTester.run('no-alias-methods', rule, {
   invalid: [
     {
       code: 'expect(a).toBeCalled()',
+      output: 'expect(a).toHaveBeenCalled()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -34,10 +35,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveBeenCalled()',
     },
     {
       code: 'expect(a).toBeCalledTimes()',
+      output: 'expect(a).toHaveBeenCalledTimes()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -49,10 +50,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveBeenCalledTimes()',
     },
     {
       code: 'expect(a).toBeCalledWith()',
+      output: 'expect(a).toHaveBeenCalledWith()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -64,10 +65,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveBeenCalledWith()',
     },
     {
       code: 'expect(a).lastCalledWith()',
+      output: 'expect(a).toHaveBeenLastCalledWith()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -79,10 +80,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveBeenLastCalledWith()',
     },
     {
       code: 'expect(a).nthCalledWith()',
+      output: 'expect(a).toHaveBeenNthCalledWith()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -94,10 +95,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveBeenNthCalledWith()',
     },
     {
       code: 'expect(a).toReturn()',
+      output: 'expect(a).toHaveReturned()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -109,10 +110,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveReturned()',
     },
     {
       code: 'expect(a).toReturnTimes()',
+      output: 'expect(a).toHaveReturnedTimes()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -124,10 +125,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveReturnedTimes()',
     },
     {
       code: 'expect(a).toReturnWith()',
+      output: 'expect(a).toHaveReturnedWith()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -139,10 +140,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveReturnedWith()',
     },
     {
       code: 'expect(a).lastReturnedWith()',
+      output: 'expect(a).toHaveLastReturnedWith()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -154,10 +155,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveLastReturnedWith()',
     },
     {
       code: 'expect(a).nthReturnedWith()',
+      output: 'expect(a).toHaveNthReturnedWith()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -169,10 +170,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toHaveNthReturnedWith()',
     },
     {
       code: 'expect(a).toThrowError()',
+      output: 'expect(a).toThrow()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -184,10 +185,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).toThrow()',
     },
     {
       code: 'expect(a).resolves.toThrowError()',
+      output: 'expect(a).resolves.toThrow()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -199,10 +200,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).resolves.toThrow()',
     },
     {
       code: 'expect(a).rejects.toThrowError()',
+      output: 'expect(a).rejects.toThrow()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -214,10 +215,10 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).rejects.toThrow()',
     },
     {
       code: 'expect(a).not.toThrowError()',
+      output: 'expect(a).not.toThrow()',
       errors: [
         {
           messageId: 'replaceAlias',
@@ -229,7 +230,6 @@ ruleTester.run('no-alias-methods', rule, {
           line: 1,
         },
       ],
-      output: 'expect(a).not.toThrow()',
     },
   ],
 });

--- a/src/rules/__tests__/no-jasmine-globals.test.ts
+++ b/src/rules/__tests__/no-jasmine-globals.test.ts
@@ -51,8 +51,8 @@ ruleTester.run('no-jasmine-globals', rule, {
     },
     {
       code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000;',
-      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
       output: 'jest.setTimeout(5000);',
+      errors: [{ messageId: 'illegalJasmine', column: 1, line: 1 }],
     },
     {
       code: 'jasmine.DEFAULT_TIMEOUT_INTERVAL = function() {}',
@@ -82,6 +82,7 @@ ruleTester.run('no-jasmine-globals', rule, {
     },
     {
       code: 'jasmine.any()',
+      output: 'expect.any()',
       errors: [
         {
           messageId: 'illegalMethod',
@@ -90,10 +91,10 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
-      output: 'expect.any()',
     },
     {
       code: 'jasmine.anything()',
+      output: 'expect.anything()',
       errors: [
         {
           messageId: 'illegalMethod',
@@ -102,10 +103,10 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
-      output: 'expect.anything()',
     },
     {
       code: 'jasmine.arrayContaining()',
+      output: 'expect.arrayContaining()',
       errors: [
         {
           messageId: 'illegalMethod',
@@ -117,10 +118,10 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
-      output: 'expect.arrayContaining()',
     },
     {
       code: 'jasmine.objectContaining()',
+      output: 'expect.objectContaining()',
       errors: [
         {
           messageId: 'illegalMethod',
@@ -132,10 +133,10 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
-      output: 'expect.objectContaining()',
     },
     {
       code: 'jasmine.stringMatching()',
+      output: 'expect.stringMatching()',
       errors: [
         {
           messageId: 'illegalMethod',
@@ -147,7 +148,6 @@ ruleTester.run('no-jasmine-globals', rule, {
           line: 1,
         },
       ],
-      output: 'expect.stringMatching()',
     },
     {
       code: 'jasmine.getEnv()',

--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -28,18 +28,17 @@ ruleTester.run('no-large-snapshots', rule, {
     'expect(something).toBe(1)',
     'expect(something).toMatchInlineSnapshot',
     {
-      filename: 'mock.js',
       code: generateExpectInlineSnapsCode(2, 'toMatchInlineSnapshot'),
+      filename: 'mock.js',
     },
     {
-      filename: 'mock.js',
       code: generateExpectInlineSnapsCode(
         2,
         'toThrowErrorMatchingInlineSnapshot',
       ),
+      filename: 'mock.js',
     },
     {
-      filename: 'mock.jsx',
       code: generateExpectInlineSnapsCode(20, 'toMatchInlineSnapshot'),
       options: [
         {
@@ -47,24 +46,24 @@ ruleTester.run('no-large-snapshots', rule, {
           inlineMaxSize: 21,
         },
       ],
+      filename: 'mock.jsx',
     },
     {
-      filename: 'mock.jsx',
       code: generateExpectInlineSnapsCode(60, 'toMatchInlineSnapshot'),
       options: [
         {
           maxSize: 61,
         },
       ],
+      filename: 'mock.jsx',
     },
     {
       // "should not report if node has fewer lines of code than limit"
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(20),
+      filename: '/mock-component.jsx.snap',
     },
     {
       // "it should not report snapshots that are allowed to be large"
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(58),
       options: [
         {
@@ -73,9 +72,9 @@ ruleTester.run('no-large-snapshots', rule, {
           },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(20),
       options: [
         {
@@ -83,11 +82,11 @@ ruleTester.run('no-large-snapshots', rule, {
           inlineMaxSize: 19,
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
   ],
   invalid: [
     {
-      filename: 'mock.js',
       code: generateExpectInlineSnapsCode(50, 'toMatchInlineSnapshot'),
       errors: [
         {
@@ -95,9 +94,9 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 51 },
         },
       ],
+      filename: 'mock.js',
     },
     {
-      filename: 'mock.js',
       code: generateExpectInlineSnapsCode(
         50,
         'toThrowErrorMatchingInlineSnapshot',
@@ -108,9 +107,9 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 51 },
         },
       ],
+      filename: 'mock.js',
     },
     {
-      filename: 'mock.js',
       code: generateExpectInlineSnapsCode(
         50,
         'toThrowErrorMatchingInlineSnapshot',
@@ -122,10 +121,10 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 51 },
         },
       ],
+      filename: 'mock.js',
     },
     {
       // "it should return an empty object for non snapshot files"
-      filename: 'mock.jsx',
       code: generateExpectInlineSnapsCode(50, 'toMatchInlineSnapshot'),
       errors: [
         {
@@ -133,10 +132,10 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 51 },
         },
       ],
+      filename: 'mock.jsx',
     },
     {
       // "should report if node has more than 50 lines of code, and no sizeThreshold option is passed"
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(52),
       errors: [
         {
@@ -144,10 +143,10 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 52 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
       // "should report if node has more lines of code than number given in sizeThreshold option"
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(100),
       options: [{ maxSize: 70 }],
       errors: [
@@ -156,9 +155,9 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 70, lineCount: 100 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(100),
       options: [{ maxSize: 70, inlineMaxSize: 101 }],
       errors: [
@@ -167,10 +166,10 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 70, lineCount: 100 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
       // "should report if maxSize is zero"
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(1),
       options: [{ maxSize: 0 }],
       errors: [
@@ -179,10 +178,10 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 0, lineCount: 1 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
       // "it should report if file is not allowed"
-      filename: '/mock-component.jsx.snap',
       code: generateExportsSnapshotString(58),
       options: [
         {
@@ -197,10 +196,10 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 58 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
       // "should not report allowed large snapshots based on regexp"
-      filename: '/mock-component.jsx.snap',
       code: [
         generateExportsSnapshotString(58, 'a big component w/ text'),
         generateExportsSnapshotString(58, 'a big component 2'),
@@ -218,9 +217,9 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 58 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
     {
-      filename: '/mock-component.jsx.snap',
       code: [
         generateExportsSnapshotString(58, 'a big component w/ text'),
         generateExportsSnapshotString(58, 'a big component 2'),
@@ -238,6 +237,7 @@ ruleTester.run('no-large-snapshots', rule, {
           data: { lineLimit: 50, lineCount: 58 },
         },
       ],
+      filename: '/mock-component.jsx.snap',
     },
   ],
 });

--- a/src/rules/__tests__/no-test-prefixes.test.ts
+++ b/src/rules/__tests__/no-test-prefixes.test.ts
@@ -26,6 +26,7 @@ ruleTester.run('no-test-prefixes', rule, {
   invalid: [
     {
       code: 'fdescribe("foo", function () {})',
+      output: 'describe.only("foo", function () {})',
       errors: [
         {
           messageId: 'usePreferredName',
@@ -34,10 +35,10 @@ ruleTester.run('no-test-prefixes', rule, {
           line: 1,
         },
       ],
-      output: 'describe.only("foo", function () {})',
     },
     {
       code: 'fit("foo", function () {})',
+      output: 'it.only("foo", function () {})',
       errors: [
         {
           messageId: 'usePreferredName',
@@ -46,10 +47,10 @@ ruleTester.run('no-test-prefixes', rule, {
           line: 1,
         },
       ],
-      output: 'it.only("foo", function () {})',
     },
     {
       code: 'fit.concurrent("foo", function () {})',
+      output: 'it.concurrent.only("foo", function () {})',
       errors: [
         {
           messageId: 'usePreferredName',
@@ -58,10 +59,10 @@ ruleTester.run('no-test-prefixes', rule, {
           line: 1,
         },
       ],
-      output: 'it.concurrent.only("foo", function () {})',
     },
     {
       code: 'xdescribe("foo", function () {})',
+      output: 'describe.skip("foo", function () {})',
       errors: [
         {
           messageId: 'usePreferredName',
@@ -70,10 +71,10 @@ ruleTester.run('no-test-prefixes', rule, {
           line: 1,
         },
       ],
-      output: 'describe.skip("foo", function () {})',
     },
     {
       code: 'xit("foo", function () {})',
+      output: 'it.skip("foo", function () {})',
       errors: [
         {
           messageId: 'usePreferredName',
@@ -82,10 +83,10 @@ ruleTester.run('no-test-prefixes', rule, {
           line: 1,
         },
       ],
-      output: 'it.skip("foo", function () {})',
     },
     {
       code: 'xtest("foo", function () {})',
+      output: 'test.skip("foo", function () {})',
       errors: [
         {
           messageId: 'usePreferredName',
@@ -94,7 +95,6 @@ ruleTester.run('no-test-prefixes', rule, {
           line: 1,
         },
       ],
-      output: 'test.skip("foo", function () {})',
     },
   ],
 });

--- a/src/rules/__tests__/prefer-inline-snapshots.test.ts
+++ b/src/rules/__tests__/prefer-inline-snapshots.test.ts
@@ -11,13 +11,13 @@ ruleTester.run('prefer-inline-snapshots', rule, {
   invalid: [
     {
       code: 'expect(something).toMatchSnapshot();',
-      errors: [{ messageId: 'toMatch', column: 19, line: 1 }],
       output: 'expect(something).toMatchInlineSnapshot();',
+      errors: [{ messageId: 'toMatch', column: 19, line: 1 }],
     },
     {
       code: 'expect(something).toThrowErrorMatchingSnapshot();',
-      errors: [{ messageId: 'toMatchError', column: 19, line: 1 }],
       output: 'expect(something).toThrowErrorMatchingInlineSnapshot();',
+      errors: [{ messageId: 'toMatchError', column: 19, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -27,87 +27,87 @@ ruleTester.run('prefer-spy-on', rule, {
   invalid: [
     {
       code: 'obj.a = jest.fn(); const test = 10;',
+      output: "jest.spyOn(obj, 'a').mockImplementation(); const test = 10;",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(obj, 'a').mockImplementation(); const test = 10;",
     },
     {
       code: "Date['now'] = jest['fn']()",
+      output: "jest.spyOn(Date, 'now').mockImplementation()",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(Date, 'now').mockImplementation()",
     },
     {
       code: 'window[`${name}`] = jest[`fn`]()',
+      output: 'jest.spyOn(window, `${name}`).mockImplementation()',
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: 'jest.spyOn(window, `${name}`).mockImplementation()',
     },
     {
       code: "obj['prop' + 1] = jest['fn']()",
+      output: "jest.spyOn(obj, 'prop' + 1).mockImplementation()",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(obj, 'prop' + 1).mockImplementation()",
     },
     {
       code: 'obj.one.two = jest.fn(); const test = 10;',
+      output:
+        "jest.spyOn(obj.one, 'two').mockImplementation(); const test = 10;",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output:
-        "jest.spyOn(obj.one, 'two').mockImplementation(); const test = 10;",
     },
     {
       code: 'obj.a = jest.fn(() => 10)',
+      output: "jest.spyOn(obj, 'a').mockImplementation(() => 10)",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output: "jest.spyOn(obj, 'a').mockImplementation(() => 10)",
     },
     {
       code:
         "obj.a.b = jest.fn(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
+      output:
+        "jest.spyOn(obj.a, 'b').mockImplementation(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output:
-        "jest.spyOn(obj.a, 'b').mockImplementation(() => ({})).mockReturnValue('default').mockReturnValueOnce('first call'); test();",
     },
     {
       code: 'window.fetch = jest.fn(() => ({})).one.two().three().four',
+      output:
+        "jest.spyOn(window, 'fetch').mockImplementation(() => ({})).one.two().three().four",
       errors: [
         {
           messageId: 'useJestSpyOn',
           type: AST_NODE_TYPES.AssignmentExpression,
         },
       ],
-      output:
-        "jest.spyOn(window, 'fetch').mockImplementation(() => ({})).one.two().three().four",
     },
   ],
 });

--- a/src/rules/__tests__/prefer-to-be-null.test.ts
+++ b/src/rules/__tests__/prefer-to-be-null.test.ts
@@ -23,33 +23,33 @@ ruleTester.run('prefer-to-be-null', rule, {
   invalid: [
     {
       code: 'expect(null).toBe(null);',
-      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
       output: 'expect(null).toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
     },
     {
       code: 'expect(null).toEqual(null);',
-      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
       output: 'expect(null).toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
     },
     {
       code: 'expect(null).toStrictEqual(null);',
-      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
       output: 'expect(null).toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
     },
     {
       code: 'expect("a string").not.toBe(null);',
-      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
     },
     {
       code: 'expect("a string").not.toEqual(null);',
-      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
     },
     {
       code: 'expect("a string").not.toStrictEqual(null);',
-      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
     },
   ],
 });
@@ -63,13 +63,13 @@ new TSESLint.RuleTester({
   invalid: [
     {
       code: 'expect(null).toBe(null as unknown as string as unknown as any);',
-      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
       output: 'expect(null).toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
     },
     {
       code: 'expect("a string").not.toEqual(null as number);',
-      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/prefer-to-be-undefined.test.ts
+++ b/src/rules/__tests__/prefer-to-be-undefined.test.ts
@@ -21,33 +21,33 @@ ruleTester.run('prefer-to-be-undefined', rule, {
   invalid: [
     {
       code: 'expect(undefined).toBe(undefined);',
-      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
       output: 'expect(undefined).toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
     },
     {
       code: 'expect(undefined).toEqual(undefined);',
-      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
       output: 'expect(undefined).toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
     },
     {
       code: 'expect(undefined).toStrictEqual(undefined);',
-      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
       output: 'expect(undefined).toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
     },
     {
       code: 'expect("a string").not.toBe(undefined);',
-      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
     },
     {
       code: 'expect("a string").not.toEqual(undefined);',
-      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
     },
     {
       code: 'expect("a string").not.toStrictEqual(undefined);',
-      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
     },
   ],
 });
@@ -61,13 +61,13 @@ new TSESLint.RuleTester({
   invalid: [
     {
       code: 'expect(undefined).toBe(undefined as unknown as string as any);',
-      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
       output: 'expect(undefined).toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 19, line: 1 }],
     },
     {
       code: 'expect("a string").not.toEqual(undefined as number);',
-      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
       output: 'expect("a string").not.toBeUndefined();',
+      errors: [{ messageId: 'useToBeUndefined', column: 24, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -29,8 +29,8 @@ ruleTester.run('prefer-to-contain', rule, {
   invalid: [
     {
       code: 'expect(a.includes(b)).toEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     // todo: support this, as it's counted by isSupportedAccessor
     // {
@@ -40,118 +40,118 @@ ruleTester.run('prefer-to-contain', rule, {
     // },
     {
       code: 'expect(a.includes(b)).toEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toBe(true);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toBe(false);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toBe(false);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toBe(true);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toStrictEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toStrictEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toStrictEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toStrictEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).toEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).toContain(b.test(p));',
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).toEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).not.toContain(b.test(p));',
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).not.toContain(b.test(p));',
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
       output: 'expect(a.test(t)).toContain(b.test(p));',
+      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toBe(true);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toBe(false);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).not.toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(true);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).not.toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(false);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toStrictEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toStrictEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).not.toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(true);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).not.toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(false);',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
       output: 'expect([{a:1}]).toContain({a:1});',
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
   ],
 });
@@ -166,8 +166,8 @@ new TSESLint.RuleTester({
   invalid: [
     {
       code: 'expect(a.includes(b)).toEqual(false as boolean);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
       output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -30,18 +30,18 @@ ruleTester.run('prefer-to-have-length', rule, {
     // },
     {
       code: 'expect(files.length).toBe(1);',
-      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
       output: 'expect(files).toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
     },
     {
       code: 'expect(files.length).toEqual(1);',
-      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
       output: 'expect(files).toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
     },
     {
       code: 'expect(files.length).toStrictEqual(1);',
-      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
       output: 'expect(files).toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
     },
   ],
 });

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -29,33 +29,33 @@ ruleTester.run('prefer-todo', rule, {
   invalid: [
     {
       code: `test("i need to write this test");`,
-      errors: [{ messageId: 'unimplementedTest' }],
       output: 'test.todo("i need to write this test");',
+      errors: [{ messageId: 'unimplementedTest' }],
     },
     {
       code: 'test(`i need to write this test`);',
-      errors: [{ messageId: 'unimplementedTest' }],
       output: 'test.todo(`i need to write this test`);',
+      errors: [{ messageId: 'unimplementedTest' }],
     },
     {
       code: 'it("foo", function () {})',
-      errors: [{ messageId: 'emptyTest' }],
       output: 'it.todo("foo")',
+      errors: [{ messageId: 'emptyTest' }],
     },
     {
       code: 'it("foo", () => {})',
-      errors: [{ messageId: 'emptyTest' }],
       output: 'it.todo("foo")',
+      errors: [{ messageId: 'emptyTest' }],
     },
     {
       code: `test.skip("i need to write this test", () => {});`,
-      errors: [{ messageId: 'emptyTest' }],
       output: 'test.todo("i need to write this test");',
+      errors: [{ messageId: 'emptyTest' }],
     },
     {
       code: `test.skip("i need to write this test", function() {});`,
-      errors: [{ messageId: 'emptyTest' }],
       output: 'test.todo("i need to write this test");',
+      errors: [{ messageId: 'emptyTest' }],
     },
   ],
 });

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -651,118 +651,118 @@ ruleTester.run('no-accidental-space', rule, {
   invalid: [
     {
       code: 'describe(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
       output: 'describe("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
     },
     {
       code: 'describe(" foo foe fum", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
       output: 'describe("foo foe fum", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
     },
     {
       code: 'describe("foo foe fum ", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
       output: 'describe("foo foe fum", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
     },
     {
       code: 'fdescribe(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
       output: 'fdescribe("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
     },
     {
       code: "fdescribe(' foo', function () {})",
-      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
       output: "fdescribe('foo', function () {})",
+      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
     },
     {
       code: 'xdescribe(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
       output: 'xdescribe("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 11, line: 1 }],
     },
     {
       code: 'it(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 4, line: 1 }],
       output: 'it("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 4, line: 1 }],
     },
     {
       code: 'it.concurrent(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 15, line: 1 }],
       output: 'it.concurrent("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 15, line: 1 }],
     },
     {
       code: 'fit(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
       output: 'fit("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
     },
     {
       code: 'fit.concurrent(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 16, line: 1 }],
       output: 'fit.concurrent("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 16, line: 1 }],
     },
     {
       code: 'fit("foo ", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
       output: 'fit("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
     },
     {
       code: 'fit.concurrent("foo ", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 16, line: 1 }],
       output: 'fit.concurrent("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 16, line: 1 }],
     },
     {
       code: 'xit(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
       output: 'xit("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 5, line: 1 }],
     },
     {
       code: 'test(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
       output: 'test("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
     },
     {
       code: 'test.concurrent(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
       output: 'test.concurrent("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
     },
     {
       code: 'test(` foo`, function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
       output: 'test(`foo`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
     },
     {
       code: 'test.concurrent(` foo`, function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
       output: 'test.concurrent(`foo`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
     },
     {
       code: 'test(` foo bar bang`, function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
       output: 'test(`foo bar bang`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
     },
     {
       code: 'test.concurrent(` foo bar bang`, function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
       output: 'test.concurrent(`foo bar bang`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
     },
     {
       code: 'test(` foo bar bang  `, function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
       output: 'test(`foo bar bang`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 1 }],
     },
     {
       code: 'test.concurrent(` foo bar bang  `, function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
       output: 'test.concurrent(`foo bar bang`, function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
     },
     {
       code: 'xtest(" foo", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 7, line: 1 }],
       output: 'xtest("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 7, line: 1 }],
     },
     {
       code: 'xtest(" foo  ", function () {})',
-      errors: [{ messageId: 'accidentalSpace', column: 7, line: 1 }],
       output: 'xtest("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 7, line: 1 }],
     },
     {
       code: `
@@ -770,12 +770,12 @@ ruleTester.run('no-accidental-space', rule, {
         it('bar', () => {})
       })
       `,
-      errors: [{ messageId: 'accidentalSpace', column: 16, line: 2 }],
       output: `
       describe('foo', () => {
         it('bar', () => {})
       })
       `,
+      errors: [{ messageId: 'accidentalSpace', column: 16, line: 2 }],
     },
     {
       code: `
@@ -783,12 +783,12 @@ ruleTester.run('no-accidental-space', rule, {
         it(' bar', () => {})
       })
       `,
-      errors: [{ messageId: 'accidentalSpace', column: 12, line: 3 }],
       output: `
       describe('foo', () => {
         it('bar', () => {})
       })
       `,
+      errors: [{ messageId: 'accidentalSpace', column: 12, line: 3 }],
     },
   ],
 });
@@ -803,28 +803,28 @@ ruleTester.run('no-duplicate-prefix ft describe', rule, {
   invalid: [
     {
       code: 'describe("describe foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
       output: 'describe("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
     },
     {
       code: 'fdescribe("describe foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
       output: 'fdescribe("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
     },
     {
       code: 'xdescribe("describe foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
       output: 'xdescribe("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
     },
     {
       code: "describe('describe foo', function () {})",
-      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
       output: "describe('foo', function () {})",
+      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
     },
     {
       code: 'fdescribe(`describe foo`, function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
       output: 'fdescribe(`foo`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 11, line: 1 }],
     },
   ],
 });
@@ -841,23 +841,23 @@ ruleTester.run('no-duplicate-prefix ft test', rule, {
   invalid: [
     {
       code: 'test("test foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
       output: 'test("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
     },
     {
       code: 'xtest("test foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 7, line: 1 }],
       output: 'xtest("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 7, line: 1 }],
     },
     {
       code: 'test(`test foo`, function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
       output: 'test(`foo`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
     },
     {
       code: 'test(`test foo test`, function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
       output: 'test(`foo test`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
     },
   ],
 });
@@ -873,23 +873,23 @@ ruleTester.run('no-duplicate-prefix ft it', rule, {
   invalid: [
     {
       code: 'it("it foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
       output: 'it("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
     },
     {
       code: 'fit("it foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
       output: 'fit("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
     },
     {
       code: 'xit("it foo", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
       output: 'xit("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
     },
     {
       code: 'it("it foos it correctly", function () {})',
-      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
       output: 'it("foos it correctly", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
     },
   ],
 });
@@ -914,12 +914,12 @@ ruleTester.run('no-duplicate-prefix ft nested', rule, {
         it('bar', () => {})
       })
       `,
-      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
       output: `
       describe('foo', () => {
         it('bar', () => {})
       })
       `,
+      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
     },
     {
       code: `
@@ -927,12 +927,12 @@ ruleTester.run('no-duplicate-prefix ft nested', rule, {
         it('describes things correctly', () => {})
       })
       `,
-      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
       output: `
       describe('foo', () => {
         it('describes things correctly', () => {})
       })
       `,
+      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
     },
     {
       code: `
@@ -940,12 +940,12 @@ ruleTester.run('no-duplicate-prefix ft nested', rule, {
         it('it bar', () => {})
       })
       `,
-      errors: [{ messageId: 'duplicatePrefix', column: 12, line: 3 }],
       output: `
       describe('foo', () => {
         it('bar', () => {})
       })
       `,
+      errors: [{ messageId: 'duplicatePrefix', column: 12, line: 3 }],
     },
   ],
 });


### PR DESCRIPTION
I was going to enable other rules too I think, but then forgot what ones. Also I tried enabling some of the other `eslint-plugin` rules but turns out they only work with `module.exports`.