### PR TITLE
fix(no-focused-tests): report on `skip` instead of `concurrent`

### DIFF
--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -114,7 +114,7 @@ ruleTester.run('no-focused-tests', rule, {
       errors: [
         {
           messageId: 'focusedTest',
-          column: 4,
+          column: 15,
           line: 1,
           suggestions: [
             {
@@ -194,7 +194,7 @@ ruleTester.run('no-focused-tests', rule, {
       errors: [
         {
           messageId: 'focusedTest',
-          column: 6,
+          column: 17,
           line: 1,
           suggestions: [
             {

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -99,7 +99,9 @@ export default createRule({
         ) {
           context.report({
             messageId: 'focusedTest',
-            node: calleeObject.property,
+            node: isConcurrentExpression(calleeObject)
+              ? callee.property
+              : calleeObject.property,
             suggest: [
               {
                 messageId: 'suggestRemoveFocus',


### PR DESCRIPTION
Noticed this while working on a refactor of `no-disabled-tests`: #787 changed the location we report on to be the actual `only` property, but doesn't account for `concurrent.only` meaning we're currently reporting on `concurrent` for those cases.