### PR TITLE
ci: don't run git hooks when in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "jest",
     "tools:regenerate-docs": "ts-node -T tools/regenerate-docs",
     "typecheck": "tsc -p .",
-    "postinstall": "husky install",
+    "postinstall": "is-ci || husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },
@@ -108,6 +108,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.0.0",
     "husky": "^5.1.3",
+    "is-ci": "^3.0.0",
     "jest": "^26.0.1",
     "jest-runner-eslint": "^0.10.0",
     "lint-staged": "^10.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3282,6 +3282,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ci-info@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "ci-info@npm:3.1.1"
+  checksum: 417d2bf17c320d477bc32997d3831bcc1b174d6b48616c2f0463765f042f073bfbfb15e06abdeea55b05ca9c8e054057eb9e0672e4e6031457e87216b2faddda
+  languageName: node
+  linkType: hard
+
 "cidr-regex@npm:^2.0.10":
   version: 2.0.10
   resolution: "cidr-regex@npm:2.0.10"
@@ -4574,6 +4581,7 @@ __metadata:
     eslint-plugin-node: ^11.0.0
     eslint-plugin-prettier: ^3.0.0
     husky: ^5.1.3
+    is-ci: ^3.0.0
     jest: ^26.0.1
     jest-runner-eslint: ^0.10.0
     lint-staged: ^10.2.2
@@ -6102,6 +6110,17 @@ __metadata:
   bin:
     is-ci: bin.js
   checksum: 09083018edafd63221ff0506356f13c0aaf4b75a6435ea648bc67d07ddab199b2d5b9297de43d0821df1a14c18cd9f1edd1775a0166abfe37390843e79137213
+  languageName: node
+  linkType: hard
+
+"is-ci@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "is-ci@npm:3.0.0"
+  dependencies:
+    ci-info: ^3.1.1
+  bin:
+    is-ci: bin.js
+  checksum: 1e26d3ba6634ebee83f9d22f260354c5d950eada4d609c30cc2642069f8ba52f3aeb4c9bbf8099aaf04a2f44a1ed7beef2a24485f988753c8c078a57e9b3a2fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Husky now doesn't handle checking if you're in CI, so we have to ourselves.

This prevented #782 from going out.