### PR TITLE
fix(valid-describe): report on concise-body arrow functions

### DIFF
--- a/docs/rules/valid-describe.md
+++ b/docs/rules/valid-describe.md
@@ -43,6 +43,12 @@ describe('myFunction', () => {
     });
   });
 });
+
+// Returning a value from a describe block is not allowed
+describe('myFunction', () =>
+  it('returns a truthy value', () => {
+    expect(myFunction()).toBeTruthy();
+  }));
 ```
 
 The following patterns are not considered warnings:

--- a/src/rules/__tests__/valid-describe.test.ts
+++ b/src/rules/__tests__/valid-describe.test.ts
@@ -37,11 +37,6 @@ ruleTester.run('valid-describe', rule, {
       })
     `,
     dedent`
-      describe('foo', () =>
-        test('bar', () => {})
-      )
-    `,
-    dedent`
       if (hasOwnProperty(obj, key)) {
       }
     `,
@@ -194,6 +189,16 @@ ruleTester.run('valid-describe', rule, {
       errors: [
         { messageId: 'noAsyncDescribeCallback', line: 1, column: 17 },
         { messageId: 'unexpectedReturnInDescribe', line: 5, column: 5 },
+      ],
+    },
+    {
+      code: dedent`
+        describe('foo', () =>
+          test('bar', () => {})
+        )
+      `,
+      errors: [
+        { messageId: 'unexpectedReturnInDescribe', line: 1, column: 17 },
       ],
     },
     {

--- a/src/rules/valid-describe.ts
+++ b/src/rules/valid-describe.ts
@@ -84,6 +84,13 @@ export default createRule({
           });
         }
 
+        if (callback.body.type === AST_NODE_TYPES.CallExpression) {
+          context.report({
+            messageId: 'unexpectedReturnInDescribe',
+            node: callback,
+          });
+        }
+
         if (callback.body.type === AST_NODE_TYPES.BlockStatement) {
           callback.body.body.forEach(node => {
             if (node.type === AST_NODE_TYPES.ReturnStatement) {


### PR DESCRIPTION
Jest 27 will throw an error if a describe block returns a value ([changelog](https://github.com/facebook/jest/blob/master/CHANGELOG.md#2700), [test-case](https://replit.com/@jcfranco/jest-playground#test.js)). This PR updates `valid-describe` to report on these instances that would fail tests. 

If deemed useful, I could look at making this fixable in a follow-up PR.