### PR TITLE
fix(consistent-test-it): false positives inside describe.each

### DIFF
--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -159,6 +159,20 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
       ],
     },
     {
+      code: 'describe.each``("foo", () => { it.each``("bar") })',
+      output: 'describe.each``("foo", () => { test.each``("bar") })',
+      options: [{ fn: TestCaseName.test }],
+      errors: [
+        {
+          messageId: 'consistentMethodWithinDescribe',
+          data: {
+            testKeywordWithinDescribe: TestCaseName.test,
+            oppositeTestKeyword: TestCaseName.it,
+          },
+        },
+      ],
+    },
+    {
       code: 'describe("suite", () => { it("foo") })',
       output: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.test }],
@@ -294,6 +308,20 @@ ruleTester.run('consistent-test-it with fn=it', rule, {
           messageId: 'consistentMethod',
           data: {
             testKeyword: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+        },
+      ],
+    },
+    {
+      code: 'describe.each``("foo", () => { test.each``("bar") })',
+      output: 'describe.each``("foo", () => { it.each``("bar") })',
+      options: [{ fn: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethodWithinDescribe',
+          data: {
+            testKeywordWithinDescribe: TestCaseName.it,
             oppositeTestKeyword: TestCaseName.test,
           },
         },

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -663,6 +663,8 @@ export const isTestCase = (
   // e.g. it.each``()
   (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression &&
     node.callee.tag.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.tag.object.type === AST_NODE_TYPES.Identifier &&
+    TestCaseName.hasOwnProperty(node.callee.tag.object.name) &&
     isSupportedAccessor(node.callee.tag.property, TestCaseProperty.each)) ||
   // e.g. it.concurrent.{skip,only}
   (node.callee.type === AST_NODE_TYPES.MemberExpression &&
@@ -683,7 +685,11 @@ export const isDescribe = (
     node.callee.object.type === AST_NODE_TYPES.Identifier &&
     DescribeAlias.hasOwnProperty(node.callee.object.name) &&
     node.callee.property.type === AST_NODE_TYPES.Identifier &&
-    DescribeProperty.hasOwnProperty(node.callee.property.name));
+    DescribeProperty.hasOwnProperty(node.callee.property.name)) ||
+  (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression &&
+    node.callee.tag.type === AST_NODE_TYPES.MemberExpression &&
+    node.callee.tag.object.type === AST_NODE_TYPES.Identifier &&
+    DescribeAlias.hasOwnProperty(node.callee.tag.object.name));
 
 /**
  * Checks if the given node` is a call to `<describe|test|it>.each(...)`.


### PR DESCRIPTION
I think [this](https://github.com/jest-community/eslint-plugin-jest/pull/722) PR added false positive ESLing errors where `test` inside `describe.each` was actually thought to be `it` inside `describe.each`. (and the other way around) - see failing tests.

The bug exists on the last release (`24.1.7`) but was not present before.

The fix was in the `isDescribe` and `isTestCase` helpers, which ignored the `.each` version with templates.