### PR TITLE
chore: use `dedent` for most tests

### DIFF
--- a/src/rules/__tests__/no-commented-out-tests.test.ts
+++ b/src/rules/__tests__/no-commented-out-tests.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-commented-out-tests';
 
@@ -30,35 +31,35 @@ ruleTester.run('no-commented-out-tests', rule, {
     '// latest(dates)',
     '// TODO: unify with Git implementation from Shipit (?)',
     '#!/usr/bin/env node',
-    [
-      'import { pending } from "actions"',
-      '',
-      'test("foo", () => {',
-      '  expect(pending()).toEqual({})',
-      '})',
-    ].join('\n'),
-    [
-      'const { pending } = require("actions")',
-      '',
-      'test("foo", () => {',
-      '  expect(pending()).toEqual({})',
-      '})',
-    ].join('\n'),
-    [
-      'test("foo", () => {',
-      '  const pending = getPending()',
-      '  expect(pending()).toEqual({})',
-      '})',
-    ].join('\n'),
-    [
-      'test("foo", () => {',
-      '  expect(pending()).toEqual({})',
-      '})',
-      '',
-      'function pending() {',
-      '  return {}',
-      '}',
-    ].join('\n'),
+    dedent`
+      import { pending } from "actions"
+
+      test("foo", () => {
+        expect(pending()).toEqual({})
+      })
+    `,
+    dedent`
+      const { pending } = require("actions")
+
+      test("foo", () => {
+        expect(pending()).toEqual({})
+      })
+    `,
+    dedent`
+      test("foo", () => {
+        const pending = getPending()
+        expect(pending()).toEqual({})
+      })
+    `,
+    dedent`
+      test("foo", () => {
+        expect(pending()).toEqual({})
+      })
+
+      function pending() {
+        return {}
+      }
+    `,
   ],
 
   invalid: [
@@ -119,17 +120,21 @@ ruleTester.run('no-commented-out-tests', rule, {
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
-      code: `// test(
-             //   "foo", function () {}
-             // )`,
+      code: dedent`
+        // test(
+        //   "foo", function () {}
+        // )
+      `,
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
-      code: `/* test
-              (
-                "foo", function () {}
-              )
-              */`,
+      code: dedent`
+        /* test
+          (
+            "foo", function () {}
+          )
+        */
+      `,
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
@@ -153,13 +158,14 @@ ruleTester.run('no-commented-out-tests', rule, {
       errors: [{ messageId: 'commentedTests', column: 1, line: 1 }],
     },
     {
-      code: `
-      foo()
-      /*
-      describe("has title but no callback", () => {})
-      */
-      bar()`,
-      errors: [{ messageId: 'commentedTests', column: 7, line: 3 }],
+      code: dedent`
+        foo()
+        /*
+          describe("has title but no callback", () => {})
+        */
+        bar()
+      `,
+      errors: [{ messageId: 'commentedTests', column: 1, line: 2 }],
     },
   ],
 });

--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-disabled-tests';
 
@@ -28,35 +29,35 @@ ruleTester.run('no-disabled-tests', rule, {
     '(a || b).f()',
     'itHappensToStartWithIt()',
     'testSomething()',
-    [
-      'import { pending } from "actions"',
-      '',
-      'test("foo", () => {',
-      '  expect(pending()).toEqual({})',
-      '})',
-    ].join('\n'),
-    [
-      'const { pending } = require("actions")',
-      '',
-      'test("foo", () => {',
-      '  expect(pending()).toEqual({})',
-      '})',
-    ].join('\n'),
-    [
-      'test("foo", () => {',
-      '  const pending = getPending()',
-      '  expect(pending()).toEqual({})',
-      '})',
-    ].join('\n'),
-    [
-      'test("foo", () => {',
-      '  expect(pending()).toEqual({})',
-      '})',
-      '',
-      'function pending() {',
-      '  return {}',
-      '}',
-    ].join('\n'),
+    dedent`
+      import { pending } from "actions"
+
+      test("foo", () => {
+        expect(pending()).toEqual({})
+      })
+    `,
+    dedent`
+      const { pending } = require("actions")
+
+      test("foo", () => {
+        expect(pending()).toEqual({})
+      })
+    `,
+    dedent`
+      test("foo", () => {
+        const pending = getPending()
+        expect(pending()).toEqual({})
+      })
+    `,
+    dedent`
+      test("foo", () => {
+        expect(pending()).toEqual({})
+      })
+
+      function pending() {
+        return {}
+      }
+    `,
   ],
 
   invalid: [

--- a/src/rules/__tests__/no-duplicate-hooks.test.ts
+++ b/src/rules/__tests__/no-duplicate-hooks.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-duplicate-hooks';
 
@@ -11,202 +12,179 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('basic describe block', rule, {
   valid: [
-    [
-      'describe("foo", () => {',
-      '  beforeEach(() => {',
-      '  }),',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  })',
-      '})',
-    ].join('\n'),
-    [
-      'beforeEach(() => {',
-      '}),',
-      'test("bar", () => {',
-      '  some_fn();',
-      '})',
-    ].join('\n'),
-    [
-      'describe("foo", () => {',
-      '  beforeAll(() => {',
-      '  }),',
-      '  beforeEach(() => {',
-      '  }),',
-      '  afterEach(() => {',
-      '  }),',
-      '  afterAll(() => {',
-      '  }),',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  })',
-      '})',
-    ].join('\n'),
+    dedent`
+      describe("foo", () => {
+        beforeEach(() => {})
+        test("bar", () => {
+          someFn();
+        })
+      })
+    `,
+    dedent`
+      beforeEach(() => {})
+      test("bar", () => {
+        someFn();
+      })
+    `,
+    dedent`
+      describe("foo", () => {
+        beforeAll(() => {}),
+        beforeEach(() => {})
+        afterEach(() => {})
+        afterAll(() => {})
+
+        test("bar", () => {
+          someFn();
+        })
+      })
+    `,
   ],
 
   invalid: [
     {
-      code: [
-        'describe("foo", () => {',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeEach(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
+      code: dedent`
+        describe("foo", () => {
+          beforeEach(() => {}),
+          beforeEach(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
       errors: [
         {
           messageId: 'noDuplicateHook',
           data: { hook: 'beforeEach' },
           column: 3,
-          line: 4,
-        },
-      ],
-    },
-    {
-      code: [
-        'describe.skip("foo", () => {',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeAll(() => {',
-        '  }),',
-        '  beforeAll(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
-      errors: [
-        {
-          messageId: 'noDuplicateHook',
-          data: { hook: 'beforeAll' },
-          column: 3,
-          line: 6,
-        },
-      ],
-    },
-    {
-      code: [
-        'describe.skip("foo", () => {',
-        '  afterEach(() => {',
-        '  }),',
-        '  afterEach(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
-      errors: [
-        {
-          messageId: 'noDuplicateHook',
-          data: { hook: 'afterEach' },
-          column: 3,
-          line: 4,
-        },
-      ],
-    },
-    {
-      code: [
-        'describe.skip("foo", () => {',
-        '  afterAll(() => {',
-        '  }),',
-        '  afterAll(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
-      errors: [
-        {
-          messageId: 'noDuplicateHook',
-          data: { hook: 'afterAll' },
-          column: 3,
-          line: 4,
-        },
-      ],
-    },
-    {
-      code: [
-        'afterAll(() => {',
-        '}),',
-        'afterAll(() => {',
-        '}),',
-        'test("bar", () => {',
-        '  some_fn();',
-        '})',
-      ].join('\n'),
-      errors: [
-        {
-          messageId: 'noDuplicateHook',
-          data: { hook: 'afterAll' },
-          column: 1,
           line: 3,
         },
       ],
     },
     {
-      code: [
-        'describe("foo", () => {',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeEach(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
+      code: dedent`
+        describe.skip("foo", () => {
+          beforeEach(() => {}),
+          beforeAll(() => {}),
+          beforeAll(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
       errors: [
         {
           messageId: 'noDuplicateHook',
-          data: { hook: 'beforeEach' },
+          data: { hook: 'beforeAll' },
           column: 3,
           line: 4,
-        },
-        {
-          messageId: 'noDuplicateHook',
-          data: { hook: 'beforeEach' },
-          column: 3,
-          line: 6,
         },
       ],
     },
     {
-      code: [
-        'describe.skip("foo", () => {',
-        '  afterAll(() => {',
-        '  }),',
-        '  afterAll(() => {',
-        '  }),',
-        '  beforeAll(() => {',
-        '  }),',
-        '  beforeAll(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
+      code: dedent`
+        describe.skip("foo", () => {
+          afterEach(() => {}),
+          afterEach(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noDuplicateHook',
+          data: { hook: 'afterEach' },
+          column: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe.skip("foo", () => {
+          afterAll(() => {}),
+          afterAll(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
       errors: [
         {
           messageId: 'noDuplicateHook',
           data: { hook: 'afterAll' },
           column: 3,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        afterAll(() => {}),
+        afterAll(() => {}),
+        test("bar", () => {
+          someFn();
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noDuplicateHook',
+          data: { hook: 'afterAll' },
+          column: 1,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe("foo", () => {
+          beforeEach(() => {}),
+          beforeEach(() => {}),
+          beforeEach(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noDuplicateHook',
+          data: { hook: 'beforeEach' },
+          column: 3,
+          line: 3,
+        },
+        {
+          messageId: 'noDuplicateHook',
+          data: { hook: 'beforeEach' },
+          column: 3,
           line: 4,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe.skip("foo", () => {
+          afterAll(() => {}),
+          afterAll(() => {}),
+          beforeAll(() => {}),
+          beforeAll(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
+      errors: [
+        {
+          messageId: 'noDuplicateHook',
+          data: { hook: 'afterAll' },
+          column: 3,
+          line: 3,
         },
         {
           messageId: 'noDuplicateHook',
           data: { hook: 'beforeAll' },
           column: 3,
-          line: 8,
+          line: 5,
         },
       ],
     },
@@ -215,58 +193,49 @@ ruleTester.run('basic describe block', rule, {
 
 ruleTester.run('multiple describe blocks', rule, {
   valid: [
-    [
-      'describe.skip("foo", () => {',
-      '  beforeEach(() => {',
-      '  }),',
-      '  beforeAll(() => {',
-      '  }),',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  })',
-      '})',
-      'describe("foo", () => {',
-      '  beforeEach(() => {',
-      '  }),',
-      '  beforeAll(() => {',
-      '  }),',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  })',
-      '})',
-    ].join('\n'),
+    dedent`
+      describe.skip("foo", () => {
+        beforeEach(() => {}),
+        beforeAll(() => {}),
+        test("bar", () => {
+          someFn();
+        })
+      })
+      describe("foo", () => {
+        beforeEach(() => {}),
+        beforeAll(() => {}),
+        test("bar", () => {
+          someFn();
+        })
+      })
+    `,
   ],
 
   invalid: [
     {
-      code: [
-        'describe.skip("foo", () => {',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeAll(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-        'describe("foo", () => {',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeEach(() => {',
-        '  }),',
-        '  beforeAll(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '})',
-      ].join('\n'),
+      code: dedent`
+        describe.skip("foo", () => {
+          beforeEach(() => {}),
+          beforeAll(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+        describe("foo", () => {
+          beforeEach(() => {}),
+          beforeEach(() => {}),
+          beforeAll(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+        })
+      `,
       errors: [
         {
           messageId: 'noDuplicateHook',
           data: { hook: 'beforeEach' },
           column: 3,
-          line: 13,
+          line: 10,
         },
       ],
     },
@@ -275,50 +244,45 @@ ruleTester.run('multiple describe blocks', rule, {
 
 ruleTester.run('nested describe blocks', rule, {
   valid: [
-    [
-      'describe("foo", () => {',
-      '  beforeEach(() => {',
-      '  }),',
-      '  test("bar", () => {',
-      '    some_fn();',
-      '  })',
-      '  describe("inner_foo", () => {',
-      '    beforeEach(() => {',
-      '    })',
-      '    test("inner bar", () => {',
-      '      some_fn();',
-      '    })',
-      '  })',
-      '})',
-    ].join('\n'),
+    dedent`
+      describe("foo", () => {
+        beforeEach(() => {}),
+        test("bar", () => {
+          someFn();
+        })
+        describe("inner_foo", () => {
+          beforeEach(() => {})
+          test("inner bar", () => {
+            someFn();
+          })
+        })
+      })
+    `,
   ],
 
   invalid: [
     {
-      code: [
-        'describe("foo", () => {',
-        '  beforeAll(() => {',
-        '  }),',
-        '  test("bar", () => {',
-        '    some_fn();',
-        '  })',
-        '  describe("inner_foo", () => {',
-        '    beforeEach(() => {',
-        '    })',
-        '    beforeEach(() => {',
-        '    })',
-        '    test("inner bar", () => {',
-        '      some_fn();',
-        '    })',
-        '  })',
-        '})',
-      ].join('\n'),
+      code: dedent`
+        describe("foo", () => {
+          beforeAll(() => {}),
+          test("bar", () => {
+            someFn();
+          })
+          describe("inner_foo", () => {
+            beforeEach(() => {})
+            beforeEach(() => {})
+            test("inner bar", () => {
+              someFn();
+            })
+          })
+        })
+      `,
       errors: [
         {
           messageId: 'noDuplicateHook',
           data: { hook: 'beforeEach' },
           column: 5,
-          line: 10,
+          line: 8,
         },
       ],
     },

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-standalone-expect';
 
@@ -23,19 +24,19 @@ ruleTester.run('no-standalone-expect', rule, {
     '{}',
     'it.each([1, true])("trues", value => { expect(value).toBe(true); });',
     'it.each([1, true])("trues", value => { expect(value).toBe(true); }); it("an it", () => { expect(1).toBe(1) });',
-    `
-    it.each\`
-      num   | value
-      \${1} | \${true}
-    \`('trues', ({ value }) => {
-      expect(value).toBe(true);
-    });
+    dedent`
+      it.each\`
+        num   | value
+        \${1} | \${true}
+      \`('trues', ({ value }) => {
+        expect(value).toBe(true);
+      });
     `,
     'it.only("an only", value => { expect(value).toBe(true); });',
     'it.concurrent("an concurrent", value => { expect(value).toBe(true); });',
     'describe.each([1, true])("trues", value => { it("an it", () => expect(value).toBe(true) ); });',
     {
-      code: `
+      code: dedent`
         describe('scenario', () => {
           const t = Math.random() ? it.only : it;
           t('testing', () => expect(true));
@@ -44,7 +45,7 @@ ruleTester.run('no-standalone-expect', rule, {
       options: [{ additionalTestBlockFunctions: ['t'] }],
     },
     {
-      code: `
+      code: dedent`
         each([
           [1, 1, 2],
           [1, 2, 3],
@@ -62,26 +63,26 @@ ruleTester.run('no-standalone-expect', rule, {
       errors: [{ endColumn: 41, column: 29, messageId: 'unexpectedExpect' }],
     },
     {
-      code: `
+      code: dedent`
         describe('scenario', () => {
           const t = Math.random() ? it.only : it;
           t('testing', () => expect(true));
         });
       `,
-      errors: [{ endColumn: 42, column: 30, messageId: 'unexpectedExpect' }],
+      errors: [{ endColumn: 34, column: 22, messageId: 'unexpectedExpect' }],
     },
     {
-      code: `
+      code: dedent`
         describe('scenario', () => {
           const t = Math.random() ? it.only : it;
           t('testing', () => expect(true));
         });
       `,
       options: [{ additionalTestBlockFunctions: undefined }],
-      errors: [{ endColumn: 42, column: 30, messageId: 'unexpectedExpect' }],
+      errors: [{ endColumn: 34, column: 22, messageId: 'unexpectedExpect' }],
     },
     {
-      code: `
+      code: dedent`
         each([
           [1, 1, 2],
           [1, 2, 3],
@@ -90,10 +91,10 @@ ruleTester.run('no-standalone-expect', rule, {
           expect(a + b).toBe(expected);
         });
       `,
-      errors: [{ endColumn: 24, column: 11, messageId: 'unexpectedExpect' }],
+      errors: [{ endColumn: 16, column: 3, messageId: 'unexpectedExpect' }],
     },
     {
-      code: `
+      code: dedent`
         each([
           [1, 1, 2],
           [1, 2, 3],
@@ -103,10 +104,10 @@ ruleTester.run('no-standalone-expect', rule, {
         });
       `,
       options: [{ additionalTestBlockFunctions: ['each'] }],
-      errors: [{ endColumn: 24, column: 11, messageId: 'unexpectedExpect' }],
+      errors: [{ endColumn: 16, column: 3, messageId: 'unexpectedExpect' }],
     },
     {
-      code: `
+      code: dedent`
         each([
           [1, 1, 2],
           [1, 2, 3],
@@ -116,7 +117,7 @@ ruleTester.run('no-standalone-expect', rule, {
         });
       `,
       options: [{ additionalTestBlockFunctions: ['test'] }],
-      errors: [{ endColumn: 24, column: 11, messageId: 'unexpectedExpect' }],
+      errors: [{ endColumn: 16, column: 3, messageId: 'unexpectedExpect' }],
     },
     {
       code: 'describe("a test", () => { expect(1).toBe(1); });',

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-test-return-statement';
 
@@ -13,52 +14,52 @@ ruleTester.run('no-test-return-statement', rule, {
     'test("noop", () => {});',
     'test("one", () => expect(1).toBe(1));',
     'test("empty")',
-    `
-    test("one", () => {
-      expect(1).toBe(1);
-    });
+    dedent`
+      test("one", () => {
+        expect(1).toBe(1);
+      });
     `,
-    `
-    it("one", function () {
-      expect(1).toBe(1);
-    });
+    dedent`
+      it("one", function () {
+        expect(1).toBe(1);
+      });
     `,
-    `
-    it("one", myTest);
-    function myTest() {
-      expect(1).toBe(1);
-    }
+    dedent`
+      it("one", myTest);
+      function myTest() {
+        expect(1).toBe(1);
+      }
     `,
-    `
-    it("one", () => expect(1).toBe(1));
-    function myHelper() {}
+    dedent`
+      it("one", () => expect(1).toBe(1));
+      function myHelper() {}
     `,
   ],
   invalid: [
     {
-      code: `
-      test("one", () => {
-        return expect(1).toBe(1);
-      });
+      code: dedent`
+        test("one", () => {
+          return expect(1).toBe(1);
+        });
       `,
-      errors: [{ messageId: 'noReturnValue', column: 9, line: 3 }],
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
     },
     {
-      code: `
-      it("one", function () {
-        return expect(1).toBe(1);
-      });
+      code: dedent`
+        it("one", function () {
+          return expect(1).toBe(1);
+        });
       `,
-      errors: [{ messageId: 'noReturnValue', column: 9, line: 3 }],
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
     },
     {
-      code: `
+      code: dedent`
         it("one", myTest);
         function myTest () {
           return expect(1).toBe(1);
         }
       `,
-      errors: [{ messageId: 'noReturnValue', column: 11, line: 4 }],
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 3 }],
     },
   ],
 });

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -11,6 +11,43 @@ const ruleTester = new TSESLint.RuleTester({
 });
 
 ruleTester.run('prefer-expect-assertions', rule, {
+  valid: [
+    'test("it1", () => {expect.assertions(0);})',
+    'test("it1", function() {expect.assertions(0);})',
+    'test("it1", function() {expect.hasAssertions();})',
+    'it("it1", function() {expect.assertions(0);})',
+    dedent`
+      it("it1", function() {
+        expect.assertions(1);
+        expect(someValue).toBe(true)
+      })
+    `,
+    'test("it1")',
+    'itHappensToStartWithIt("foo", function() {})',
+    'testSomething("bar", function() {})',
+    'it(async () => {expect.assertions(0);})',
+    {
+      code: dedent`
+        it("it1", async () => {
+          expect.assertions(1);
+          expect(someValue).toBe(true)
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: dedent`
+        it("it1", function() {
+          expect(someValue).toBe(true)
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: 'it("it1", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+  ],
   invalid: [
     {
       code: 'it("it1", () => {})',
@@ -219,46 +256,6 @@ ruleTester.run('prefer-expect-assertions', rule, {
           line: 1,
         },
       ],
-    },
-  ],
-
-  valid: [
-    {
-      code: 'test("it1", () => {expect.assertions(0);})',
-    },
-    'test("it1", function() {expect.assertions(0);})',
-    'test("it1", function() {expect.hasAssertions();})',
-    'it("it1", function() {expect.assertions(0);})',
-    `
-      it("it1", function() {
-        expect.assertions(1);
-        expect(someValue).toBe(true)
-      })
-    `,
-    'test("it1")',
-    'itHappensToStartWithIt("foo", function() {})',
-    'testSomething("bar", function() {})',
-    'it(async () => {expect.assertions(0);})',
-    {
-      code: dedent`
-        it("it1", async () => {
-          expect.assertions(1);
-          expect(someValue).toBe(true)
-        })
-      `,
-      options: [{ onlyFunctionsWithAsyncKeyword: true }],
-    },
-    {
-      code: dedent`
-        it("it1", function() {
-          expect(someValue).toBe(true)
-        })
-      `,
-      options: [{ onlyFunctionsWithAsyncKeyword: true }],
-    },
-    {
-      code: 'it("it1", () => {})',
-      options: [{ onlyFunctionsWithAsyncKeyword: true }],
     },
   ],
 });

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../valid-expect-in-promise';
 
@@ -11,7 +12,7 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('valid-expect-in-promise', rule, {
   valid: [
-    `
+    dedent`
       it('it1', () => new Promise((done) => {
         test()
           .then(() => {
@@ -20,42 +21,42 @@ ruleTester.run('valid-expect-in-promise', rule, {
           });
       }));
     `,
-    `
+    dedent`
       it('it1', () => {
         return somePromise.then(() => {
           expect(someThing).toEqual(true);
         });
       });
     `,
-    `
+    dedent`
       it('it1', function() {
         return somePromise.catch(function() {
           expect(someThing).toEqual(true);
         });
       });
     `,
-    `
+    dedent`
       it('it1', function() {
         return somePromise.then(function() {
           doSomeThingButNotExpect();
         });
       });
     `,
-    `
+    dedent`
       it('it1', function() {
         return getSomeThing().getPromise().then(function() {
           expect(someThing).toEqual(true);
         });
       });
     `,
-    `
+    dedent`
       it('it1', function() {
         return Promise.resolve().then(function() {
           expect(someThing).toEqual(true);
         });
       });
     `,
-    `
+    dedent`
       it('it1', function () {
         return Promise.resolve().then(function () {
           /*fulfillment*/
@@ -66,7 +67,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
         });
       });
     `,
-    `
+    dedent`
       it('it1', function () {
         return Promise.resolve().then(function () {
           /*fulfillment*/
@@ -76,70 +77,71 @@ ruleTester.run('valid-expect-in-promise', rule, {
         });
       });
     `,
-    `
+    dedent`
       it('it1', function () {
         return somePromise.then()
       });
     `,
-    `
+    dedent`
       it('it1', async () => {
         await Promise.resolve().then(function () {
           expect(someThing).toEqual(true)
         });
       });
     `,
-    `
+    dedent`
       it('it1', async () => {
         await somePromise.then(() => {
           expect(someThing).toEqual(true)
         });
       });
     `,
-    `
+    dedent`
       it('it1', async () => {
         await getSomeThing().getPromise().then(function () {
           expect(someThing).toEqual(true)
         });
       });
     `,
-    `
+    dedent`
       it('it1', () => {
         return somePromise.then(() => {
-            expect(someThing).toEqual(true);
-          })
-          .then(() => {
-            expect(someThing).toEqual(true);
-          })
+          expect(someThing).toEqual(true);
+        })
+        .then(() => {
+          expect(someThing).toEqual(true);
+        })
       });
     `,
-    `
+    dedent`
       it('it1', () => {
         return somePromise.then(() => {
-            expect(someThing).toEqual(true);
-          })
-          .catch(() => {
-            expect(someThing).toEqual(false);
-          })
+          expect(someThing).toEqual(true);
+        })
+        .catch(() => {
+          expect(someThing).toEqual(false);
+        })
       });
     `,
-    `
-     test('later return', () => {
-       const promise = something().then(value => {
-         expect(value).toBe('red');
-       });
-
-       return promise;
-     });
+    dedent`
+      test('later return', () => {
+        const promise = something().then(value => {
+          expect(value).toBe('red');
+        });
+        
+        return promise;
+      });
     `,
-    `
-     it('shorthand arrow', () =>
-       something().then(value => {
-         expect(() => {
-           value();
-         }).toThrow();
-       }));
+    dedent`
+      it('shorthand arrow', () =>
+        something().then(value => {
+          expect(() => {
+            value();
+          }).toThrow();
+        })
+      );
     `,
-    `
+    dedent`
       it('promise test', () => {
         const somePromise = getThatPromise();
         somePromise.then((data) => {
@@ -149,7 +151,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
         return somePromise;
       });
     `,
-    `
+    dedent`
       test('promise test', function () {
         let somePromise = getThatPromise();
         somePromise.then((data) => {
@@ -159,7 +161,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
         return somePromise;
       });
     `,
-    `
+    dedent`
       it('crawls for files based on patterns', () => {
         const promise = nodeCrawl({}).then(data => {
           expect(childProcess.spawn).lastCalledWith('find');
@@ -167,38 +169,46 @@ ruleTester.run('valid-expect-in-promise', rule, {
         return promise;
       });
     `,
-    `
-      it('test function',
+    dedent`
+      it(
+        'test function',
         () => {
-          return Builder.getPromiseBuilder().get().build()
+          return Builder
+            .getPromiseBuilder()
+            .get().build()
             .then((data) => {
               expect(data).toEqual('Hi');
             });
-      });
+        }
+      );
     `,
-    `
-      notATestFunction('not a test function',
+    dedent`
+      notATestFunction(
+        'not a test function',
         () => {
-          Builder.getPromiseBuilder().get().build()
+          Builder
+            .getPromiseBuilder()
+            .get()
+            .build()
             .then((data) => {
               expect(data).toEqual('Hi');
             });
-      });
+        }
+      );
     `,
-    `
+    dedent`
       it("it1", () => somePromise.then(() => {
         expect(someThing).toEqual(true)
       }))
     `,
-    ` it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))`,
-
-    `
+    'it("it1", () => somePromise.then(() => expect(someThing).toEqual(true)))',
+    dedent`
       it('promise test with done', (done) => {
         const promise = getPromise();
         promise.then(() => expect(someThing).toEqual(true));
       });
     `,
-    `
+    dedent`
       it('name of done param does not matter', (nameDoesNotMatter) => {
         const promise = getPromise();
         promise.then(() => expect(someThing).toEqual(true));
@@ -207,14 +217,14 @@ ruleTester.run('valid-expect-in-promise', rule, {
   ],
   invalid: [
     {
-      code: `
-         it('it1', () => {
-           somePromise.then(() => {
-             expect(someThing).toEqual(true);
-           });
-         });
+      code: dedent`
+        it('it1', () => {
+          somePromise.then(() => {
+            expect(someThing).toEqual(true);
+          });
+        });
       `,
-      errors: [{ column: 12, endColumn: 15, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 6, messageId: 'returnPromise' }],
     },
     // {
     //   code: `
@@ -227,49 +237,47 @@ ruleTester.run('valid-expect-in-promise', rule, {
     //   errors: [{ column: 12, endColumn: 15, messageId: 'returnPromise' }],
     // },
     {
-      code: `
+      code: dedent`
         it('it1', function() {
-            getSomeThing().getPromise().then(function() {
-              expect(someThing).toEqual(true);
-            });
+          getSomeThing().getPromise().then(function() {
+            expect(someThing).toEqual(true);
+          });
         });
       `,
-      errors: [{ column: 13, endColumn: 16, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 6, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('it1', function() {
-            Promise.resolve().then(function() {
-              expect(someThing).toEqual(true);
-            });
+          Promise.resolve().then(function() {
+            expect(someThing).toEqual(true);
           });
+        });
       `,
-      errors: [{ column: 13, endColumn: 16, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 6, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('it1', function() {
-            somePromise.catch(function() {
-              expect(someThing).toEqual(true)
-            })
-          }
-        )
+          somePromise.catch(function() {
+            expect(someThing).toEqual(true)
+          })
+        })
       `,
-      errors: [{ column: 13, endColumn: 15, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('it1', function() {
-            somePromise.then(function() {
-              expect(someThing).toEqual(true)
-            })
-          }
-        )
+          somePromise.then(function() {
+            expect(someThing).toEqual(true)
+          })
+        })
       `,
-      errors: [{ column: 13, endColumn: 15, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('it1', function () {
           Promise.resolve().then(/*fulfillment*/ function () {
             expect(someThing).toEqual(true);
@@ -278,10 +286,10 @@ ruleTester.run('valid-expect-in-promise', rule, {
           })
         })
       `,
-      errors: [{ column: 11, endColumn: 13, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('it1', function () {
           Promise.resolve().then(/*fulfillment*/ function () {
           }, /*rejection*/ function () {
@@ -289,37 +297,37 @@ ruleTester.run('valid-expect-in-promise', rule, {
           })
         });
       `,
-      errors: [{ column: 11, endColumn: 13, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('test function', () => {
           Builder.getPromiseBuilder().get().build().then((data) => expect(data).toEqual('Hi'));
         });
       `,
-      errors: [{ column: 11, endColumn: 96, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 88, messageId: 'returnPromise' }],
     },
     {
-      code: `
+      code: dedent`
         it('it1', () => {
-            somePromise.then(() => {
-              doSomeOperation();
-              expect(someThing).toEqual(true);
-            })
-          });
+          somePromise.then(() => {
+            doSomeOperation();
+            expect(someThing).toEqual(true);
+          })
+        });
       `,
-      errors: [{ column: 13, endColumn: 15, messageId: 'returnPromise' }],
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
     },
     {
-      code: `
-         test('invalid return', () => {
-           const promise = something().then(value => {
-             const foo = "foo";
-             return expect(value).toBe('red');
-           });
-         });
+      code: dedent`
+        test('invalid return', () => {
+          const promise = something().then(value => {
+            const foo = "foo";
+            return expect(value).toBe('red');
+          });
+        });
       `,
-      errors: [{ column: 18, endColumn: 14, messageId: 'returnPromise' }],
+      errors: [{ column: 9, endColumn: 5, messageId: 'returnPromise' }],
     },
   ],
 });

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../valid-expect';
 
@@ -54,25 +55,25 @@ ruleTester.run('valid-expect', rule, {
     'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().catch(() => console.log("valid-case")); });',
     'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => console.log("valid-case")).catch(() => console.log("another valid case")); });',
     'test("valid-expect", async () => { await expect(Promise.reject(2)).resolves.not.toBeDefined().then(() => { expect(someMock).toHaveBeenCalledTimes(1); }); });',
-    {
-      code: `test("valid-expect", () => {
-      return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
-        return expect(Promise.resolve(2)).resolves.toBe(1);
+    dedent`
+      test("valid-expect", () => {
+        return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
+          return expect(Promise.resolve(2)).resolves.toBe(1);
+        });
       });
-    });`,
-    },
-    {
-      code: `test("valid-expect", () => {
-      return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
-        await expect(Promise.resolve(2)).resolves.toBe(1);
+    `,
+    dedent`
+      test("valid-expect", () => {
+        return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
+          await expect(Promise.resolve(2)).resolves.toBe(1);
+        });
       });
-    });`,
-    },
-    {
-      code: `test("valid-expect", () => {
-      return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => expect(Promise.resolve(2)).resolves.toBe(1));
-    });`,
-    },
+    `,
+    dedent`
+      test("valid-expect", () => {
+        return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => expect(Promise.resolve(2)).resolves.toBe(1));
+      });
+    `,
     {
       code: 'expect(1).toBe(2);',
       options: [{ maxArgs: 2 }],
@@ -447,22 +448,24 @@ ruleTester.run('valid-expect', rule, {
     },
     // alwaysAwait:false, one not awaited
     {
-      code: `test("valid-expect", async () => {
+      code: dedent`
+        test("valid-expect", async () => {
           expect(Promise.resolve(2)).resolves.not.toBeDefined();
           expect(Promise.resolve(1)).rejects.toBeDefined();
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 64,
+          column: 3,
+          endColumn: 56,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
         {
           line: 3,
-          column: 11,
-          endColumn: 59,
+          column: 3,
+          endColumn: 51,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -470,15 +473,17 @@ ruleTester.run('valid-expect', rule, {
     },
     // alwaysAwait: true, one returned
     {
-      code: `test("valid-expect", async () => {
+      code: dedent`
+        test("valid-expect", async () => {
           await expect(Promise.resolve(2)).resolves.not.toBeDefined();
           expect(Promise.resolve(1)).rejects.toBeDefined();
-        });`,
+        });
+      `,
       errors: [
         {
           line: 3,
-          column: 11,
-          endColumn: 59,
+          column: 3,
+          endColumn: 51,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -489,37 +494,41 @@ ruleTester.run('valid-expect', rule, {
      */
     // both not awaited
     {
-      code: `test("valid-expect", async () => {
+      code: dedent`
+        test("valid-expect", async () => {
           expect(Promise.resolve(2)).resolves.not.toBeDefined();
           return expect(Promise.resolve(1)).rejects.toBeDefined();
-        });`,
+        });
+      `,
       options: [{ alwaysAwait: true }],
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 64,
+          column: 3,
+          endColumn: 56,
           messageId: 'asyncMustBeAwaited',
         },
         {
           line: 3,
-          column: 18,
-          endColumn: 66,
+          column: 10,
+          endColumn: 58,
           messageId: 'asyncMustBeAwaited',
         },
       ],
     },
     // alwaysAwait:true, one not awaited, one returned
     {
-      code: `test("valid-expect", async () => {
+      code: dedent`
+        test("valid-expect", async () => {
           expect(Promise.resolve(2)).resolves.not.toBeDefined();
           return expect(Promise.resolve(1)).rejects.toBeDefined();
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 64,
+          column: 3,
+          endColumn: 56,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -527,16 +536,18 @@ ruleTester.run('valid-expect', rule, {
     },
     // one not awaited
     {
-      code: `test("valid-expect", async () => {
+      code: dedent`
+        test("valid-expect", async () => {
           await expect(Promise.resolve(2)).resolves.not.toBeDefined();
           return expect(Promise.resolve(1)).rejects.toBeDefined();
-        });`,
+        });
+      `,
       options: [{ alwaysAwait: true }],
       errors: [
         {
           line: 3,
-          column: 18,
-          endColumn: 66,
+          column: 10,
+          endColumn: 58,
           messageId: 'asyncMustBeAwaited',
         },
       ],
@@ -546,42 +557,48 @@ ruleTester.run('valid-expect', rule, {
      * Promise.x(expect()) usages
      */
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 81,
+          column: 3,
+          endColumn: 73,
           messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
       ],
     },
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           Promise.reject(expect(Promise.resolve(2)).resolves.not.toBeDefined());
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 80,
+          column: 3,
+          endColumn: 72,
           messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
       ],
     },
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           Promise.x(expect(Promise.resolve(2)).resolves.not.toBeDefined());
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 75,
+          column: 3,
+          endColumn: 67,
           messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -589,33 +606,37 @@ ruleTester.run('valid-expect', rule, {
     },
     // alwaysAwait option changes error message
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           Promise.resolve(expect(Promise.resolve(2)).resolves.not.toBeDefined());
-        });`,
+        });
+      `,
       options: [{ alwaysAwait: true }],
       errors: [
         {
           line: 2,
-          column: 11,
-          endColumn: 81,
+          column: 3,
+          endColumn: 73,
           messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
         },
       ],
     },
     // Promise method accepts arrays and returns 1 error
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           Promise.all([
             expect(Promise.resolve(2)).resolves.not.toBeDefined(),
             expect(Promise.resolve(3)).resolves.not.toBeDefined(),
           ]);
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
+          column: 3,
           endLine: 5,
-          endColumn: 13,
+          endColumn: 5,
           messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -623,18 +644,20 @@ ruleTester.run('valid-expect', rule, {
     },
     // Promise.any([expect1, expect2]) returns one error
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           Promise.x([
             expect(Promise.resolve(2)).resolves.not.toBeDefined(),
             expect(Promise.resolve(3)).resolves.not.toBeDefined(),
           ]);
-        });`,
+        });
+      `,
       errors: [
         {
           line: 2,
-          column: 11,
+          column: 3,
           endLine: 5,
-          endColumn: 13,
+          endColumn: 5,
           messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -642,26 +665,28 @@ ruleTester.run('valid-expect', rule, {
     },
     //
     {
-      code: `test("valid-expect", () => {
+      code: dedent`
+        test("valid-expect", () => {
           const assertions = [
             expect(Promise.resolve(2)).resolves.not.toBeDefined(),
             expect(Promise.resolve(3)).resolves.not.toBeDefined(),
           ]
-        });`,
+        });
+      `,
       errors: [
         {
           line: 3,
-          column: 13,
+          column: 5,
           endLine: 3,
-          endColumn: 66,
+          endColumn: 58,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
         {
           line: 4,
-          column: 13,
+          column: 5,
           endLine: 4,
-          endColumn: 66,
+          endColumn: 58,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
@@ -686,45 +711,51 @@ ruleTester.run('valid-expect', rule, {
       ],
     },
     {
-      code: `test("valid-expect", () => {
-        return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
-          expect(Promise.resolve(2)).resolves.toBe(1);
+      code: dedent`
+        test("valid-expect", () => {
+          return expect(functionReturningAPromise()).resolves.toEqual(1).then(() => {
+            expect(Promise.resolve(2)).resolves.toBe(1);
+          });
         });
-      });`,
+      `,
       errors: [
         {
           line: 3,
-          column: 11,
+          column: 5,
           endLine: 3,
-          endColumn: 54,
+          endColumn: 48,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
       ],
     },
     {
-      code: `test("valid-expect", () => {
-        return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
-          await expect(Promise.resolve(2)).resolves.toBe(1);
-          expect(Promise.resolve(4)).resolves.toBe(4);
+      code: dedent`
+        test("valid-expect", () => {
+          return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
+            await expect(Promise.resolve(2)).resolves.toBe(1);
+            expect(Promise.resolve(4)).resolves.toBe(4);
+          });
         });
-      });`,
+      `,
       errors: [
         {
           line: 4,
-          column: 11,
+          column: 5,
           endLine: 4,
-          endColumn: 54,
+          endColumn: 48,
           messageId: 'asyncMustBeAwaited',
           data: { orReturned: ' or returned' },
         },
       ],
     },
     {
-      code: `test("valid-expect", async () => {
-        await expect(Promise.resolve(1));
-      });`,
-      errors: [{ endColumn: 41, column: 15, messageId: 'matcherNotFound' }],
+      code: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(1));
+        });
+      `,
+      errors: [{ endColumn: 35, column: 9, messageId: 'matcherNotFound' }],
     },
   ],
 });

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -511,11 +511,15 @@ ruleTester.run('no-empty-title', rule, {
       ],
     },
     {
-      code: ["describe('foo', () => {", "it('', () => {})", '})'].join('\n'),
+      code: dedent`
+        describe('foo', () => {
+          it('', () => {});
+        });
+      `,
       errors: [
         {
           messageId: 'emptyTitle',
-          column: 1,
+          column: 3,
           line: 2,
           data: { jestFunctionName: 'test' },
         },
@@ -642,10 +646,10 @@ ruleTester.run('no-accidental-space', rule, {
     'xtest("foo", function () {})',
     'xtest(`foo`, function () {})',
     'someFn("foo", function () {})',
-    `
-    describe('foo', () => {
-      it('bar', () => {})
-    })
+    dedent`
+      describe('foo', () => {
+        it('bar', () => {})
+      })
     `,
   ],
   invalid: [
@@ -765,30 +769,30 @@ ruleTester.run('no-accidental-space', rule, {
       errors: [{ messageId: 'accidentalSpace', column: 7, line: 1 }],
     },
     {
-      code: `
-      describe(' foo', () => {
-        it('bar', () => {})
-      })
+      code: dedent`
+        describe(' foo', () => {
+          it('bar', () => {})
+        })
       `,
-      output: `
-      describe('foo', () => {
-        it('bar', () => {})
-      })
+      output: dedent`
+        describe('foo', () => {
+          it('bar', () => {})
+        })
       `,
-      errors: [{ messageId: 'accidentalSpace', column: 16, line: 2 }],
+      errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
     },
     {
-      code: `
-      describe('foo', () => {
-        it(' bar', () => {})
-      })
+      code: dedent`
+        describe('foo', () => {
+          it(' bar', () => {})
+        })
       `,
-      output: `
-      describe('foo', () => {
-        it('bar', () => {})
-      })
+      output: dedent`
+        describe('foo', () => {
+          it('bar', () => {})
+        })
       `,
-      errors: [{ messageId: 'accidentalSpace', column: 12, line: 3 }],
+      errors: [{ messageId: 'accidentalSpace', column: 6, line: 2 }],
     },
   ],
 });
@@ -896,56 +900,56 @@ ruleTester.run('no-duplicate-prefix ft it', rule, {
 
 ruleTester.run('no-duplicate-prefix ft nested', rule, {
   valid: [
-    `
-    describe('foo', () => {
-      it('bar', () => {})
-    })
+    dedent`
+      describe('foo', () => {
+        it('bar', () => {})
+      })
     `,
-    `
-    describe('foo', () => {
-      it('describes things correctly', () => {})
-    })
+    dedent`
+      describe('foo', () => {
+        it('describes things correctly', () => {})
+      })
     `,
   ],
   invalid: [
     {
-      code: `
-      describe('describe foo', () => {
-        it('bar', () => {})
-      })
+      code: dedent`
+        describe('describe foo', () => {
+          it('bar', () => {})
+        })
       `,
-      output: `
-      describe('foo', () => {
-        it('bar', () => {})
-      })
+      output: dedent`
+        describe('foo', () => {
+          it('bar', () => {})
+        })
       `,
-      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
+      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
     },
     {
-      code: `
-      describe('describe foo', () => {
-        it('describes things correctly', () => {})
-      })
+      code: dedent`
+        describe('describe foo', () => {
+          it('describes things correctly', () => {})
+        })
       `,
-      output: `
-      describe('foo', () => {
-        it('describes things correctly', () => {})
-      })
+      output: dedent`
+        describe('foo', () => {
+          it('describes things correctly', () => {})
+        })
       `,
-      errors: [{ messageId: 'duplicatePrefix', column: 16, line: 2 }],
+      errors: [{ messageId: 'duplicatePrefix', column: 10, line: 1 }],
     },
     {
-      code: `
-      describe('foo', () => {
-        it('it bar', () => {})
-      })
+      code: dedent`
+        describe('foo', () => {
+          it('it bar', () => {})
+        })
       `,
-      output: `
-      describe('foo', () => {
-        it('bar', () => {})
-      })
+      output: dedent`
+        describe('foo', () => {
+          it('bar', () => {})
+        })
       `,
-      errors: [{ messageId: 'duplicatePrefix', column: 12, line: 3 }],
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 2 }],
     },
   ],
 });


### PR DESCRIPTION
The main one left is `no-identical-title`, which is pretty much entirely made up of `].join('\n')` style test cases 😭 