### PR TITLE
test(no-test-prefixes): add case for `xdescribe.each`

### DIFF
--- a/src/rules/__tests__/no-test-prefixes.test.ts
+++ b/src/rules/__tests__/no-test-prefixes.test.ts
@@ -47,6 +47,18 @@ ruleTester.run('no-test-prefixes', rule, {
       ],
     },
     {
+      code: 'xdescribe.each([])("foo", function () {})',
+      output: 'describe.skip.each([])("foo", function () {})',
+      errors: [
+        {
+          messageId: 'usePreferredName',
+          data: { preferredNodeName: 'describe.skip.each' },
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
       code: 'fit("foo", function () {})',
       output: 'it.only("foo", function () {})',
       errors: [


### PR DESCRIPTION
#722 fixed the first half of #776 - this is just adding an explicit test case for this situation.

Fixes #776