### PR TITLE
fix(no-disabled-tests): support `describe.skip.each` & `xdescribe.each`

### DIFF
--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -66,6 +66,14 @@ ruleTester.run('no-disabled-tests', rule, {
       errors: [{ messageId: 'skippedTestSuite', column: 1, line: 1 }],
     },
     {
+      code: 'describe.skip.each([1, 2, 3])("%s", (a, b) => {});',
+      errors: [{ messageId: 'skippedTestSuite', column: 1, line: 1 }],
+    },
+    {
+      code: 'xdescribe.each([1, 2, 3])("%s", (a, b) => {});',
+      errors: [{ messageId: 'skippedTestSuite', column: 1, line: 1 }],
+    },
+    {
       code: 'describe[`skip`]("foo", function () {})',
       errors: [{ messageId: 'skippedTestSuite', column: 1, line: 1 }],
     },

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -45,6 +45,8 @@ export default createRule({
         }
 
         switch (functionName) {
+          case 'describe.skip.each':
+          case 'xdescribe.each':
           case 'describe.skip':
             context.report({ messageId: 'skippedTestSuite', node });
             break;


### PR DESCRIPTION
#722 makes this just a matter of adding the extra `case`s 🎉 

Relates to #776