### PR TITLE
chore(readme): remove `$` from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 
 ## Installation
 
-```
-$ yarn add --dev eslint eslint-plugin-jest
+```bash
+yarn add --dev eslint eslint-plugin-jest
 ```
 
 **Note:** If you installed ESLint globally then you must also install


### PR DESCRIPTION
Github has introduced the Copy Markdown functionality, so users can click the copy button to get the command in their clipboard.

Having the $ in front of the copied command means they can't use this feature.