### PR TITLE
fix: support all variations of `describe`, `it`, & `test`

### DIFF
--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -214,6 +214,32 @@ ruleTester.run('consistent-test-it with fn=test', rule, {
       ],
     },
     {
+      code: dedent`
+        describe.only.each()("%s", () => {
+          test("is valid, but should not be", () => {});
+
+          it("is not valid, but should be", () => {});
+        });
+      `,
+      output: dedent`
+        describe.only.each()("%s", () => {
+          it("is valid, but should not be", () => {});
+
+          it("is not valid, but should be", () => {});
+        });
+      `,
+      options: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
+      errors: [
+        {
+          messageId: 'consistentMethodWithinDescribe',
+          data: {
+            testKeywordWithinDescribe: TestCaseName.it,
+            oppositeTestKeyword: TestCaseName.test,
+          },
+        },
+      ],
+    },
+    {
       code: 'describe("suite", () => { it("foo") })',
       output: 'describe("suite", () => { test("foo") })',
       options: [{ fn: TestCaseName.test }],

--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -52,6 +52,10 @@ ruleTester.run('lowercase-name', rule, {
     'describe(function () {})',
     'describe(``)',
     'describe("")',
+    dedent`
+      describe.each()(1);
+      describe.each()(2);
+    `,
     'describe(42)',
     {
       code: 'describe(42)',

--- a/src/rules/__tests__/no-conditional-expect.test.ts
+++ b/src/rules/__tests__/no-conditional-expect.test.ts
@@ -145,6 +145,14 @@ ruleTester.run('logical conditions', rule, {
     },
     {
       code: `
+        it.each\`\`('foo', () => {
+          something || expect(something).toHaveBeenCalled();
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
         function getValue() {
           something || expect(something).toHaveBeenCalled(); 
         }
@@ -197,6 +205,14 @@ ruleTester.run('conditional conditions', rule, {
     {
       code: `
         it('foo', () => {
+          something ? noop() : expect(something).toHaveBeenCalled();
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.each\`\`('foo', () => {
           something ? noop() : expect(something).toHaveBeenCalled();
         })
       `,
@@ -277,6 +293,19 @@ ruleTester.run('switch conditions', rule, {
     },
     {
       code: `
+        it.each\`\`('foo', () => {
+          switch(something) {
+            case 'value':
+              expect(something).toHaveBeenCalled();
+            default:
+              break;
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
         function getValue() {
           switch(something) {
             case 'value':
@@ -334,6 +363,18 @@ ruleTester.run('if conditions', rule, {
     {
       code: `
         it('foo', () => {
+          if(!doSomething) {
+            // do nothing
+          } else {
+            expect(something).toHaveBeenCalled();
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.each\`\`('foo', () => {
           if(!doSomething) {
             // do nothing
           } else {
@@ -429,6 +470,30 @@ ruleTester.run('catch conditions', rule, {
     {
       code: `
         it('foo', () => {
+          try {
+  
+          } catch (err) {
+            expect(err).toMatch('Error');
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.each\`\`('foo', () => {
+          try {
+  
+          } catch (err) {
+            expect(err).toMatch('Error');
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.skip.each\`\`('foo', () => {
           try {
   
           } catch (err) {

--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import resolveFrom from 'resolve-from';
 import rule from '../no-export';
 
@@ -23,7 +24,40 @@ ruleTester.run('no-export', rule, {
   invalid: [
     {
       code:
-        'export const myThing = "invalid";  test("a test", () => { expect(1).toBe(1);});',
+        'export const myThing = "invalid"; test("a test", () => { expect(1).toBe(1);});',
+      parserOptions: { sourceType: 'module' },
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: dedent`
+        export const myThing = 'invalid';
+
+        test.each()('my code', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: dedent`
+        export const myThing = 'invalid';
+
+        test.each\`\`('my code', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: dedent`
+        export const myThing = 'invalid';
+
+        test.only.each\`\`('my code', () => {
+          expect(1).toBe(1);
+        });
+      `,
       parserOptions: { sourceType: 'module' },
       errors: [{ endColumn: 34, column: 1, messageId: 'unexpectedExport' }],
     },

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -814,6 +814,34 @@ ruleTester.run('if statements', rule, {
     },
     {
       code: dedent`
+        it.each\`\`('foo', () => {
+          callExpression()
+          if ('bar') {}
+        })
+      `,
+      errors: [
+        {
+          data: { condition: 'if' },
+          messageId: 'conditionalInTest',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it.only.each\`\`('foo', () => {
+          callExpression()
+          if ('bar') {}
+        })
+      `,
+      errors: [
+        {
+          data: { condition: 'if' },
+          messageId: 'conditionalInTest',
+        },
+      ],
+    },
+    {
+      code: dedent`
         describe('valid', () => {
           describe('still valid', () => {
             it('really still valid', () => {

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -54,6 +54,30 @@ ruleTester.run('no-test-return-statement', rule, {
     },
     {
       code: dedent`
+        it.skip("one", function () {
+          return expect(1).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
+    },
+    {
+      code: dedent`
+        it.each\`\`("one", function () {
+          return expect(1).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
+    },
+    {
+      code: dedent`
+        it.only.each\`\`("one", function () {
+          return expect(1).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
+    },
+    {
+      code: dedent`
         it("one", myTest);
         function myTest () {
           return expect(1).toBe(1);

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -45,6 +45,48 @@ ruleTester.run('basic describe block', rule, {
         },
       ],
     },
+    {
+      code: dedent`
+        describe('foo', () => {
+          beforeEach(() => {});
+          test.each\`\`('bar', () => {
+            someFn();
+          });
+          beforeAll(() => {});
+          test.only('bar', () => {
+            someFn();
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 6,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe('foo', () => {
+          beforeEach(() => {});
+          test.only.each\`\`('bar', () => {
+            someFn();
+          });
+          beforeAll(() => {});
+          test.only('bar', () => {
+            someFn();
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'noHookOnTop',
+          column: 3,
+          line: 6,
+        },
+      ],
+    },
   ],
 });
 

--- a/src/rules/__tests__/require-top-level-describe.test.ts
+++ b/src/rules/__tests__/require-top-level-describe.test.ts
@@ -12,6 +12,7 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('require-top-level-describe', rule, {
   valid: [
+    'it.each()',
     'describe("test suite", () => { test("my test") });',
     'describe("test suite", () => { it("my test") });',
     dedent`
@@ -90,7 +91,23 @@ ruleTester.run('require-top-level-describe', rule, {
       errors: [{ messageId: 'unexpectedHook' }],
     },
     {
+      code: "it.skip('test', () => {});",
+      errors: [{ messageId: 'unexpectedTestCase' }],
+    },
+    {
       code: "it.each([1, 2, 3])('%n', () => {});",
+      errors: [{ messageId: 'unexpectedTestCase' }],
+    },
+    {
+      code: "it.skip.each([1, 2, 3])('%n', () => {});",
+      errors: [{ messageId: 'unexpectedTestCase' }],
+    },
+    {
+      code: "it.skip.each``('%n', () => {});",
+      errors: [{ messageId: 'unexpectedTestCase' }],
+    },
+    {
+      code: "it.each``('%n', () => {});",
       errors: [{ messageId: 'unexpectedTestCase' }],
     },
   ],

--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -1,0 +1,427 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import resolveFrom from 'resolve-from';
+import { createRule, isDescribeCall, isTestCaseCall } from '../utils';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parserOptions: {
+    ecmaVersion: 2015,
+  },
+});
+
+const rule = createRule({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Possible Errors',
+      description: 'Fake rule for testing AST guards',
+      recommended: false,
+    },
+    messages: {
+      foundDescribeCall: 'found a call to `describe`',
+      foundTestCaseCall: 'found a call to a test case',
+    },
+    schema: [],
+    type: 'problem',
+  },
+  defaultOptions: [],
+  create: context => ({
+    CallExpression(node) {
+      const messageId =
+        (isDescribeCall(node) && ('foundDescribeCall' as const)) ||
+        (isTestCaseCall(node) && ('foundTestCaseCall' as const));
+
+      if (messageId) {
+        context.report({
+          messageId,
+          node,
+        });
+      }
+    },
+  }),
+});
+
+ruleTester.run('nonexistent methods', rule, {
+  valid: [
+    'describe.something()',
+    'describe.me()',
+    'test.me()',
+    'it.fails()',
+    'context()',
+    'context.each``()',
+    'context.each()',
+    'describe.context()',
+    'describe.concurrent()()',
+    'describe.concurrent``()',
+    'describe.every``()',
+  ],
+  invalid: [],
+});
+
+ruleTester.run('it', rule, {
+  valid: [
+    'it["concurrent"]["skip"]',
+    'it["concurrent"].skip',
+    'it.concurrent["skip"]',
+    'it.concurrent.skip',
+
+    'it["concurrent"]["only"]',
+    'it["concurrent"].only',
+    'it.concurrent["only"]',
+    'it.concurrent.only',
+
+    'it["skip"]["each"]()',
+    'it["skip"].each()',
+    'it.skip["each"]()',
+    'it.skip.each()',
+
+    'it["skip"]["each"]``',
+    'it["skip"].each``',
+    'it.skip["each"]``',
+    'it.skip.each``',
+
+    'it["only"]["each"]()',
+    'it["only"].each()',
+    'it.only["each"]()',
+    'it.only.each()',
+
+    'it["only"]["each"]``',
+    'it["only"].each``',
+    'it.only["each"]``',
+    'it.only.each``',
+
+    'xit["each"]()',
+    'xit.each()',
+
+    'xit["each"]``',
+    'xit.each``',
+
+    'fit["each"]()',
+    'fit.each()',
+
+    'fit["each"]``',
+    'fit.each``',
+
+    'it["skip"]',
+    'it.skip',
+
+    'it["only"]',
+    'it.only',
+
+    'it["each"]()',
+    'it.each()',
+
+    'it["each"]``',
+    'it.each``',
+
+    'fit',
+    'xit',
+    'it',
+  ],
+  invalid: [
+    ...[
+      'it["concurrent"]["skip"]()',
+      'it["concurrent"].skip()',
+      'it.concurrent["skip"]()',
+      'it.concurrent.skip()',
+
+      'it["concurrent"]["only"]()',
+      'it["concurrent"].only()',
+      'it.concurrent["only"]()',
+      'it.concurrent.only()',
+
+      'it["skip"]["each"]()()',
+      'it["skip"].each()()',
+      'it.skip["each"]()()',
+      'it.skip.each()()',
+
+      'it["skip"]["each"]``()',
+      'it["skip"].each``()',
+      'it.skip["each"]``()',
+      'it.skip.each``()',
+
+      'it["only"]["each"]()()',
+      'it["only"].each()()',
+      'it.only["each"]()()',
+      'it.only.each()()',
+
+      'it["only"]["each"]``()',
+      'it["only"].each``()',
+
+      'it.only["each"]``()',
+      'it.only.each``()',
+
+      'xit["each"]()()',
+      'xit.each()()',
+
+      'xit["each"]``()',
+      'xit.each``()',
+
+      'fit["each"]()()',
+      'fit.each()()',
+
+      'fit["each"]``()',
+      'fit.each``()',
+
+      'it["skip"]()',
+      'it.skip()',
+
+      'it["only"]()',
+      'it.only()',
+
+      'it["each"]()()',
+      'it.each()()',
+
+      'it["each"]``()',
+      'it.each``()',
+
+      'fit()',
+      'xit()',
+      'it()',
+    ].map(code => ({
+      code,
+      errors: [
+        {
+          messageId: 'foundTestCaseCall' as const,
+          data: {},
+          column: 1,
+          line: 1,
+        },
+      ],
+    })),
+  ],
+});
+
+ruleTester.run('test', rule, {
+  valid: [
+    'test["concurrent"]["skip"]',
+    'test["concurrent"].skip',
+    'test.concurrent["skip"]',
+    'test.concurrent.skip',
+
+    'test["concurrent"]["only"]',
+    'test["concurrent"].only',
+    'test.concurrent["only"]',
+    'test.concurrent.only',
+
+    'test["skip"]["each"]()',
+    'test["skip"].each()',
+    'test.skip["each"]()',
+    'test.skip.each()',
+
+    'test["skip"]["each"]``',
+    'test["skip"].each``',
+    'test.skip["each"]``',
+    'test.skip.each``',
+
+    'test["only"]["each"]()',
+    'test["only"].each()',
+    'test.only["each"]()',
+    'test.only.each()',
+
+    'test["only"]["each"]``',
+    'test["only"].each``',
+    'test.only["each"]``',
+    'test.only.each``',
+
+    'xtest["each"]()',
+    'xtest.each()',
+
+    'xtest["each"]``',
+    'xtest.each``',
+
+    'test["skip"]',
+    'test.skip',
+
+    'test["only"]',
+    'test.only',
+
+    'test["each"]()',
+    'test.each()',
+
+    'test["each"]``',
+    'test.each``',
+
+    'xtest',
+    'test',
+  ],
+  invalid: [
+    ...[
+      'test["concurrent"]["skip"]()',
+      'test["concurrent"].skip()',
+      'test.concurrent["skip"]()',
+      'test.concurrent.skip()',
+
+      'test["concurrent"]["only"]()',
+      'test["concurrent"].only()',
+      'test.concurrent["only"]()',
+      'test.concurrent.only()',
+
+      'test["skip"]["each"]()()',
+      'test["skip"].each()()',
+      'test.skip["each"]()()',
+      'test.skip.each()()',
+
+      'test["skip"]["each"]``()',
+      'test["skip"].each``()',
+      'test.skip["each"]``()',
+      'test.skip.each``()',
+
+      'test["only"]["each"]()()',
+      'test["only"].each()()',
+      'test.only["each"]()()',
+      'test.only.each()()',
+
+      'test["only"]["each"]``()',
+      'test["only"].each``()',
+
+      'test.only["each"]``()',
+      'test.only.each``()',
+
+      'xtest["each"]()()',
+      'xtest.each()()',
+
+      'xtest["each"]``()',
+      'xtest.each``()',
+
+      'test["skip"]()',
+      'test.skip()',
+
+      'test["only"]()',
+      'test.only()',
+
+      'test["each"]()()',
+      'test.each()()',
+
+      'test["each"]``()',
+      'test.each``()',
+
+      'xtest()',
+      'test()',
+    ].map(code => ({
+      code,
+      errors: [
+        {
+          messageId: 'foundTestCaseCall' as const,
+          data: {},
+          column: 1,
+          line: 1,
+        },
+      ],
+    })),
+  ],
+});
+
+ruleTester.run('describe', rule, {
+  valid: [
+    'describe["skip"]["each"]()',
+    'describe["skip"].each()',
+    'describe.skip["each"]()',
+    'describe.skip.each()',
+
+    'describe["skip"]["each"]``',
+    'describe["skip"].each``',
+    'describe.skip["each"]``',
+    'describe.skip.each``',
+
+    'describe["only"]["each"]()',
+    'describe["only"].each()',
+    'describe.only["each"]()',
+    'describe.only.each()',
+
+    'describe["only"]["each"]``',
+    'describe["only"].each``',
+    'describe.only["each"]``',
+    'describe.only.each``',
+
+    'xdescribe["each"]()',
+    'xdescribe.each()',
+
+    'xdescribe["each"]``',
+    'xdescribe.each``',
+
+    'fdescribe["each"]()',
+    'fdescribe.each()',
+
+    'fdescribe["each"]``',
+    'fdescribe.each``',
+
+    'describe["skip"]',
+    'describe.skip',
+
+    'describe["only"]',
+    'describe.only',
+
+    'describe["each"]()',
+    'describe.each()',
+
+    'describe["each"]``',
+    'describe.each``',
+
+    'fdescribe',
+    'xdescribe',
+    'describe',
+  ],
+  invalid: [
+    ...[
+      'describe["skip"]["each"]()()',
+      'describe["skip"].each()()',
+      'describe.skip["each"]()()',
+      'describe.skip.each()()',
+
+      'describe["skip"]["each"]``()',
+      'describe["skip"].each``()',
+      'describe.skip["each"]``()',
+      'describe.skip.each``()',
+
+      'describe["only"]["each"]()()',
+      'describe["only"].each()()',
+      'describe.only["each"]()()',
+      'describe.only.each()()',
+
+      'describe["only"]["each"]``()',
+      'describe["only"].each``()',
+
+      'describe.only["each"]``()',
+      'describe.only.each``()',
+
+      'xdescribe["each"]()()',
+      'xdescribe.each()()',
+
+      'xdescribe["each"]``()',
+      'xdescribe.each``()',
+
+      'fdescribe["each"]()()',
+      'fdescribe.each()()',
+
+      'fdescribe["each"]``()',
+      'fdescribe.each``()',
+
+      'describe["skip"]()',
+      'describe.skip()',
+
+      'describe["only"]()',
+      'describe.only()',
+
+      'describe["each"]()()',
+      'describe.each()()',
+
+      'describe["each"]``()',
+      'describe.each``()',
+
+      'fdescribe()',
+      'xdescribe()',
+      'describe()',
+    ].map(code => ({
+      code,
+      errors: [
+        {
+          messageId: 'foundDescribeCall' as const,
+          data: {},
+          column: 1,
+          line: 1,
+        },
+      ],
+    })),
+  ],
+});

--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -58,370 +58,210 @@ ruleTester.run('nonexistent methods', rule, {
   invalid: [],
 });
 
+const itMemberExpressions = [
+  'it["concurrent"]["skip"]',
+  'it["concurrent"].skip',
+  'it.concurrent["skip"]',
+  'it.concurrent.skip',
+
+  'it["concurrent"]["only"]',
+  'it["concurrent"].only',
+  'it.concurrent["only"]',
+  'it.concurrent.only',
+
+  'it["skip"]["each"]()',
+  'it["skip"].each()',
+  'it.skip["each"]()',
+  'it.skip.each()',
+
+  'it["skip"]["each"]``',
+  'it["skip"].each``',
+  'it.skip["each"]``',
+  'it.skip.each``',
+
+  'it["only"]["each"]()',
+  'it["only"].each()',
+  'it.only["each"]()',
+  'it.only.each()',
+
+  'it["only"]["each"]``',
+  'it["only"].each``',
+  'it.only["each"]``',
+  'it.only.each``',
+
+  'xit["each"]()',
+  'xit.each()',
+
+  'xit["each"]``',
+  'xit.each``',
+
+  'fit["each"]()',
+  'fit.each()',
+
+  'fit["each"]``',
+  'fit.each``',
+
+  'it["skip"]',
+  'it.skip',
+
+  'it["only"]',
+  'it.only',
+
+  'it["each"]()',
+  'it.each()',
+
+  'it["each"]``',
+  'it.each``',
+
+  'fit',
+  'xit',
+  'it',
+];
+
 ruleTester.run('it', rule, {
-  valid: [
-    'it["concurrent"]["skip"]',
-    'it["concurrent"].skip',
-    'it.concurrent["skip"]',
-    'it.concurrent.skip',
-
-    'it["concurrent"]["only"]',
-    'it["concurrent"].only',
-    'it.concurrent["only"]',
-    'it.concurrent.only',
-
-    'it["skip"]["each"]()',
-    'it["skip"].each()',
-    'it.skip["each"]()',
-    'it.skip.each()',
-
-    'it["skip"]["each"]``',
-    'it["skip"].each``',
-    'it.skip["each"]``',
-    'it.skip.each``',
-
-    'it["only"]["each"]()',
-    'it["only"].each()',
-    'it.only["each"]()',
-    'it.only.each()',
-
-    'it["only"]["each"]``',
-    'it["only"].each``',
-    'it.only["each"]``',
-    'it.only.each``',
-
-    'xit["each"]()',
-    'xit.each()',
-
-    'xit["each"]``',
-    'xit.each``',
-
-    'fit["each"]()',
-    'fit.each()',
-
-    'fit["each"]``',
-    'fit.each``',
-
-    'it["skip"]',
-    'it.skip',
-
-    'it["only"]',
-    'it.only',
-
-    'it["each"]()',
-    'it.each()',
-
-    'it["each"]``',
-    'it.each``',
-
-    'fit',
-    'xit',
-    'it',
-  ],
-  invalid: [
-    ...[
-      'it["concurrent"]["skip"]()',
-      'it["concurrent"].skip()',
-      'it.concurrent["skip"]()',
-      'it.concurrent.skip()',
-
-      'it["concurrent"]["only"]()',
-      'it["concurrent"].only()',
-      'it.concurrent["only"]()',
-      'it.concurrent.only()',
-
-      'it["skip"]["each"]()()',
-      'it["skip"].each()()',
-      'it.skip["each"]()()',
-      'it.skip.each()()',
-
-      'it["skip"]["each"]``()',
-      'it["skip"].each``()',
-      'it.skip["each"]``()',
-      'it.skip.each``()',
-
-      'it["only"]["each"]()()',
-      'it["only"].each()()',
-      'it.only["each"]()()',
-      'it.only.each()()',
-
-      'it["only"]["each"]``()',
-      'it["only"].each``()',
-
-      'it.only["each"]``()',
-      'it.only.each``()',
-
-      'xit["each"]()()',
-      'xit.each()()',
-
-      'xit["each"]``()',
-      'xit.each``()',
-
-      'fit["each"]()()',
-      'fit.each()()',
-
-      'fit["each"]``()',
-      'fit.each``()',
-
-      'it["skip"]()',
-      'it.skip()',
-
-      'it["only"]()',
-      'it.only()',
-
-      'it["each"]()()',
-      'it.each()()',
-
-      'it["each"]``()',
-      'it.each``()',
-
-      'fit()',
-      'xit()',
-      'it()',
-    ].map(code => ({
-      code,
-      errors: [
-        {
-          messageId: 'foundTestCaseCall' as const,
-          data: {},
-          column: 1,
-          line: 1,
-        },
-      ],
-    })),
-  ],
+  valid: itMemberExpressions,
+  invalid: itMemberExpressions.map(code => ({
+    code: `${code}('works', () => {})`,
+    errors: [
+      {
+        messageId: 'foundTestCaseCall' as const,
+        data: {},
+        column: 1,
+        line: 1,
+      },
+    ],
+  })),
 });
+
+const testMemberExpressions = [
+  'test["concurrent"]["skip"]',
+  'test["concurrent"].skip',
+  'test.concurrent["skip"]',
+  'test.concurrent.skip',
+
+  'test["concurrent"]["only"]',
+  'test["concurrent"].only',
+  'test.concurrent["only"]',
+  'test.concurrent.only',
+
+  'test["skip"]["each"]()',
+  'test["skip"].each()',
+  'test.skip["each"]()',
+  'test.skip.each()',
+
+  'test["skip"]["each"]``',
+  'test["skip"].each``',
+  'test.skip["each"]``',
+  'test.skip.each``',
+
+  'test["only"]["each"]()',
+  'test["only"].each()',
+  'test.only["each"]()',
+  'test.only.each()',
+
+  'test["only"]["each"]``',
+  'test["only"].each``',
+  'test.only["each"]``',
+  'test.only.each``',
+
+  'xtest["each"]()',
+  'xtest.each()',
+
+  'xtest["each"]``',
+  'xtest.each``',
+
+  'test["skip"]',
+  'test.skip',
+
+  'test["only"]',
+  'test.only',
+
+  'test["each"]()',
+  'test.each()',
+
+  'test["each"]``',
+  'test.each``',
+
+  'xtest',
+  'test',
+];
 
 ruleTester.run('test', rule, {
-  valid: [
-    'test["concurrent"]["skip"]',
-    'test["concurrent"].skip',
-    'test.concurrent["skip"]',
-    'test.concurrent.skip',
-
-    'test["concurrent"]["only"]',
-    'test["concurrent"].only',
-    'test.concurrent["only"]',
-    'test.concurrent.only',
-
-    'test["skip"]["each"]()',
-    'test["skip"].each()',
-    'test.skip["each"]()',
-    'test.skip.each()',
-
-    'test["skip"]["each"]``',
-    'test["skip"].each``',
-    'test.skip["each"]``',
-    'test.skip.each``',
-
-    'test["only"]["each"]()',
-    'test["only"].each()',
-    'test.only["each"]()',
-    'test.only.each()',
-
-    'test["only"]["each"]``',
-    'test["only"].each``',
-    'test.only["each"]``',
-    'test.only.each``',
-
-    'xtest["each"]()',
-    'xtest.each()',
-
-    'xtest["each"]``',
-    'xtest.each``',
-
-    'test["skip"]',
-    'test.skip',
-
-    'test["only"]',
-    'test.only',
-
-    'test["each"]()',
-    'test.each()',
-
-    'test["each"]``',
-    'test.each``',
-
-    'xtest',
-    'test',
-  ],
-  invalid: [
-    ...[
-      'test["concurrent"]["skip"]()',
-      'test["concurrent"].skip()',
-      'test.concurrent["skip"]()',
-      'test.concurrent.skip()',
-
-      'test["concurrent"]["only"]()',
-      'test["concurrent"].only()',
-      'test.concurrent["only"]()',
-      'test.concurrent.only()',
-
-      'test["skip"]["each"]()()',
-      'test["skip"].each()()',
-      'test.skip["each"]()()',
-      'test.skip.each()()',
-
-      'test["skip"]["each"]``()',
-      'test["skip"].each``()',
-      'test.skip["each"]``()',
-      'test.skip.each``()',
-
-      'test["only"]["each"]()()',
-      'test["only"].each()()',
-      'test.only["each"]()()',
-      'test.only.each()()',
-
-      'test["only"]["each"]``()',
-      'test["only"].each``()',
-
-      'test.only["each"]``()',
-      'test.only.each``()',
-
-      'xtest["each"]()()',
-      'xtest.each()()',
-
-      'xtest["each"]``()',
-      'xtest.each``()',
-
-      'test["skip"]()',
-      'test.skip()',
-
-      'test["only"]()',
-      'test.only()',
-
-      'test["each"]()()',
-      'test.each()()',
-
-      'test["each"]``()',
-      'test.each``()',
-
-      'xtest()',
-      'test()',
-    ].map(code => ({
-      code,
-      errors: [
-        {
-          messageId: 'foundTestCaseCall' as const,
-          data: {},
-          column: 1,
-          line: 1,
-        },
-      ],
-    })),
-  ],
+  valid: testMemberExpressions,
+  invalid: testMemberExpressions.map(code => ({
+    code: `${code}('works', () => {})`,
+    errors: [
+      {
+        messageId: 'foundTestCaseCall' as const,
+        data: {},
+        column: 1,
+        line: 1,
+      },
+    ],
+  })),
 });
 
+const describeMemberExpressions = [
+  'describe["skip"]["each"]()',
+  'describe["skip"].each()',
+  'describe.skip["each"]()',
+  'describe.skip.each()',
+
+  'describe["skip"]["each"]``',
+  'describe["skip"].each``',
+  'describe.skip["each"]``',
+  'describe.skip.each``',
+
+  'describe["only"]["each"]()',
+  'describe["only"].each()',
+  'describe.only["each"]()',
+  'describe.only.each()',
+
+  'describe["only"]["each"]``',
+  'describe["only"].each``',
+  'describe.only["each"]``',
+  'describe.only.each``',
+
+  'xdescribe["each"]()',
+  'xdescribe.each()',
+
+  'xdescribe["each"]``',
+  'xdescribe.each``',
+
+  'fdescribe["each"]()',
+  'fdescribe.each()',
+
+  'fdescribe["each"]``',
+  'fdescribe.each``',
+
+  'describe["skip"]',
+  'describe.skip',
+
+  'describe["only"]',
+  'describe.only',
+
+  'describe["each"]()',
+  'describe.each()',
+
+  'describe["each"]``',
+  'describe.each``',
+
+  'fdescribe',
+  'xdescribe',
+  'describe',
+];
+
 ruleTester.run('describe', rule, {
-  valid: [
-    'describe["skip"]["each"]()',
-    'describe["skip"].each()',
-    'describe.skip["each"]()',
-    'describe.skip.each()',
-
-    'describe["skip"]["each"]``',
-    'describe["skip"].each``',
-    'describe.skip["each"]``',
-    'describe.skip.each``',
-
-    'describe["only"]["each"]()',
-    'describe["only"].each()',
-    'describe.only["each"]()',
-    'describe.only.each()',
-
-    'describe["only"]["each"]``',
-    'describe["only"].each``',
-    'describe.only["each"]``',
-    'describe.only.each``',
-
-    'xdescribe["each"]()',
-    'xdescribe.each()',
-
-    'xdescribe["each"]``',
-    'xdescribe.each``',
-
-    'fdescribe["each"]()',
-    'fdescribe.each()',
-
-    'fdescribe["each"]``',
-    'fdescribe.each``',
-
-    'describe["skip"]',
-    'describe.skip',
-
-    'describe["only"]',
-    'describe.only',
-
-    'describe["each"]()',
-    'describe.each()',
-
-    'describe["each"]``',
-    'describe.each``',
-
-    'fdescribe',
-    'xdescribe',
-    'describe',
-  ],
-  invalid: [
-    ...[
-      'describe["skip"]["each"]()()',
-      'describe["skip"].each()()',
-      'describe.skip["each"]()()',
-      'describe.skip.each()()',
-
-      'describe["skip"]["each"]``()',
-      'describe["skip"].each``()',
-      'describe.skip["each"]``()',
-      'describe.skip.each``()',
-
-      'describe["only"]["each"]()()',
-      'describe["only"].each()()',
-      'describe.only["each"]()()',
-      'describe.only.each()()',
-
-      'describe["only"]["each"]``()',
-      'describe["only"].each``()',
-
-      'describe.only["each"]``()',
-      'describe.only.each``()',
-
-      'xdescribe["each"]()()',
-      'xdescribe.each()()',
-
-      'xdescribe["each"]``()',
-      'xdescribe.each``()',
-
-      'fdescribe["each"]()()',
-      'fdescribe.each()()',
-
-      'fdescribe["each"]``()',
-      'fdescribe.each``()',
-
-      'describe["skip"]()',
-      'describe.skip()',
-
-      'describe["only"]()',
-      'describe.only()',
-
-      'describe["each"]()()',
-      'describe.each()()',
-
-      'describe["each"]``()',
-      'describe.each``()',
-
-      'fdescribe()',
-      'xdescribe()',
-      'describe()',
-    ].map(code => ({
-      code,
-      errors: [
-        {
-          messageId: 'foundDescribeCall' as const,
-          data: {},
-          column: 1,
-          line: 1,
-        },
-      ],
-    })),
-  ],
+  valid: describeMemberExpressions,
+  invalid: describeMemberExpressions.map(code => ({
+    code: `${code}('works', () => {})`,
+    errors: [
+      {
+        messageId: 'foundDescribeCall' as const,
+        data: {},
+        column: 1,
+        line: 1,
+      },
+    ],
+  })),
 });

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -354,6 +354,26 @@ ruleTester.run('title-must-be-string', rule, {
       ],
     },
     {
+      code: 'it.skip.each([])(1, () => {});',
+      errors: [
+        {
+          messageId: 'titleMustBeString',
+          column: 18,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'it.skip.each``(1, () => {});',
+      errors: [
+        {
+          messageId: 'titleMustBeString',
+          column: 16,
+          line: 1,
+        },
+      ],
+    },
+    {
       code: 'it(123, () => {});',
       errors: [
         {
@@ -657,6 +677,16 @@ ruleTester.run('no-accidental-space', rule, {
       code: 'describe(" foo", function () {})',
       output: 'describe("foo", function () {})',
       errors: [{ messageId: 'accidentalSpace', column: 10, line: 1 }],
+    },
+    {
+      code: 'describe.each()(" foo", function () {})',
+      output: 'describe.each()("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 17, line: 1 }],
+    },
+    {
+      code: 'describe.only.each()(" foo", function () {})',
+      output: 'describe.only.each()("foo", function () {})',
+      errors: [{ messageId: 'accidentalSpace', column: 22, line: 1 }],
     },
     {
       code: 'describe(" foo foe fum", function () {})',

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -7,9 +7,9 @@ import {
   TestCaseName,
   createRule,
   getNodeName,
-  isDescribe,
+  isDescribeCall,
   isEachCall,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const buildFixer = (
@@ -79,7 +79,7 @@ export default createRule<
           return;
         }
 
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           describeNestingLevel++;
         }
 
@@ -89,7 +89,7 @@ export default createRule<
             : node.callee;
 
         if (
-          isTestCase(node) &&
+          isTestCaseCall(node) &&
           describeNestingLevel === 0 &&
           !nodeName.includes(testKeyword)
         ) {
@@ -104,7 +104,7 @@ export default createRule<
         }
 
         if (
-          isTestCase(node) &&
+          isTestCaseCall(node) &&
           describeNestingLevel > 0 &&
           !nodeName.includes(testKeywordWithinDescribe)
         ) {
@@ -121,7 +121,7 @@ export default createRule<
         }
       },
       'CallExpression:exit'(node) {
-        if (isDescribe(node) && !isEachCall(node)) {
+        if (isDescribeCall(node) && !isEachCall(node)) {
           describeNestingLevel--;
         }
       },

--- a/src/rules/lowercase-name.ts
+++ b/src/rules/lowercase-name.ts
@@ -10,10 +10,10 @@ import {
   TestCaseName,
   createRule,
   getStringValue,
-  isDescribe,
+  isDescribeCall,
   isEachCall,
   isStringNode,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 type IgnorableFunctionExpressions =
@@ -29,7 +29,7 @@ const hasStringAsFirstArgument = (
 const findNodeNameAndArgument = (
   node: TSESTree.CallExpression,
 ): [name: string, firstArg: StringNode] | null => {
-  if (!(isTestCase(node) || isDescribe(node))) {
+  if (!(isTestCaseCall(node) || isDescribeCall(node))) {
     return null;
   }
 
@@ -116,7 +116,7 @@ export default createRule<
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           numberOfDescribeBlocks++;
 
           if (ignoreTopLevelDescribe && numberOfDescribeBlocks === 1) {
@@ -170,7 +170,7 @@ export default createRule<
         });
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -3,7 +3,7 @@ import {
   createRule,
   getTestCallExpressionsFromDeclaredVariables,
   isExpectCall,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 export default createRule({
@@ -40,7 +40,7 @@ export default createRule({
         }
       },
       CallExpression(node: TSESTree.CallExpression) {
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           inTestCase = true;
         }
 
@@ -52,7 +52,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           inTestCase = false;
         }
       },

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -7,7 +7,7 @@ import {
   getNodeName,
   isFunction,
   isHook,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const findCallbackArg = (
@@ -22,7 +22,7 @@ const findCallbackArg = (
     return node.arguments[0];
   }
 
-  if (isTestCase(node) && node.arguments.length >= 2) {
+  if (isTestCaseCall(node) && node.arguments.length >= 2) {
     return node.arguments[1];
   }
 

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -1,4 +1,4 @@
-import { createRule, isDescribe, isEachCall, isHook } from './utils';
+import { createRule, isDescribeCall, isEachCall, isHook } from './utils';
 
 const newHookContext = () => ({
   beforeAll: 0,
@@ -27,7 +27,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           hookContexts.push(newHookContext());
         }
 
@@ -45,7 +45,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isDescribe(node) && !isEachCall(node)) {
+        if (isDescribeCall(node) && !isEachCall(node)) {
           hookContexts.pop();
         }
       },

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -2,7 +2,7 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
-import { createRule, isTestCase } from './utils';
+import { createRule, isTestCaseCall } from './utils';
 
 export default createRule({
   name: __filename,
@@ -37,7 +37,7 @@ export default createRule({
       },
 
       CallExpression(node) {
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           hasTestCase = true;
         }
       },

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -2,9 +2,9 @@ import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
 import {
   createRule,
   getStringValue,
-  isDescribe,
+  isDescribeCall,
   isStringNode,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 interface DescribeContext {
@@ -42,7 +42,7 @@ export default createRule({
       CallExpression(node) {
         const currentLayer = contexts[contexts.length - 1];
 
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           contexts.push(newDescribeContext());
         }
 
@@ -58,7 +58,7 @@ export default createRule({
 
         const title = getStringValue(argument);
 
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           if (currentLayer.testTitles.includes(title)) {
             context.report({
               messageId: 'multipleTestTitle',
@@ -68,7 +68,7 @@ export default createRule({
           currentLayer.testTitles.push(title);
         }
 
-        if (!isDescribe(node)) {
+        if (!isDescribeCall(node)) {
           return;
         }
         if (currentLayer.describeTitles.includes(title)) {
@@ -80,7 +80,7 @@ export default createRule({
         currentLayer.describeTitles.push(title);
       },
       'CallExpression:exit'(node) {
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           contexts.pop();
         }
       },

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -7,7 +7,7 @@ import {
   createRule,
   getNodeName,
   getTestCallExpressionsFromDeclaredVariables,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const testCaseNames = new Set<string | null>([
@@ -75,7 +75,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           stack.push(true);
         }
       },

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -7,10 +7,10 @@ import {
   TestCaseName,
   createRule,
   getNodeName,
-  isDescribe,
+  isDescribeCall,
   isExpectCall,
   isFunction,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const getBlockType = (
@@ -39,7 +39,7 @@ const getBlockType = (
     }
 
     // if it's not a variable, it will be callExpr, we only care about describe
-    if (expr.type === AST_NODE_TYPES.CallExpression && isDescribe(expr)) {
+    if (expr.type === AST_NODE_TYPES.CallExpression && isDescribeCall(expr)) {
       return 'describe';
     }
   }
@@ -94,7 +94,7 @@ export default createRule<
       additionalTestBlockFunctions.includes(getNodeName(node) || '');
 
     const isTestBlock = (node: TSESTree.CallExpression): boolean =>
-      isTestCase(node) || isCustomTestBlockFunction(node);
+      isTestCaseCall(node) || isCustomTestBlockFunction(node);
 
     return {
       CallExpression(node) {

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -1,5 +1,10 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
-import { createRule, getNodeName, isDescribe, isTestCase } from './utils';
+import {
+  createRule,
+  getNodeName,
+  isDescribeCall,
+  isTestCaseCall,
+} from './utils';
 
 export default createRule({
   name: __filename,
@@ -22,7 +27,8 @@ export default createRule({
       CallExpression(node) {
         const nodeName = getNodeName(node.callee);
 
-        if (!nodeName || (!isDescribe(node) && !isTestCase(node))) return;
+        if (!nodeName || (!isDescribeCall(node) && !isTestCaseCall(node)))
+          return;
 
         const preferredNodeName = getPreferredNodeName(nodeName);
 

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -6,7 +6,7 @@ import {
   createRule,
   getTestCallExpressionsFromDeclaredVariables,
   isFunction,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const getBody = (args: TSESTree.Expression[]) => {
@@ -41,7 +41,7 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        if (!isTestCase(node)) return;
+        if (!isTestCaseCall(node)) return;
         const body = getBody(node.arguments);
         const returnStmt = body.find(
           t => t.type === AST_NODE_TYPES.ReturnStatement,

--- a/src/rules/no-try-expect.ts
+++ b/src/rules/no-try-expect.ts
@@ -3,7 +3,7 @@ import {
   createRule,
   getTestCallExpressionsFromDeclaredVariables,
   isExpectCall,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 export default createRule({
@@ -37,7 +37,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           isTest = true;
         } else if (isTest && isThrowExpectCall(node)) {
           context.report({
@@ -67,7 +67,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isTestCase(node)) {
+        if (isTestCaseCall(node)) {
           isTest = false;
         }
       },

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -11,7 +11,7 @@ import {
   isEachCall,
   isFunction,
   isSupportedAccessor,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const isExpectAssertionsOrHasAssertionsCall = (
@@ -101,7 +101,7 @@ export default createRule<[RuleOptions], MessageIds>({
   create(context, [options]) {
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        if (!isTestCase(node)) {
+        if (!isTestCaseCall(node)) {
           return;
         }
 

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -1,4 +1,4 @@
-import { createRule, isHook, isTestCase } from './utils';
+import { createRule, isHook, isTestCaseCall } from './utils';
 
 export default createRule({
   name: __filename,
@@ -20,7 +20,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (!isHook(node) && isTestCase(node)) {
+        if (!isHook(node) && isTestCaseCall(node)) {
           hooksContext[hooksContext.length - 1] = true;
         }
         if (hooksContext[hooksContext.length - 1] && isHook(node)) {

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -11,7 +11,7 @@ import {
   hasOnlyOneArgument,
   isFunction,
   isStringNode,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 function isEmptyFunction(node: TSESTree.Expression) {
@@ -36,7 +36,7 @@ function createTodoFixer(
 const isTargetedTestCase = (
   node: TSESTree.CallExpression,
 ): node is JestFunctionCallExpression<TestCaseName> =>
-  isTestCase(node) &&
+  isTestCaseCall(node) &&
   [TestCaseName.it, TestCaseName.test, 'it.skip', 'test.skip'].includes(
     getNodeName(node.callee),
   );

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -1,10 +1,10 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
 import {
   createRule,
-  isDescribe,
+  isDescribeCall,
   isEachCall,
   isHook,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 export default createRule({
@@ -29,14 +29,14 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (isDescribe(node)) {
+        if (isDescribeCall(node)) {
           numberOfDescribeBlocks++;
 
           return;
         }
 
         if (numberOfDescribeBlocks === 0) {
-          if (isTestCase(node)) {
+          if (isTestCaseCall(node)) {
             context.report({ node, messageId: 'unexpectedTestCase' });
 
             return;
@@ -50,7 +50,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isDescribe(node) && !isEachCall(node)) {
+        if (isDescribeCall(node) && !isEachCall(node)) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -10,9 +10,9 @@ import {
   getJestFunctionArguments,
   getNodeName,
   getStringValue,
-  isDescribe,
+  isDescribeCall,
   isStringNode,
-  isTestCase,
+  isTestCaseCall,
 } from './utils';
 
 const trimFXprefix = (word: string) =>
@@ -161,7 +161,7 @@ export default createRule<[Options], MessageIds>({
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        if (!isDescribe(node) && !isTestCase(node)) {
+        if (!isDescribeCall(node) && !isTestCaseCall(node)) {
           return;
         }
 
@@ -181,7 +181,7 @@ export default createRule<[Options], MessageIds>({
 
           if (
             argument.type !== AST_NODE_TYPES.TemplateLiteral &&
-            !(ignoreTypeOfDescribeName && isDescribe(node))
+            !(ignoreTypeOfDescribeName && isDescribeCall(node))
           ) {
             context.report({
               messageId: 'titleMustBeString',
@@ -198,7 +198,7 @@ export default createRule<[Options], MessageIds>({
           context.report({
             messageId: 'emptyTitle',
             data: {
-              jestFunctionName: isDescribe(node)
+              jestFunctionName: isDescribeCall(node)
                 ? DescribeAlias.describe
                 : TestCaseName.test,
             },


### PR DESCRIPTION
We've had a bit of flurry of activity in the last few weeks which has resulted in some of our technical debt coming to the surface, so this is (hopefully) the start of me addressing some of that.

There are two main goals with this refactor:
  * we're consistent by only matching if the given `node` is a *call* i.e it'll result in `jest` doing "something"
    * This is primarily important for `.each`, because of`.each()` - while that looks like a call (and technically is), it's not the "right" kind of call we're wanting to match with these methods.
  * we're matching all possible variations both in terms of properties and accessor style (dot property & square brackets)

Because in a perfect world I'd like this to be the last time I have to think twice about this when using these methods, I've implemented a set of tests using an inline eslint rule to ensure we're matching every possible variation of calls and not-calls for these methods.

The end result was `lowercase-name` losing a point of cover due to not having a test that covers when the names are not strings, and a few "valid" cases for `valid-describe` failing as they're now actually supported (🎉).

Because I'd like to land this as a refactor commit by itself for now, I've renamed the methods so that I can keep the old `isDescribe` around for `valid-describe` to use - I'll be refactoring it once this is landed to support the new guards.

It's also technically a more accurate name anyway 🤷 

-----

Because of the interlocking nature of things, I've picked this as a starting point and deliberately ignored other possible refactors as I think it'll be premature to do them in one lump go - this is why I'm not doing any deduplication on the methods (since they now actually share pretty much the exact same implementation) nor touched the types or other util functions.

My goal is to have this as a stable starting point that I can build other refactors & fixes up around :)