### PR TITLE
fix(no-identical-titles): missing describe context

### DIFF
--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -125,6 +125,15 @@ ruleTester.run('no-identical-title', rule, {
       ${'a'}
     \`("$description", () => {})
     `,
+    dedent`
+    describe("top level", () => {
+      describe.each\`\`("nested each", () => {
+        describe.each\`\`("nested nested each", () => {})
+      })
+
+      describe("nested", () => {})
+    })
+    `,
   ],
   invalid: [
     {

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -42,13 +42,14 @@ export default createRule({
       CallExpression(node) {
         const currentLayer = contexts[contexts.length - 1];
 
+        if (isDescribe(node)) {
+          contexts.push(newDescribeContext());
+        }
+
         if (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression) {
           return;
         }
 
-        if (isDescribe(node)) {
-          contexts.push(newDescribeContext());
-        }
         const [argument] = node.arguments;
 
         if (!argument || !isStringNode(argument)) {


### PR DESCRIPTION
In this case, because we pop the describe context on `CallExpression:exit`, but not insert one in the case of a template describe.each, we try to use `describeTitles` of undefined.

