### PR TITLE
fix: improve handling of `.each` calls and with tagged literals

### DIFF
--- a/src/rules/__tests__/lowercase-name.test.ts
+++ b/src/rules/__tests__/lowercase-name.test.ts
@@ -191,7 +191,7 @@ ruleTester.run('lowercase-name', rule, {
         {
           messageId: 'unexpectedLowercase',
           data: { method: TestCaseName.it },
-          column: 9,
+          column: 29,
           line: 1,
         },
       ],
@@ -203,7 +203,7 @@ ruleTester.run('lowercase-name', rule, {
         {
           messageId: 'unexpectedLowercase',
           data: { method: DescribeAlias.describe },
-          column: 15,
+          column: 35,
           line: 1,
         },
       ],

--- a/src/rules/__tests__/no-conditional-expect.test.ts
+++ b/src/rules/__tests__/no-conditional-expect.test.ts
@@ -153,6 +153,14 @@ ruleTester.run('logical conditions', rule, {
     },
     {
       code: `
+        it.each()('foo', () => {
+          something || expect(something).toHaveBeenCalled();
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
         function getValue() {
           something || expect(something).toHaveBeenCalled(); 
         }
@@ -213,6 +221,14 @@ ruleTester.run('conditional conditions', rule, {
     {
       code: `
         it.each\`\`('foo', () => {
+          something ? noop() : expect(something).toHaveBeenCalled();
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.each()('foo', () => {
           something ? noop() : expect(something).toHaveBeenCalled();
         })
       `,
@@ -306,6 +322,19 @@ ruleTester.run('switch conditions', rule, {
     },
     {
       code: `
+        it.each()('foo', () => {
+          switch(something) {
+            case 'value':
+              expect(something).toHaveBeenCalled();
+            default:
+              break;
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
         function getValue() {
           switch(something) {
             case 'value':
@@ -375,6 +404,18 @@ ruleTester.run('if conditions', rule, {
     {
       code: `
         it.each\`\`('foo', () => {
+          if(!doSomething) {
+            // do nothing
+          } else {
+            expect(something).toHaveBeenCalled();
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.each()('foo', () => {
           if(!doSomething) {
             // do nothing
           } else {
@@ -493,7 +534,31 @@ ruleTester.run('catch conditions', rule, {
     },
     {
       code: `
+        it.each()('foo', () => {
+          try {
+  
+          } catch (err) {
+            expect(err).toMatch('Error');
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
         it.skip.each\`\`('foo', () => {
+          try {
+  
+          } catch (err) {
+            expect(err).toMatch('Error');
+          }
+        })
+      `,
+      errors: [{ messageId: 'conditionalExpect' }],
+    },
+    {
+      code: `
+        it.skip.each()('foo', () => {
           try {
   
           } catch (err) {

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -46,7 +46,7 @@ ruleTester.run('no-focused-tests', rule, {
       ],
     },
     {
-      code: 'describe.only.each()',
+      code: 'describe.only.each()()',
       errors: [
         {
           messageId: 'focusedTest',
@@ -55,7 +55,7 @@ ruleTester.run('no-focused-tests', rule, {
           suggestions: [
             {
               messageId: 'suggestRemoveFocus',
-              output: 'describe.each()',
+              output: 'describe.each()()',
             },
           ],
         },
@@ -126,7 +126,7 @@ ruleTester.run('no-focused-tests', rule, {
       ],
     },
     {
-      code: 'it.only.each()',
+      code: 'it.only.each()()',
       errors: [
         {
           messageId: 'focusedTest',
@@ -135,7 +135,7 @@ ruleTester.run('no-focused-tests', rule, {
           suggestions: [
             {
               messageId: 'suggestRemoveFocus',
-              output: 'it.each()',
+              output: 'it.each()()',
             },
           ],
         },
@@ -206,7 +206,7 @@ ruleTester.run('no-focused-tests', rule, {
       ],
     },
     {
-      code: 'test.only.each()',
+      code: 'test.only.each()()',
       errors: [
         {
           messageId: 'focusedTest',
@@ -215,7 +215,7 @@ ruleTester.run('no-focused-tests', rule, {
           suggestions: [
             {
               messageId: 'suggestRemoveFocus',
-              output: 'test.each()',
+              output: 'test.each()()',
             },
           ],
         },
@@ -286,7 +286,7 @@ ruleTester.run('no-focused-tests', rule, {
       ],
     },
     {
-      code: 'fit.each()',
+      code: 'fit.each()()',
       errors: [
         {
           messageId: 'focusedTest',
@@ -295,7 +295,7 @@ ruleTester.run('no-focused-tests', rule, {
           suggestions: [
             {
               messageId: 'suggestRemoveFocus',
-              output: 'it.each()',
+              output: 'it.each()()',
             },
           ],
         },

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -27,6 +27,13 @@ ruleTester.run('conditional expressions', rule, {
         };
       });
     `,
+    dedent`
+      it.each()('foo', function () {
+        const foo = function (bar) {
+          return foo ? bar : null;
+        };
+      });
+    `,
   ],
   invalid: [
     {
@@ -117,6 +124,11 @@ ruleTester.run('switch statements', rule, {
     `,
     dedent`
       describe.skip('foo', () => {
+        switch('bar') {}
+      })
+    `,
+    dedent`
+      describe.skip.each()('foo', () => {
         switch('bar') {}
       })
     `,
@@ -502,6 +514,13 @@ ruleTester.run('if statements', rule, {
       })
     `,
     dedent`
+      describe.each\`\`('foo', () => {
+        afterEach(() => {
+          if('bar') {}
+        });
+      })
+    `,
+    dedent`
       describe('foo', () => {
         beforeEach(() => {
           if('bar') {}
@@ -828,7 +847,35 @@ ruleTester.run('if statements', rule, {
     },
     {
       code: dedent`
+        it.each()('foo', () => {
+          callExpression()
+          if ('bar') {}
+        })
+      `,
+      errors: [
+        {
+          data: { condition: 'if' },
+          messageId: 'conditionalInTest',
+        },
+      ],
+    },
+    {
+      code: dedent`
         it.only.each\`\`('foo', () => {
+          callExpression()
+          if ('bar') {}
+        })
+      `,
+      errors: [
+        {
+          data: { condition: 'if' },
+          messageId: 'conditionalInTest',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it.only.each()('foo', () => {
           callExpression()
           if ('bar') {}
         })

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -70,7 +70,23 @@ ruleTester.run('no-test-return-statement', rule, {
     },
     {
       code: dedent`
+        it.each()("one", function () {
+          return expect(1).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
+    },
+    {
+      code: dedent`
         it.only.each\`\`("one", function () {
+          return expect(1).toBe(1);
+        });
+      `,
+      errors: [{ messageId: 'noReturnValue', column: 3, line: 2 }],
+    },
+    {
+      code: dedent`
+        it.only.each()("one", function () {
           return expect(1).toBe(1);
         });
       `,

--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -20,6 +20,7 @@ const rule = createRule({
     messages: {
       details: [
         'callType', //
+        'numOfArgs',
       ]
         .map(data => `${data}: {{ ${data} }}`)
         .join('\n'),
@@ -38,7 +39,10 @@ const rule = createRule({
         context.report({
           messageId: 'details',
           node,
-          data: { callType },
+          data: {
+            callType,
+            numOfArgs: node.arguments.length,
+          },
         });
       }
     },
@@ -86,7 +90,10 @@ const testUtilsAgainst = (
       errors: [
         {
           messageId: 'details' as const,
-          data: { callType },
+          data: {
+            callType,
+            numOfArgs: 2,
+          },
           column: 1,
           line: 1,
         },

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -8,7 +8,6 @@ import {
   createRule,
   getNodeName,
   isDescribeCall,
-  isEachCall,
   isTestCaseCall,
 } from './utils';
 
@@ -86,6 +85,8 @@ export default createRule<
         const funcNode =
           node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
             ? node.callee.tag
+            : node.callee.type === AST_NODE_TYPES.CallExpression
+            ? node.callee.callee
             : node.callee;
 
         if (
@@ -121,7 +122,7 @@ export default createRule<
         }
       },
       'CallExpression:exit'(node) {
-        if (isDescribeCall(node) && !isEachCall(node)) {
+        if (isDescribeCall(node)) {
           describeNestingLevel--;
         }
       },

--- a/src/rules/lowercase-name.ts
+++ b/src/rules/lowercase-name.ts
@@ -1,17 +1,13 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
 import {
   CallExpressionWithSingleArgument,
   DescribeAlias,
   StringNode,
   TestCaseName,
   createRule,
+  getNodeName,
   getStringValue,
   isDescribeCall,
-  isEachCall,
   isStringNode,
   isTestCaseCall,
 } from './utils';
@@ -33,25 +29,11 @@ const findNodeNameAndArgument = (
     return null;
   }
 
-  if (isEachCall(node)) {
-    if (
-      node.parent.arguments.length > 0 &&
-      isStringNode(node.parent.arguments[0])
-    ) {
-      return [node.callee.object.name, node.parent.arguments[0]];
-    }
-
+  if (!hasStringAsFirstArgument(node)) {
     return null;
   }
 
-  if (
-    node.callee.type !== AST_NODE_TYPES.Identifier ||
-    !hasStringAsFirstArgument(node)
-  ) {
-    return null;
-  }
-
-  return [node.callee.name, node.arguments[0]];
+  return [getNodeName(node).split('.')[0], node.arguments[0]];
 };
 
 export default createRule<

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -1,4 +1,4 @@
-import { createRule, isDescribeCall, isEachCall, isHook } from './utils';
+import { createRule, isDescribeCall, isHook } from './utils';
 
 const newHookContext = () => ({
   beforeAll: 0,
@@ -45,7 +45,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isDescribeCall(node) && !isEachCall(node)) {
+        if (isDescribeCall(node)) {
           hookContexts.pop();
         }
       },

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -77,6 +77,10 @@ export default createRule({
       CallExpression(node) {
         if (isTestCaseCall(node)) {
           stack.push(true);
+
+          if (getNodeName(node).endsWith('each')) {
+            stack.push(true);
+          }
         }
       },
       FunctionExpression(node) {

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -4,7 +4,6 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import {
   DescribeAlias,
-  TestCaseName,
   createRule,
   getNodeName,
   isDescribeCall,
@@ -46,14 +45,6 @@ const getBlockType = (
 
   return null;
 };
-
-const isEach = (node: TSESTree.CallExpression): boolean =>
-  node.callee.type === AST_NODE_TYPES.CallExpression &&
-  node.callee.callee.type === AST_NODE_TYPES.MemberExpression &&
-  node.callee.callee.property.type === AST_NODE_TYPES.Identifier &&
-  node.callee.callee.property.name === 'each' &&
-  node.callee.callee.object.type === AST_NODE_TYPES.Identifier &&
-  TestCaseName.hasOwnProperty(node.callee.callee.object.name);
 
 type BlockType = 'test' | 'function' | 'describe' | 'arrow' | 'template';
 
@@ -121,9 +112,8 @@ export default createRule<
 
         if (
           (top === 'test' &&
-            (isEach(node) ||
-              (isTestBlock(node) &&
-                node.callee.type !== AST_NODE_TYPES.MemberExpression))) ||
+            isTestBlock(node) &&
+            node.callee.type !== AST_NODE_TYPES.MemberExpression) ||
           (top === 'template' &&
             node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression)
         ) {

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -37,6 +37,8 @@ export default createRule({
         const funcNode =
           node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
             ? node.callee.tag
+            : node.callee.type === AST_NODE_TYPES.CallExpression
+            ? node.callee.callee
             : node.callee;
 
         context.report({

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -8,7 +8,6 @@ import {
   createRule,
   getAccessorValue,
   hasOnlyOneArgument,
-  isEachCall,
   isFunction,
   isSupportedAccessor,
   isTestCaseCall,
@@ -105,13 +104,11 @@ export default createRule<[RuleOptions], MessageIds>({
           return;
         }
 
-        const args = isEachCall(node) ? node.parent.arguments : node.arguments;
-
-        if (args.length < 2) {
+        if (node.arguments.length < 2) {
           return;
         }
 
-        const [, testFn] = args;
+        const [, testFn] = node.arguments;
 
         if (
           !isFunction(testFn) ||

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -28,7 +28,7 @@ function createTodoFixer(
   node: JestFunctionCallExpression<TestCaseName>,
   fixer: TSESLint.RuleFixer,
 ) {
-  const testName = getNodeName(node.callee).split('.').shift();
+  const testName = getNodeName(node).split('.').shift();
 
   return fixer.replaceText(node.callee, `${testName}.todo`);
 }
@@ -38,7 +38,7 @@ const isTargetedTestCase = (
 ): node is JestFunctionCallExpression<TestCaseName> =>
   isTestCaseCall(node) &&
   [TestCaseName.it, TestCaseName.test, 'it.skip', 'test.skip'].includes(
-    getNodeName(node.callee),
+    getNodeName(node),
   );
 
 export default createRule({

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -1,11 +1,5 @@
 import { TSESTree } from '@typescript-eslint/experimental-utils';
-import {
-  createRule,
-  isDescribeCall,
-  isEachCall,
-  isHook,
-  isTestCaseCall,
-} from './utils';
+import { createRule, isDescribeCall, isHook, isTestCaseCall } from './utils';
 
 export default createRule({
   name: __filename,
@@ -50,7 +44,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isDescribeCall(node) && !isEachCall(node)) {
+        if (isDescribeCall(node)) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -794,39 +794,6 @@ export const isDescribeCall = (
   return false;
 };
 
-/**
- * Checks if the given node` is a call to `<describe|test|it>.each(...)()`.
- * If `true`, the code must look like `<method>.each(...)()`.
- *
- * @param {JestFunctionCallExpression<DescribeAlias | TestCaseName>} node
- *
- * @return {node is JestFunctionCallExpressionWithMemberExpressionCallee<DescribeAlias | TestCaseName, DescribeProperty.each | TestCaseProperty.each> & {parent: TSESTree.CallExpression}}
- */
-export const isEachCall = (
-  node: JestFunctionCallExpression<DescribeAlias | TestCaseName>,
-): node is JestEachCallExpression<DescribeAlias | TestCaseName> =>
-  getNodeName(node).endsWith('each');
-
-/**
- * Gets the arguments of the given `JestFunctionCallExpression`.
- *
- * If the `node` is an `each` call, then the arguments of the actual suite
- * are returned, rather then the `each` array argument.
- *
- * @param {JestFunctionCallExpression<DescribeAlias | TestCaseName>} node
- *
- * @return {Expression[]}
- */
-export const getJestFunctionArguments = (
-  node: JestFunctionCallExpression<DescribeAlias | TestCaseName>,
-) =>
-  node.callee.type === AST_NODE_TYPES.MemberExpression &&
-  isSupportedAccessor(node.callee.property, DescribeProperty.each) &&
-  node.parent &&
-  node.parent.type === AST_NODE_TYPES.CallExpression
-    ? node.parent.arguments
-    : node.arguments;
-
 const collectReferences = (scope: TSESLint.Scope.Scope) => {
   const locals = new Set();
   const unresolved = new Set();

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -262,7 +262,7 @@ export const getAccessorValue = <S extends string = string>(
     ? accessor.name
     : getStringValue(accessor);
 
-type AccessorNode<Specifics extends string = string> =
+export type AccessorNode<Specifics extends string = string> =
   | StringNode<Specifics>
   | KnownIdentifier<Specifics>;
 
@@ -609,7 +609,10 @@ type JestEachCallExpression<
 > = JestCalledEachCallExpression<TName> | JestTaggedEachCallExpression<TName>;
 
 export type JestFunctionCallExpression<
-  FunctionName extends Exclude<JestFunctionName, HookName>
+  FunctionName extends Exclude<JestFunctionName, HookName> = Exclude<
+    JestFunctionName,
+    HookName
+  >
 > =
   | JestEachCallExpression<FunctionName>
   | JestFunctionCallExpressionWithMemberExpressionCallee<FunctionName>

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -2,13 +2,7 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
-import {
-  createRule,
-  getJestFunctionArguments,
-  isDescribeCall,
-  isEachCall,
-  isFunction,
-} from './utils';
+import { createRule, isDescribeCall, isEachCall, isFunction } from './utils';
 
 const paramsLocation = (
   params: TSESTree.Expression[] | TSESTree.Parameter[],
@@ -45,28 +39,23 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        if (
-          !isDescribeCall(node) ||
-          node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
-        ) {
+        if (!isDescribeCall(node)) {
           return;
         }
 
-        const nodeArguments = getJestFunctionArguments(node);
-
-        if (nodeArguments.length < 1) {
+        if (node.arguments.length < 1) {
           return context.report({
             messageId: 'nameAndCallback',
             loc: node.loc,
           });
         }
 
-        const [, callback] = nodeArguments;
+        const [, callback] = node.arguments;
 
         if (!callback) {
           context.report({
             messageId: 'nameAndCallback',
-            loc: paramsLocation(nodeArguments),
+            loc: paramsLocation(node.arguments),
           });
 
           return;
@@ -75,7 +64,7 @@ export default createRule({
         if (!isFunction(callback)) {
           context.report({
             messageId: 'secondArgumentMustBeFunction',
-            loc: paramsLocation(nodeArguments),
+            loc: paramsLocation(node.arguments),
           });
 
           return;

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -2,7 +2,7 @@ import {
   AST_NODE_TYPES,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
-import { createRule, isDescribeCall, isEachCall, isFunction } from './utils';
+import { createRule, getNodeName, isDescribeCall, isFunction } from './utils';
 
 const paramsLocation = (
   params: TSESTree.Expression[] | TSESTree.Parameter[],
@@ -77,7 +77,7 @@ export default createRule({
           });
         }
 
-        if (!isEachCall(node) && callback.params.length) {
+        if (!getNodeName(node).endsWith('each') && callback.params.length) {
           context.report({
             messageId: 'unexpectedDescribeArgument',
             loc: paramsLocation(callback.params),

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -237,7 +237,7 @@ export default createRule<[Options], MessageIds>({
           });
         }
 
-        const nodeName = trimFXprefix(getNodeName(node.callee));
+        const nodeName = trimFXprefix(getNodeName(node));
         const [firstWord] = title.split(' ');
 
         if (firstWord.toLowerCase() === nodeName) {

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -7,7 +7,6 @@ import {
   StringNode,
   TestCaseName,
   createRule,
-  getJestFunctionArguments,
   getNodeName,
   getStringValue,
   isDescribeCall,
@@ -165,7 +164,7 @@ export default createRule<[Options], MessageIds>({
           return;
         }
 
-        const [argument] = getJestFunctionArguments(node);
+        const [argument] = node.arguments;
 
         if (!argument) {
           return;


### PR DESCRIPTION
Implements the change described [here](https://github.com/jest-community/eslint-plugin-jest/pull/792#issuecomment-803498682), so that `isDescribeCall` and `isTestCaseCall` now return `true` for the outer `CallExpression` in `.each()()` calls, meaning matched nodes are now consistent as it'll always be the top-most one.

This has let us shed a bunch of edge-case code across our rules and utils, and also made it easy to refactor `no-focused-tests` so that it's 1/3rd smaller 🎉 

Because of the mix of dependent and independent changes, I'm going to open this PR as a draft, and cherry pick some of the changes out into their own PRs.

Resolves #809
Resolves #810
Resolves #811