### PR TITLE
chore: run release workflow when other workflows complete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: [Lint, 'Unit tests']
+    branches: [master]
+    types:
+      - completed
 
 jobs:
   release:
@@ -24,12 +26,6 @@ jobs:
           node-version: 12.x
       - name: install
         run: yarn
-      - name: run prettier
-        run: yarn prettier:check
-      - name: run typecheck
-        run: yarn typecheck
-      - name: run tests
-        run: yarn test --coverage
       - run: yarn semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I think this makes sense

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/
https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_run