### PR TITLE
fix: improve support for it.each involving tagged template literals

### DIFF
--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -33,6 +33,14 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
       options: [{ fn: TestCaseName.test }],
     },
     {
+      code: 'test.each([])("foo")',
+      options: [{ fn: TestCaseName.test }],
+    },
+    {
+      code: 'test.each``("foo")',
+      options: [{ fn: TestCaseName.test }],
+    },
+    {
       code: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.test }],
     },
@@ -123,6 +131,34 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
       ],
     },
     {
+      code: 'it.each([])("foo")',
+      output: 'test.each([])("foo")',
+      options: [{ fn: TestCaseName.test }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testKeyword: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+        },
+      ],
+    },
+    {
+      code: 'it.each``("foo")',
+      output: 'test.each``("foo")',
+      options: [{ fn: TestCaseName.test }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testKeyword: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+        },
+      ],
+    },
+    {
       code: 'describe("suite", () => { it("foo") })',
       output: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.test }],
@@ -163,6 +199,14 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
     },
     {
       code: 'it.concurrent("foo")',
+      options: [{ fn: TestCaseName.it }],
+    },
+    {
+      code: 'it.each([])("foo")',
+      options: [{ fn: TestCaseName.it }],
+    },
+    {
+      code: 'it.each``("foo")',
       options: [{ fn: TestCaseName.it }],
     },
     {
@@ -230,6 +274,34 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
     {
       code: 'test.only("foo")',
       output: 'it.only("foo")',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testKeyword: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+        },
+      ],
+    },
+    {
+      code: 'test.each([])("foo")',
+      output: 'it.each([])("foo")',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethod',
+          data: {
+            testKeyword: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+        },
+      ],
+    },
+    {
+      code: 'test.each``("foo")',
+      output: 'it.each``("foo")',
       options: [{ fn: TestCaseName.it }],
       errors: [
         {

--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -16,6 +16,7 @@ ruleTester.run('no-disabled-tests', rule, {
     'it("foo", function () {})',
     'describe.only("foo", function () {})',
     'it.only("foo", function () {})',
+    'it.each("foo", () => {})',
     'it.concurrent("foo", function () {})',
     'test("foo", function () {})',
     'test.only("foo", function () {})',
@@ -88,6 +89,22 @@ ruleTester.run('no-disabled-tests', rule, {
       errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
+      code: 'it.skip.each``("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'test.skip.each``("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'it.skip.each([])("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'test.skip.each([])("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
       code: 'test.concurrent.skip("foo", function () {})',
       errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
@@ -106,6 +123,22 @@ ruleTester.run('no-disabled-tests', rule, {
     {
       code: 'xtest("foo", function () {})',
       errors: [{ messageId: 'disabledTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'xit.each``("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'xtest.each``("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'xit.each([])("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
+    },
+    {
+      code: 'xtest.each([])("foo", function () {})',
+      errors: [{ messageId: 'skippedTest', column: 1, line: 1 }],
     },
     {
       code: 'it("has title but no callback")',

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -58,6 +58,10 @@ ruleTester.run('no-standalone-expect', rule, {
   ],
   invalid: [
     {
+      code: `(() => {})('testing', () => expect(true))`,
+      errors: [{ endColumn: 41, column: 29, messageId: 'unexpectedExpect' }],
+    },
+    {
       code: `
         describe('scenario', () => {
           const t = Math.random() ? it.only : it;

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -58,7 +58,7 @@ ruleTester.run('no-standalone-expect', rule, {
   ],
   invalid: [
     {
-      code: `(() => {})('testing', () => expect(true))`,
+      code: "(() => {})('testing', () => expect(true))",
       errors: [{ endColumn: 41, column: 29, messageId: 'unexpectedExpect' }],
     },
     {

--- a/src/rules/__tests__/no-test-prefixes.test.ts
+++ b/src/rules/__tests__/no-test-prefixes.test.ts
@@ -12,8 +12,18 @@ ruleTester.run('no-test-prefixes', rule, {
     'test.concurrent("foo", function () {})',
     'describe.only("foo", function () {})',
     'it.only("foo", function () {})',
+    'it.each()("foo", function () {})',
+    {
+      code: 'it.each``("foo", function () {})',
+      parserOptions: { ecmaVersion: 6 },
+    },
     'it.concurrent.only("foo", function () {})',
     'test.only("foo", function () {})',
+    'test.each()("foo", function () {})',
+    {
+      code: 'test.each``("foo", function () {})',
+      parserOptions: { ecmaVersion: 6 },
+    },
     'test.concurrent.only("foo", function () {})',
     'describe.skip("foo", function () {})',
     'it.skip("foo", function () {})',
@@ -91,6 +101,56 @@ ruleTester.run('no-test-prefixes', rule, {
         {
           messageId: 'usePreferredName',
           data: { preferredNodeName: 'test.skip' },
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'xit.each``("foo", function () {})',
+      output: 'it.skip.each``("foo", function () {})',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'it.skip.each' },
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'xtest.each``("foo", function () {})',
+      output: 'test.skip.each``("foo", function () {})',
+      parserOptions: { ecmaVersion: 6 },
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'test.skip.each' },
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'xit.each([])("foo", function () {})',
+      output: 'it.skip.each([])("foo", function () {})',
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'it.skip.each' },
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'xtest.each([])("foo", function () {})',
+      output: 'test.skip.each([])("foo", function () {})',
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'test.skip.each' },
           column: 1,
           line: 1,
         },

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -82,6 +82,11 @@ export default createRule<
           describeNestingLevel++;
         }
 
+        const funcNode =
+          node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
+            ? node.callee.tag
+            : node.callee;
+
         if (
           isTestCase(node) &&
           describeNestingLevel === 0 &&
@@ -93,7 +98,7 @@ export default createRule<
             messageId: 'consistentMethod',
             node: node.callee,
             data: { testKeyword, oppositeTestKeyword },
-            fix: buildFixer(node.callee, nodeName, testKeyword),
+            fix: buildFixer(funcNode, nodeName, testKeyword),
           });
         }
 
@@ -110,7 +115,7 @@ export default createRule<
             messageId: 'consistentMethodWithinDescribe',
             node: node.callee,
             data: { testKeywordWithinDescribe, oppositeTestKeyword },
-            fix: buildFixer(node.callee, nodeName, testKeywordWithinDescribe),
+            fix: buildFixer(funcNode, nodeName, testKeywordWithinDescribe),
           });
         }
       },

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -39,6 +39,9 @@ export default createRule({
       CallExpression(node) {
         const functionName = getNodeName(node.callee);
 
+        // prevent duplicate warnings for it.each()()
+        if (node.callee.type === 'CallExpression') return;
+
         switch (functionName) {
           case 'describe.skip':
             context.report({ messageId: 'skippedTestSuite', node });
@@ -48,6 +51,10 @@ export default createRule({
           case 'it.concurrent.skip':
           case 'test.skip':
           case 'test.concurrent.skip':
+          case 'it.skip.each':
+          case 'test.skip.each':
+          case 'xit.each':
+          case 'xtest.each':
             context.report({ messageId: 'skippedTest', node });
             break;
         }

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -1,3 +1,4 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
 import { createRule, getNodeName, isDescribe, isTestCase } from './utils';
 
 export default createRule({
@@ -27,12 +28,17 @@ export default createRule({
 
         if (!preferredNodeName) return;
 
+        const funcNode =
+          node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
+            ? node.callee.tag
+            : node.callee;
+
         context.report({
           messageId: 'usePreferredName',
           node: node.callee,
           data: { preferredNodeName },
           fix(fixer) {
-            return [fixer.replaceText(node.callee, preferredNodeName)];
+            return [fixer.replaceText(funcNode, preferredNodeName)];
           },
         });
       },
@@ -43,12 +49,14 @@ export default createRule({
 function getPreferredNodeName(nodeName: string) {
   const firstChar = nodeName.charAt(0);
 
+  const suffix = nodeName.endsWith('.each') ? '.each' : '';
+
   if (firstChar === 'f') {
-    return `${nodeName.slice(1)}.only`;
+    return `${nodeName.slice(1).replace('.each', '')}.only${suffix}`;
   }
 
   if (firstChar === 'x') {
-    return `${nodeName.slice(1)}.skip`;
+    return `${nodeName.slice(1).replace('.each', '')}.skip${suffix}`;
   }
 
   return null;

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -580,10 +580,16 @@ export interface JestFunctionCallExpressionWithIdentifierCallee<
   callee: JestFunctionIdentifier<FunctionName>;
 }
 
+export interface JestFunctionCallTaggedTemplateExpression
+  extends TSESTree.CallExpression {
+  callee: TSESTree.TaggedTemplateExpression;
+}
+
 export type JestFunctionCallExpression<
   FunctionName extends JestFunctionName = JestFunctionName
 > =
   | JestFunctionCallExpressionWithMemberExpressionCallee<FunctionName>
+  | JestFunctionCallTaggedTemplateExpression
   | JestFunctionCallExpressionWithIdentifierCallee<FunctionName>;
 
 const joinNames = (a: string | null, b: string | null): string | null =>
@@ -592,6 +598,7 @@ const joinNames = (a: string | null, b: string | null): string | null =>
 export function getNodeName(
   node:
     | JestFunctionMemberExpression<JestFunctionName>
+    | TSESTree.TaggedTemplateExpression
     | JestFunctionIdentifier<JestFunctionName>,
 ): string;
 export function getNodeName(node: TSESTree.Node): string | null;
@@ -653,6 +660,11 @@ export const isTestCase = (
 ): node is JestFunctionCallExpression<TestCaseName> =>
   (node.callee.type === AST_NODE_TYPES.Identifier &&
     TestCaseName.hasOwnProperty(node.callee.name)) ||
+  // e.g. it.each``()
+  (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+    node.callee.tag.type === AST_NODE_TYPES.MemberExpression &&
+    isSupportedAccessor(node.callee.tag.property, TestCaseProperty.each)) ||
+  // e.g. it.concurrent.{skip,only}
   (node.callee.type === AST_NODE_TYPES.MemberExpression &&
     node.callee.property.type === AST_NODE_TYPES.Identifier &&
     TestCaseProperty.hasOwnProperty(node.callee.property.name) &&

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -601,6 +601,8 @@ export function getNodeName(node: TSESTree.Node): string | null {
   }
 
   switch (node.type) {
+    case AST_NODE_TYPES.TaggedTemplateExpression:
+      return getNodeName(node.tag);
     case AST_NODE_TYPES.MemberExpression:
       return joinNames(getNodeName(node.object), getNodeName(node.property));
     case AST_NODE_TYPES.NewExpression:

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -580,7 +580,7 @@ export interface JestFunctionCallExpressionWithIdentifierCallee<
   callee: JestFunctionIdentifier<FunctionName>;
 }
 
-export interface JestFunctionCallTaggedTemplateExpression
+interface JestFunctionCallExpressionWithTaggedTemplateCallee
   extends TSESTree.CallExpression {
   callee: TSESTree.TaggedTemplateExpression;
 }
@@ -589,7 +589,7 @@ export type JestFunctionCallExpression<
   FunctionName extends JestFunctionName = JestFunctionName
 > =
   | JestFunctionCallExpressionWithMemberExpressionCallee<FunctionName>
-  | JestFunctionCallTaggedTemplateExpression
+  | JestFunctionCallExpressionWithTaggedTemplateCallee
   | JestFunctionCallExpressionWithIdentifierCallee<FunctionName>;
 
 const joinNames = (a: string | null, b: string | null): string | null =>
@@ -598,8 +598,8 @@ const joinNames = (a: string | null, b: string | null): string | null =>
 export function getNodeName(
   node:
     | JestFunctionMemberExpression<JestFunctionName>
-    | TSESTree.TaggedTemplateExpression
-    | JestFunctionIdentifier<JestFunctionName>,
+    | JestFunctionIdentifier<JestFunctionName>
+    | TSESTree.TaggedTemplateExpression,
 ): string;
 export function getNodeName(node: TSESTree.Node): string | null;
 export function getNodeName(node: TSESTree.Node): string | null {


### PR DESCRIPTION
`it.each` has [an unusual syntax](https://jestjs.io/docs/en/api#2--testeachtablename-fn-timeout-) which means `no-disabled-tests`, `no-test-prefixes`, and `consistent-test-it` don't work for it. 

This PR makes `it.each` work with those three rules