### PR TITLE
fix(prefer-expect-assertions): support `.each`

### DIFF
--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -14,6 +14,7 @@ const ruleTester = new TSESLint.RuleTester({
 ruleTester.run('lowercase-name', rule, {
   valid: [
     'it.each()',
+    'it.each()(1)',
     'randomFunction()',
     'foo.bar()',
     'it()',

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -12,6 +12,7 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('prefer-expect-assertions', rule, {
   valid: [
+    'test("nonsense", [])',
     'test("it1", () => {expect.assertions(0);})',
     'test("it1", function() {expect.assertions(0);})',
     'test("it1", function() {expect.hasAssertions();})',
@@ -254,6 +255,186 @@ ruleTester.run('prefer-expect-assertions', rule, {
           messageId: 'haveExpectAssertions',
           column: 1,
           line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('.each support', rule, {
+  valid: [
+    'test.each()("is fine", () => { expect.assertions(0); })',
+    'test.each``("is fine", () => { expect.assertions(0); })',
+    'test.each()("is fine", () => { expect.hasAssertions(); })',
+    'test.each``("is fine", () => { expect.hasAssertions(); })',
+    'it.each()("is fine", () => { expect.assertions(0); })',
+    'it.each``("is fine", () => { expect.assertions(0); })',
+    'it.each()("is fine", () => { expect.hasAssertions(); })',
+    'it.each``("is fine", () => { expect.hasAssertions(); })',
+    {
+      code: 'test.each()("is fine", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: 'test.each``("is fine", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: 'it.each()("is fine", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: 'it.each``("is fine", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    dedent`
+      describe.each(['hello'])('%s', () => {
+        it('is fine', () => {
+          expect.assertions(0);
+        });
+      });
+    `,
+    dedent`
+      describe.each\`\`('%s', () => {
+        it('is fine', () => {
+          expect.assertions(0);
+        });
+      });
+    `,
+    dedent`
+      describe.each(['hello'])('%s', () => {
+        it('is fine', () => {
+          expect.hasAssertions();
+        });
+      });
+    `,
+    dedent`
+      describe.each\`\`('%s', () => {
+        it('is fine', () => {
+          expect.hasAssertions();
+        });
+      });
+    `,
+    dedent`
+      describe.each(['hello'])('%s', () => {
+        it.each()('is fine', () => {
+          expect.assertions(0);
+        });
+      });
+    `,
+    dedent`
+      describe.each\`\`('%s', () => {
+        it.each()('is fine', () => {
+          expect.assertions(0);
+        });
+      });
+    `,
+    dedent`
+      describe.each(['hello'])('%s', () => {
+        it.each()('is fine', () => {
+          expect.hasAssertions();
+        });
+      });
+    `,
+    dedent`
+      describe.each\`\`('%s', () => {
+        it.each()('is fine', () => {
+          expect.hasAssertions();
+        });
+      });
+    `,
+  ],
+  invalid: [
+    {
+      code: dedent`
+        test.each()("is not fine", () => {
+          expect(someValue).toBe(true);
+        });
+      `,
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe.each()('something', () => {
+          it("is not fine", () => {
+            expect(someValue).toBe(true);
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 3,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe.each()('something', () => {
+          test.each()("is not fine", () => {
+            expect(someValue).toBe(true);
+          });
+        });
+      `,
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 3,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test.each()("is not fine", async () => {
+          expect(someValue).toBe(true);
+        });
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it.each()("is not fine", async () => {
+          expect(someValue).toBe(true);
+        });
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe.each()('something', () => {
+          test.each()("is not fine", async () => {
+            expect(someValue).toBe(true);
+          });
+        });
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 3,
+          line: 2,
         },
       ],
     },

--- a/src/rules/lowercase-name.ts
+++ b/src/rules/lowercase-name.ts
@@ -35,8 +35,8 @@ const findNodeNameAndArgument = (
 
   if (isEachCall(node)) {
     if (
-      node.parent?.type === AST_NODE_TYPES.CallExpression &&
-      hasStringAsFirstArgument(node.parent)
+      node.parent.arguments.length > 0 &&
+      isStringNode(node.parent.arguments[0])
     ) {
       return [node.callee.object.name, node.parent.arguments[0]];
     }

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -692,19 +692,20 @@ export const isDescribe = (
     DescribeAlias.hasOwnProperty(node.callee.tag.object.name));
 
 /**
- * Checks if the given node` is a call to `<describe|test|it>.each(...)`.
- * If `true`, the code must look like `<method>.each(...)`.
+ * Checks if the given node` is a call to `<describe|test|it>.each(...)()`.
+ * If `true`, the code must look like `<method>.each(...)()`.
  *
  * @param {JestFunctionCallExpression<DescribeAlias | TestCaseName>} node
  *
- * @return {node is JestFunctionCallExpressionWithMemberExpressionCallee<DescribeAlias | TestCaseName, DescribeProperty.each | TestCaseProperty.each>}
+ * @return {node is JestFunctionCallExpressionWithMemberExpressionCallee<DescribeAlias | TestCaseName, DescribeProperty.each | TestCaseProperty.each> & {parent: TSESTree.CallExpression}}
  */
 export const isEachCall = (
   node: JestFunctionCallExpression<DescribeAlias | TestCaseName>,
 ): node is JestFunctionCallExpressionWithMemberExpressionCallee<
   DescribeAlias | TestCaseName,
   DescribeProperty.each | TestCaseProperty.each
-> =>
+> & { parent: TSESTree.CallExpression } =>
+  node.parent?.type === AST_NODE_TYPES.CallExpression &&
   node.callee.type === AST_NODE_TYPES.MemberExpression &&
   isSupportedAccessor(node.callee.property, DescribeProperty.each);
 


### PR DESCRIPTION
Fixes #676

Issue was that we were using a specific selector, which couldn't account for `.each` - have refactored the rule to match using conditions instead like the rest of our rules.

Had to modify `isEachCall` in the process - technically it's got a slightly different behaviour as it's stricter, but this is actually what's being checked for in the refactored utils so when #792 is landed this method will be doing the right thing anyway. Plus this hasn't broken any tests so its fine 

(it did break TypeScript, which is why I had to make a change to `lowercase-name` - I'm pretty sure this is another instance of https://github.com/microsoft/TypeScript/issues/35953 but tbh I'm going to look to do a major refactor of our types once I've straighted out the `.each`-based stuff anyway, which'll include dropping some of the generics that we don't really need).