### PR TITLE
Fix: Bubble up file tree to find `jest`

### DIFF
--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import {
   AST_NODE_TYPES,
@@ -40,9 +41,23 @@ const detectJestVersion = (): JestVersion => {
     return cachedJestVersion;
   }
 
+  const cwd = process.cwd();
+  const pathsToCheck = [cwd];
+  if (__dirname.includes(cwd)) {
+    let relPath = __dirname.replace(cwd, "");
+    while (relPath !== "") {
+      relPath = path
+        .resolve(relPath)
+        .split(`${path.sep}node_modules`)
+        .slice(0,-1)
+        .join(`${path.sep}node_modules`);
+      pathsToCheck.unshift(path.join(cwd, relPath));
+    }
+  }
+
   try {
     const jestPath = require.resolve('jest/package.json', {
-      paths: [process.cwd()],
+      paths: pathsToCheck
     });
 
     const jestPackageJson =


### PR DESCRIPTION
## Problem
I ran into an breaking error when trying to run eslint at the root level of a monorepo and the jest plugin was used by a submodule and only loaded within the submodule context.

Monorepos desire to run test/lint functionality from the root folder rather than all submodules which can cause conflicts with what the `process.cwd()` is set to.

Error log:
```log
$ npm run lint

> lint
> eslint . --ext ts,js,json,md,mdx,.remarkrc

Oops! Something went wrong! :(

ESLint: 7.32.0

Error: Error while loading rule 'jest/no-deprecated-functions': Unable to detect Jest version - please ensure jest package is installed, or otherwise set version explicitly
Occurred while linting /Users/me/dev/project/core/client/.eslintrc.js
    at detectJestVersion (/Users/me/dev/project/core/client/node_modules/eslint-plugin-jest/lib/rules/no-deprecated-functions.js:39:9)
    at create (/Users/me/dev/project/core/client/node_modules/eslint-plugin-jest/lib/rules/no-deprecated-functions.js:62:256)
    at Object.create (/Users/me/dev/project/core/client/node_modules/@typescript-eslint/experimental-utils/dist/eslint-utils/RuleCreator.js:13:24)
    at createRuleListeners (/Users/me/dev/project/node_modules/eslint/lib/linter/linter.js:765:21)
    at /Users/me/dev/project/node_modules/eslint/lib/linter/linter.js:937:31
    at Array.forEach (<anonymous>)
    at runRules (/Users/me/dev/project/node_modules/eslint/lib/linter/linter.js:882:34)
    at Linter._verifyWithoutProcessors (/Users/me/dev/project/node_modules/eslint/lib/linter/linter.js:1181:31)
    at Linter.<anonymous> (/Users/me/dev/project/node_modules/eslint-plugin-json-format/lib/index.js:48:28)
    at Linter._verifyWithConfigArray (/Users/me/dev/project/node_modules/eslint/lib/linter/linter.js:1280:21)
```

With a little debugging, I was able to identify the following variables were currently set to:

```log
__dirname = '/Users/me/dev/project/core/client/node_modules/eslint-plugin-jest/lib/rules'
process.cwd() = '/Users/me/dev/project/'

# actual location
require.resolve('jest') = '/Users/me/dev/project/core/client/node_modules/jest'
```

My project was laid out:
```log
project/
  |-> core/
  |     |-> client/
  |     |     |-> .eslintrc.js                # loads eslint-plugin-jest for unit-tests
  |     |     '-> package.json                # devDependencies: { "jest", "eslint-plugin-jest" }
  |     |-> server/
  |           '-> package.json                # no jest
  |-> .eslintrc.js
  |-> package.json       # devDependencies: { "eslint" }, no jest
                         # scripts: { "lint": "eslint . --ext ts,js,json,md,mdx,.remarkrc" }
```

## Alternatives

1. Define jest version statically in the root `package.json` as a configuration option.  I would rather not do this since I would have to keep the definition in sync from the root project and the submodule's package definition.

## Solution

This small loop bubbles up the file tree when it detects the edge case where the `eslint-plugin-jest` module is installed in a submodule's dependencies only and the `process.cwd()` does not directly match.  
