### PR TITLE
fix(no-disabled-tests): adjust selector to match only test functions

### DIFF
--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -29,6 +29,8 @@ ruleTester.run('no-disabled-tests', rule, {
     '(a || b).f()',
     'itHappensToStartWithIt()',
     'testSomething()',
+    'xitSomethingElse()',
+    'xitiViewMap()',
     dedent`
       import { pending } from "actions"
 

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -68,13 +68,13 @@ export default createRule({
       'CallExpression[callee.name="xdescribe"]'(node) {
         context.report({ messageId: 'disabledSuite', node });
       },
-      'CallExpression[callee.name=/^xit|xtest$/]'(node) {
+      'CallExpression[callee.name=/^(xit|xtest)$/]'(node) {
         context.report({ messageId: 'disabledTest', node });
       },
       'CallExpression[callee.name="describe"]:exit'() {
         suiteDepth--;
       },
-      'CallExpression[callee.name=/^it|test$/]:exit'() {
+      'CallExpression[callee.name=/^(it|test)$/]:exit'() {
         testDepth--;
       },
     };


### PR DESCRIPTION
The missing brackets means we're currently checking for `(^xit) OR (xtest$)`