### PR TITLE
fix(valid-describe): support using `each` with modifiers

### DIFF
--- a/src/rules/__tests__/valid-describe.test.ts
+++ b/src/rules/__tests__/valid-describe.test.ts
@@ -12,11 +12,6 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('valid-describe', rule, {
   valid: [
-    'describe["each"]()()',
-    'describe["each"](() => {})()',
-    'describe["each"](() => {})("foo")',
-    'describe["each"]()(() => {})',
-    'describe["each"]("foo")(() => {})',
     'describe.each([1, 2, 3])("%s", (a, b) => {});',
     'describe("foo", function() {})',
     'describe("foo", () => {})',
@@ -51,16 +46,19 @@ ruleTester.run('valid-describe', rule, {
       }
     `,
     dedent`
-    describe.each\`
-    something | other
-    ${1} | ${2} |
-    \`
-    ("$something", ({ something, other }) => { });
+      describe.each\`
+        foo  | foe
+        ${1} | ${2}
+      \`('$something', ({ foo, foe }) => {});
     `,
   ],
   invalid: [
     {
       code: 'describe.each()()',
+      errors: [{ messageId: 'nameAndCallback', line: 1, column: 1 }],
+    },
+    {
+      code: 'describe["each"]()()',
       errors: [{ messageId: 'nameAndCallback', line: 1, column: 1 }],
     },
     {
@@ -76,8 +74,16 @@ ruleTester.run('valid-describe', rule, {
       errors: [{ messageId: 'nameAndCallback', line: 1, column: 17 }],
     },
     {
+      code: 'describe["each"]()(() => {})',
+      errors: [{ messageId: 'nameAndCallback', line: 1, column: 20 }],
+    },
+    {
       code: 'describe.each("foo")(() => {})',
       errors: [{ messageId: 'nameAndCallback', line: 1, column: 22 }],
+    },
+    {
+      code: 'describe.only.each("foo")(() => {})',
+      errors: [{ messageId: 'nameAndCallback', line: 1, column: 27 }],
     },
     {
       code: 'describe(() => {})',

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -763,21 +763,6 @@ export const isDescribeCall = (
   return false;
 };
 
-export const isDescribe = (
-  node: TSESTree.CallExpression,
-): node is JestFunctionCallExpression<DescribeAlias> =>
-  (node.callee.type === AST_NODE_TYPES.Identifier &&
-    DescribeAlias.hasOwnProperty(node.callee.name)) ||
-  (node.callee.type === AST_NODE_TYPES.MemberExpression &&
-    node.callee.object.type === AST_NODE_TYPES.Identifier &&
-    DescribeAlias.hasOwnProperty(node.callee.object.name) &&
-    node.callee.property.type === AST_NODE_TYPES.Identifier &&
-    DescribeProperty.hasOwnProperty(node.callee.property.name)) ||
-  (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression &&
-    node.callee.tag.type === AST_NODE_TYPES.MemberExpression &&
-    node.callee.tag.object.type === AST_NODE_TYPES.Identifier &&
-    DescribeAlias.hasOwnProperty(node.callee.tag.object.name));
-
 /**
  * Checks if the given node` is a call to `<describe|test|it>.each(...)()`.
  * If `true`, the code must look like `<method>.each(...)()`.

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -5,7 +5,7 @@ import {
 import {
   createRule,
   getJestFunctionArguments,
-  isDescribe,
+  isDescribeCall,
   isEachCall,
   isFunction,
 } from './utils';
@@ -46,7 +46,7 @@ export default createRule({
     return {
       CallExpression(node) {
         if (
-          !isDescribe(node) ||
+          !isDescribeCall(node) ||
           node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression
         ) {
           return;


### PR DESCRIPTION
This cherry-picks the change I made in #814 to have `valid-describe` use the new `isDescribeCall` util, thus giving it better support for `describe.each`.