### PR TITLE
feat(expect-expect): support `additionalTestBlockFunctions` option

### DIFF
--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -34,7 +34,8 @@ it('should work with callbacks/async', () => {
   "jest/expect-expect": [
     "error",
     {
-      "assertFunctionNames": ["expect"]
+      "assertFunctionNames": ["expect"],
+      "additionalTestBlockFunctions": []
     }
   ]
 }
@@ -100,5 +101,45 @@ describe('GET /user', function () {
   it('responds with json', function (done) {
     request(app).get('/user').expect('Content-Type', /json/).expect(200, done);
   });
+});
+```
+
+### `additionalTestBlockFunctions`
+
+This array can be used to specify the names of functions that should also be
+treated as test blocks:
+
+```json
+{
+  "rules": {
+    "jest/expect-expect": [
+      "error",
+      { "additionalTestBlockFunctions": ["theoretically"] }
+    ]
+  }
+}
+```
+
+The following is _correct_ when using the above configuration:
+
+```js
+import theoretically from 'jest-theories';
+
+describe('NumberToLongString', () => {
+  const theories = [
+    { input: 100, expected: 'One hundred' },
+    { input: 1000, expected: 'One thousand' },
+    { input: 10000, expected: 'Ten thousand' },
+    { input: 100000, expected: 'One hundred thousand' },
+  ];
+
+  theoretically(
+    'the number {input} is correctly translated to string',
+    theories,
+    theory => {
+      const output = NumberToLongString(theory.input);
+      expect(output).toBe(theory.expected);
+    },
+  );
 });
 ```

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -15,6 +15,7 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('expect-expect', rule, {
   valid: [
+    "['x']();",
     'it("should pass", () => expect(true).toBeDefined())',
     'test("should pass", () => expect(true).toBeDefined())',
     'it("should pass", () => somePromise().then(() => expect(true).toBeDefined()))',
@@ -69,7 +70,21 @@ ruleTester.run('expect-expect', rule, {
     },
     {
       code: 'it("should pass", () => expect(true).toBeDefined())',
-      options: [{ assertFunctionNames: undefined }],
+      options: [
+        {
+          assertFunctionNames: undefined,
+          additionalTestBlockFunctions: undefined,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        theoretically('the number {input} is correctly translated to string', theories, theory => {
+          const output = NumberToLongString(theory.input);
+          expect(output).toBe(theory.expected);
+        })
+      `,
+      options: [{ additionalTestBlockFunctions: ['theoretically'] }],
     },
   ],
 
@@ -94,6 +109,39 @@ ruleTester.run('expect-expect', rule, {
     },
     {
       code: 'test("should fail", () => {});',
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+    },
+    {
+      code: 'test.skip("should fail", () => {});',
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+    },
+    {
+      code: 'afterEach(() => {});',
+      options: [{ additionalTestBlockFunctions: ['afterEach'] }],
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        theoretically('the number {input} is correctly translated to string', theories, theory => {
+          const output = NumberToLongString(theory.input);
+        })
+      `,
+      options: [{ additionalTestBlockFunctions: ['theoretically'] }],
       errors: [
         {
           messageId: 'noAssertions',


### PR DESCRIPTION
Helps with #534

Probably wants to be replaced with just `testBlockFunctions` at some point when we decide we want to support `settings`.
Could be worth doing now - haven't decided 🤔 