### PR TITLE
docs(expect-expect): change suggested rule config

### DIFF
--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -87,10 +87,10 @@ it('is money-like', () => {
 
 Examples of **correct** code for working with the HTTP assertions library
 [SuperTest](https://www.npmjs.com/package/supertest) with the
-`{ "assertFunctionNames": ["expect", "request.*.expect"] }` option:
+`{ "assertFunctionNames": ["expect", "request.**.expect"] }` option:
 
 ```js
-/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "request.*.expect"] }] */
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "request.**.expect"] }] */
 const request = require('supertest');
 const express = require('express');
 


### PR DESCRIPTION
Change the suggested rule config for jest/expect-expect when using supertest to use "request.**.expect" in the assertFunctionNames array rather than "request.*.expect". A supertest chained assertion may have more than one function call between `request(app)` and `.expect()`. Without this change the following would raise an error/warning:

```js
describe('Get All Items', () => {
  it('/items/all returns json list of all items', () =>
    request(app)
      .get('/items/all')
      .set('Accept', 'application/json')
      .expect('Content-Type', /json/)
      .expect(200),
  )
})
```