### PR TITLE
fix(no-identical-titles): ignore .each template cases

### DIFF
--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-identical-title';
 
@@ -113,6 +114,17 @@ ruleTester.run('no-identical-title', rule, {
       'describe.content(`testing backticks with the same title`);',
       'describe.content(`testing backticks with the same title`);',
     ].join('\n'),
+    dedent`
+    describe.each\`
+      description
+      ${'b'}
+    \`("$description", () => {})
+
+    describe.each\`
+      description
+      ${'a'}
+    \`("$description", () => {})
+    `,
   ],
   invalid: [
     {

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -1,3 +1,4 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
 import {
   createRule,
   getStringValue,
@@ -40,6 +41,10 @@ export default createRule({
     return {
       CallExpression(node) {
         const currentLayer = contexts[contexts.length - 1];
+
+        if (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+          return;
+        }
 
         if (isDescribe(node)) {
           contexts.push(newDescribeContext());


### PR DESCRIPTION
Fixes #786 