### PR TITLE
feat: create `prefer-to-be-for-literals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ installations requiring long-term consistency.
 | [prefer-hooks-on-top](docs/rules/prefer-hooks-on-top.md)                     | Suggest having hooks before any test cases                      |                  |              |
 | [prefer-spy-on](docs/rules/prefer-spy-on.md)                                 | Suggest using `jest.spyOn()`                                    |                  | ![fixable][] |
 | [prefer-strict-equal](docs/rules/prefer-strict-equal.md)                     | Suggest using `toStrictEqual()`                                 |                  | ![suggest][] |
-| [prefer-to-be-for-literals](docs/rules/prefer-to-be-for-literals.md)         | Suggest using `tooBe()` for primitive literals                  |                  | ![fixable][] |
+| [prefer-to-be-for-literals](docs/rules/prefer-to-be-for-literals.md)         | Suggest using `toBe()` for primitive literals                   |                  | ![fixable][] |
 | [prefer-to-be-null](docs/rules/prefer-to-be-null.md)                         | Suggest using `toBeNull()`                                      | ![style][]       | ![fixable][] |
 | [prefer-to-be-undefined](docs/rules/prefer-to-be-undefined.md)               | Suggest using `toBeUndefined()`                                 | ![style][]       | ![fixable][] |
 | [prefer-to-contain](docs/rules/prefer-to-contain.md)                         | Suggest using `toContain()`                                     | ![style][]       | ![fixable][] |

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ installations requiring long-term consistency.
 | [prefer-hooks-on-top](docs/rules/prefer-hooks-on-top.md)                     | Suggest having hooks before any test cases                      |                  |              |
 | [prefer-spy-on](docs/rules/prefer-spy-on.md)                                 | Suggest using `jest.spyOn()`                                    |                  | ![fixable][] |
 | [prefer-strict-equal](docs/rules/prefer-strict-equal.md)                     | Suggest using `toStrictEqual()`                                 |                  | ![suggest][] |
+| [prefer-to-be-for-literals](docs/rules/prefer-to-be-for-literals.md)         | Suggest using `tooBe()` for primitive literals                  |                  | ![fixable][] |
 | [prefer-to-be-null](docs/rules/prefer-to-be-null.md)                         | Suggest using `toBeNull()`                                      | ![style][]       | ![fixable][] |
 | [prefer-to-be-undefined](docs/rules/prefer-to-be-undefined.md)               | Suggest using `toBeUndefined()`                                 | ![style][]       | ![fixable][] |
 | [prefer-to-contain](docs/rules/prefer-to-contain.md)                         | Suggest using `toContain()`                                     | ![style][]       | ![fixable][] |

--- a/docs/rules/prefer-to-be-for-literals.md
+++ b/docs/rules/prefer-to-be-for-literals.md
@@ -1,4 +1,4 @@
-# Suggest using `tooBe()` for primitive literals (`prefer-to-be-for-literals`)
+# Suggest using `toBe()` for primitive literals (`prefer-to-be-for-literals`)
 
 When asserting against primitive literals such as numbers and strings, the
 equality matchers all operate the same, but read slightly differently in code.

--- a/docs/rules/prefer-to-be-for-literals.md
+++ b/docs/rules/prefer-to-be-for-literals.md
@@ -1,0 +1,30 @@
+# Suggest using `tooBe()` for primitive literals (`prefer-to-be-for-literals`)
+
+When asserting against primitive literals such as numbers and strings, the
+equality matchers all operate the same, but read slightly differently in code.
+
+This rule recommends using the `toBe` matcher in these situations, as it forms
+the most grammatically natural sentence.
+
+## Rule details
+
+This rule triggers a warning if `toEqual()` or `toStrictEqual()` are used to
+assert a primitive literal value such as a string or a number.
+
+The following patterns are considered warnings:
+
+```js
+expect(value).not.toEqual(5);
+expect(getMessage()).toStrictEqual('hello world');
+expect(loadMessage()).resolves.toEqual('hello world');
+```
+
+The following pattern is not warning:
+
+```js
+expect(value).not.toBe(5);
+expect(getMessage()).toBe('hello world');
+expect(loadMessage()).resolves.toBe('hello world');
+
+expect(catchError()).toStrictEqual({ message: 'oh noes!' });
+```

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -39,6 +39,7 @@ Object {
       "jest/prefer-hooks-on-top": "error",
       "jest/prefer-spy-on": "error",
       "jest/prefer-strict-equal": "error",
+      "jest/prefer-to-be-for-literals": "error",
       "jest/prefer-to-be-null": "error",
       "jest/prefer-to-be-undefined": "error",
       "jest/prefer-to-contain": "error",

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 import plugin from '../';
 
-const numberOfRules = 45;
+const numberOfRules = 46;
 const ruleNames = Object.keys(plugin.rules);
 const deprecatedRules = Object.entries(plugin.rules)
   .filter(([, rule]) => rule.meta.deprecated)

--- a/src/rules/__tests__/prefer-to-be-for-literals.test.ts
+++ b/src/rules/__tests__/prefer-to-be-for-literals.test.ts
@@ -1,0 +1,59 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import rule from '../prefer-to-be-for-literals';
+
+const ruleTester = new TSESLint.RuleTester();
+
+ruleTester.run('prefer-to-be-for-literals', rule, {
+  valid: [
+    'expect(null).toBeNull();',
+    'expect(null).not.toBeNull();',
+    'expect(obj).toStrictEqual([ x, 1 ]);',
+    'expect(obj).toStrictEqual({ x: 1 });',
+    'expect(obj).not.toStrictEqual({ x: 1 });',
+    'expect(value).toMatchSnapshot();',
+    "expect(catchError()).toStrictEqual({ message: 'oh noes!' })",
+    'expect("something");',
+  ],
+  invalid: [
+    {
+      code: 'expect(null).toEqual(null);',
+      output: 'expect(null).toBe(null);',
+      errors: [{ messageId: 'useToBe', column: 14, line: 1 }],
+    },
+    {
+      code: 'expect(value).toEqual("my string");',
+      output: 'expect(value).toBe("my string");',
+      errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
+    },
+    {
+      code: 'expect(value).toStrictEqual("my string");',
+      output: 'expect(value).toBe("my string");',
+      errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
+    },
+    {
+      code: 'expect(loadMessage()).resolves.toStrictEqual("hello world");',
+      output: 'expect(loadMessage()).resolves.toBe("hello world");',
+      errors: [{ messageId: 'useToBe', column: 32, line: 1 }],
+    },
+  ],
+});
+
+new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+}).run('prefer-to-be-for-literals: typescript edition', rule, {
+  valid: [
+    "(expect('Model must be bound to an array if the multiple property is true') as any).toHaveBeenTipped()",
+  ],
+  invalid: [
+    {
+      code: 'expect(null).toEqual(1 as unknown as string as unknown as any);',
+      output: 'expect(null).toBe(1 as unknown as string as unknown as any);',
+      errors: [{ messageId: 'useToBe', column: 14, line: 1 }],
+    },
+    {
+      code: 'expect("a string").not.toStrictEqual(null as number);',
+      output: 'expect("a string").not.toBe(null as number);',
+      errors: [{ messageId: 'useToBe', column: 24, line: 1 }],
+    },
+  ],
+});

--- a/src/rules/prefer-to-be-for-literals.ts
+++ b/src/rules/prefer-to-be-for-literals.ts
@@ -1,0 +1,51 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import {
+  ParsedExpectMatcher,
+  createRule,
+  followTypeAssertionChain,
+  isExpectCall,
+  isParsedEqualityMatcherCall,
+  parseExpectCall,
+} from './utils';
+
+const isPrimitiveLiteral = (matcher: ParsedExpectMatcher) =>
+  isParsedEqualityMatcherCall(matcher) &&
+  followTypeAssertionChain(matcher.arguments[0]).type ===
+    AST_NODE_TYPES.Literal;
+
+export default createRule({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Suggest using `tooBe()` for primitive literals',
+      recommended: false,
+    },
+    messages: {
+      useToBe: 'Use `toBe` when expecting primitive literals',
+    },
+    fixable: 'code',
+    type: 'suggestion',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isExpectCall(node)) {
+          return;
+        }
+
+        const { matcher } = parseExpectCall(node);
+
+        if (matcher && isPrimitiveLiteral(matcher)) {
+          context.report({
+            fix: fixer => fixer.replaceText(matcher.node.property, 'toBe'),
+            messageId: 'useToBe',
+            node: matcher.node.property,
+          });
+        }
+      },
+    };
+  },
+});

--- a/src/rules/prefer-to-be-for-literals.ts
+++ b/src/rules/prefer-to-be-for-literals.ts
@@ -18,7 +18,7 @@ export default createRule({
   meta: {
     docs: {
       category: 'Best Practices',
-      description: 'Suggest using `tooBe()` for primitive literals',
+      description: 'Suggest using `toBe()` for primitive literals',
       recommended: false,
     },
     messages: {


### PR DESCRIPTION
Resolves #801

I'm open to bikeshedding on the name:
  * `prefer-to-be` - we've already had a rule named this, but maybe thats ok?
  * `prefer-to-be-for-literals` - a little wordy, arguably a little inaccurate
  * `prefer-to-be-for-primitive-literal` - wordier, but the most accurate

I think this could be good to have in `styles` config when it comes time to do our next major.