### PR TITLE
fix(valid-describe): false positive with template describe.each

### DIFF
--- a/src/rules/__tests__/valid-describe.test.ts
+++ b/src/rules/__tests__/valid-describe.test.ts
@@ -50,6 +50,13 @@ ruleTester.run('valid-describe', rule, {
       if (hasOwnProperty(obj, key)) {
       }
     `,
+    dedent`
+    describe.each\`
+    something | other
+    ${1} | ${2} |
+    \`
+    ("$something", ({ something, other }) => { });
+    `,
   ],
   invalid: [
     {

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -45,7 +45,10 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        if (!isDescribe(node)) {
+        if (
+          !isDescribe(node) ||
+          node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
+        ) {
           return;
         }
 


### PR DESCRIPTION
Due to [my previous fix](https://github.com/jest-community/eslint-plugin-jest/pull/782), now `valid-describe` has false positives 😆 

