### PR TITLE
feat(no-duplicate-prefix): check both test and it interchangeably

### DIFF
--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -93,7 +93,9 @@ Examples of **incorrect** code for this rule
 
 ```js
 test('test foo', () => {});
+test('it foo', () => {});
 it('it foo', () => {});
+it('test foo', () => {});
 
 describe('foo', () => {
   test('test bar', () => {});

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -863,6 +863,26 @@ ruleTester.run('no-duplicate-prefix ft test', rule, {
       output: 'test(`foo test`, function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
     },
+    {
+      code: 'test("it foo", function () {})',
+      output: 'test("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
+    },
+    {
+      code: 'xtest("it foo", function () {})',
+      output: 'xtest("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 7, line: 1 }],
+    },
+    {
+      code: 'test(`it foo`, function () {})',
+      output: 'test(`foo`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
+    },
+    {
+      code: 'test(`it foo test`, function () {})',
+      output: 'test(`foo test`, function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 6, line: 1 }],
+    },
   ],
 });
 
@@ -892,6 +912,26 @@ ruleTester.run('no-duplicate-prefix ft it', rule, {
     },
     {
       code: 'it("it foos it correctly", function () {})',
+      output: 'it("foos it correctly", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
+    },
+    {
+      code: 'it("test foo", function () {})',
+      output: 'it("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
+    },
+    {
+      code: 'fit("test foo", function () {})',
+      output: 'fit("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
+    },
+    {
+      code: 'xit("test foo", function () {})',
+      output: 'xit("foo", function () {})',
+      errors: [{ messageId: 'duplicatePrefix', column: 5, line: 1 }],
+    },
+    {
+      code: 'it("test foos it correctly", function () {})',
       output: 'it("foos it correctly", function () {})',
       errors: [{ messageId: 'duplicatePrefix', column: 4, line: 1 }],
     },

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -239,8 +239,14 @@ export default createRule<[Options], MessageIds>({
 
         const nodeName = trimFXprefix(getNodeName(node.callee));
         const [firstWord] = title.split(' ');
+        const lowerCaseFirstWord = firstWord.toLowerCase();
 
-        if (firstWord.toLowerCase() === nodeName) {
+        if (
+          (nodeName === 'describe' && lowerCaseFirstWord === nodeName) ||
+          [nodeName, lowerCaseFirstWord].every(word =>
+            ['test', 'it'].includes(word),
+          )
+        ) {
           context.report({
             messageId: 'duplicatePrefix',
             node: argument,


### PR DESCRIPTION
This resolves https://github.com/jest-community/eslint-plugin-jest/issues/742

With this, `test('it foo', () => {})` and `it('test foo', () => {})` will fail as well. So the new behavior will be:

Examples of **incorrect** code for this rule

```diff
test('test foo', () => {});
+test('it foo', () => {});
it('it foo', () => {});
+it('test foo', () => {});

describe('foo', () => {
  test('test bar', () => {});
});

describe('describe foo', () => {
  test('bar', () => {});
});
```

Examples of **correct** code for this rule

```js
test('foo', () => {});
it('foo', () => {});

describe('foo', () => {
  test('bar', () => {});
});
```