### PR TITLE
fix(lowercase-name): support `.each` methods

### DIFF
--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -13,6 +13,7 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('lowercase-name', rule, {
   valid: [
+    'it.each()',
     'randomFunction()',
     'foo.bar()',
     'it()',
@@ -174,6 +175,30 @@ ruleTester.run('lowercase-name', rule, {
           messageId: 'unexpectedLowercase',
           data: { method: DescribeAlias.describe },
           column: 10,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "it.each(['green', 'black'])('Should return %', () => {})",
+      output: "it.each(['green', 'black'])('should return %', () => {})",
+      errors: [
+        {
+          messageId: 'unexpectedLowercase',
+          data: { method: TestCaseName.it },
+          column: 9,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: "describe.each(['green', 'black'])('Should return %', () => {})",
+      output: "describe.each(['green', 'black'])('should return %', () => {})",
+      errors: [
+        {
+          messageId: 'unexpectedLowercase',
+          data: { method: DescribeAlias.describe },
+          column: 15,
           line: 1,
         },
       ],

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -672,16 +672,18 @@ export const isDescribe = (
     DescribeProperty.hasOwnProperty(node.callee.property.name));
 
 /**
- * Checks if the given `describe` is a call to `describe.each`.
+ * Checks if the given node` is a call to `<describe|test|it>.each(...)`.
+ * If `true`, the code must look like `<method>.each(...)`.
  *
- * @param {JestFunctionCallExpression<DescribeAlias>} node
- * @return {node is JestFunctionCallExpression<DescribeAlias, DescribeProperty.each>}
+ * @param {JestFunctionCallExpression<DescribeAlias | TestCaseName>} node
+ *
+ * @return {node is JestFunctionCallExpressionWithMemberExpressionCallee<DescribeAlias | TestCaseName, DescribeProperty.each | TestCaseProperty.each>}
  */
-export const isDescribeEach = (
-  node: JestFunctionCallExpression<DescribeAlias>,
+export const isEachCall = (
+  node: JestFunctionCallExpression<DescribeAlias | TestCaseName>,
 ): node is JestFunctionCallExpressionWithMemberExpressionCallee<
-  DescribeAlias,
-  DescribeProperty.each
+  DescribeAlias | TestCaseName,
+  DescribeProperty.each | TestCaseProperty.each
 > =>
   node.callee.type === AST_NODE_TYPES.MemberExpression &&
   isSupportedAccessor(node.callee.property, DescribeProperty.each);

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -6,7 +6,7 @@ import {
   createRule,
   getJestFunctionArguments,
   isDescribe,
-  isDescribeEach,
+  isEachCall,
   isFunction,
 } from './utils';
 
@@ -85,7 +85,7 @@ export default createRule({
           });
         }
 
-        if (!isDescribeEach(node) && callback.params.length) {
+        if (!isEachCall(node) && callback.params.length) {
           context.report({
             messageId: 'unexpectedDescribeArgument',
             loc: paramsLocation(callback.params),


### PR DESCRIPTION
Fixes #744 

I've taken the "throw code in the air and see where it settles after a few iterations" refactor method.

I think we could probably extract a helper for checking if a things an `.each`, but not going to try to build it until we've got more rules interacting with `.each`.

Will conflict with #745, so should be rebased before merging.