### PR TITLE
fix(no-done-callback): fix regression with it.each

### DIFF
--- a/src/rules/__tests__/no-done-callback.test.ts
+++ b/src/rules/__tests__/no-done-callback.test.ts
@@ -15,6 +15,10 @@ ruleTester.run('no-done-callback', rule, {
     'test("something", () => {})',
     'test("something", async () => {})',
     'test("something", function() {})',
+    'test.each``("something", ({ a, b }) => {})',
+    'test.each()("something", ({ a, b }) => {})',
+    'it.each()("something", ({ a, b }) => {})',
+    'it.each``("something", ({ a, b }) => {})',
     'test("something", async function () {})',
     'test("something", someArg)',
     'beforeEach(() => {})',
@@ -382,6 +386,46 @@ ruleTester.run('no-done-callback', rule, {
               `,
             },
           ],
+        },
+      ],
+    },
+    {
+      code: 'test.each``("something", ({ a, b }, done) => { done(); })',
+      errors: [
+        {
+          messageId: 'noDoneCallback',
+          line: 1,
+          column: 37,
+        },
+      ],
+    },
+    {
+      code: 'test.each()("something", ({ a, b }, done) => { done(); })',
+      errors: [
+        {
+          messageId: 'noDoneCallback',
+          line: 1,
+          column: 37,
+        },
+      ],
+    },
+    {
+      code: 'it.each``("something", ({ a, b }, done) => { done(); })',
+      errors: [
+        {
+          messageId: 'noDoneCallback',
+          line: 1,
+          column: 35,
+        },
+      ],
+    },
+    {
+      code: 'it.each()("something", ({ a, b }, done) => { done(); })',
+      errors: [
+        {
+          messageId: 'noDoneCallback',
+          line: 1,
+          column: 35,
         },
       ],
     },

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -53,7 +53,7 @@ export default createRule({
     return {
       CallExpression(node) {
         // done is the second argument for it.each, not the first
-        const isJestEach = !!getNodeName(node.callee)?.endsWith('.each');
+        const isJestEach = getNodeName(node.callee)?.endsWith('.each') ?? false;
 
         const callback = findCallbackArg(node, isJestEach);
         const callbackArgIndex = Number(isJestEach);

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -14,7 +14,9 @@ const findCallbackArg = (
   node: TSESTree.CallExpression,
   isJestEach: boolean,
 ): TSESTree.CallExpression['arguments'][0] | null => {
-  if (isJestEach) return node.arguments[1];
+  if (isJestEach) {
+    return node.arguments[1];
+  }
 
   if (isHook(node) && node.arguments.length >= 1) {
     return node.arguments[0];
@@ -54,7 +56,7 @@ export default createRule({
         const isJestEach = !!getNodeName(node.callee)?.endsWith('.each');
 
         const callback = findCallbackArg(node, isJestEach);
-        const callbackArgIndex = +isJestEach;
+        const callbackArgIndex = Number(isJestEach);
 
         if (
           !callback ||


### PR DESCRIPTION
Closes #709

my recent PR #701 caused a false positive for `no-done-callback` when used with jest-each (sorry!)

`it.each` uses the first argument for options, and the second argument for the done callback.

This PR fixes the bug and adds test cases for it.each