### PR TITLE
docs(no-focused-tests): remove references to `ftest` method

### DIFF
--- a/docs/rules/no-focused-tests.md
+++ b/docs/rules/no-focused-tests.md
@@ -12,7 +12,7 @@ whenever you are using the exclusivity feature.
 ## Rule Details
 
 This rule looks for every `describe.only`, `it.only`, `test.only`, `fdescribe`,
-`fit` and `ftest` occurrences within the source code. Of course there are some
+and `fit` occurrences within the source code. Of course there are some
 edge-cases which can’t be detected by this rule e.g.:
 
 ```js
@@ -31,11 +31,7 @@ test.only('foo', () => {});
 test['only']('bar', () => {});
 fdescribe('foo', () => {});
 fit('foo', () => {});
-ftest('bar', () => {});
 fit.each`
-  table
-`();
-ftest.each`
   table
 `();
 ```

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -317,21 +317,5 @@ ruleTester.run('no-focused-tests', rule, {
         },
       ],
     },
-    {
-      code: 'ftest.each`table`()',
-      errors: [
-        {
-          messageId: 'focusedTest',
-          column: 1,
-          line: 1,
-          suggestions: [
-            {
-              messageId: 'suggestRemoveFocus',
-              output: 'test.each`table`()',
-            },
-          ],
-        },
-      ],
-    },
   ],
 });


### PR DESCRIPTION
There's no such prefixed method for `test`; only `fit` & `fdescribe`