### PR TITLE
fix: stop testing ESLint 5

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x]
-        eslint-version: [5, 6, 7]
+        eslint-version: [6, 7]
     runs-on: ubuntu-latest
 
     steps:
@@ -83,12 +83,11 @@ jobs:
           yarn
           yarn add --dev eslint@${{ matrix.eslint-version }}
       - name: run tests
-        # only collect coverage on eslint versions that support the suggestions api
-        run: yarn test --coverage ${{ matrix.eslint-version >= 6 }}
+        run: yarn test --coverage
         env:
           CI: true
       - uses: codecov/codecov-action@v2.0.3
-        if: ${{ matrix.eslint-version >= 6 }}
+        if: always()
   test-os:
     name: Test on ${{ matrix.os }} using Node.js LTS
     needs: prepare-yarn-cache


### PR DESCRIPTION
BREAKING CHANGE: Drop support for ESLint 5