### PR TITLE
fix: mark rules that suggest fixes with `hasSuggestion` for ESLint v8

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ declare module '@typescript-eslint/experimental-utils/dist/ts-eslint/Rule' {
   export interface RuleMetaDataDocs {
     suggestion?: boolean;
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  export interface RuleMetaData<TMessageIds extends string> {
+    hasSuggestion?: boolean;
+  }
 }
 
 // copied from https://github.com/babel/babel/blob/d8da63c929f2d28c401571e2a43166678c555bc4/packages/babel-helpers/src/helpers.js#L602-L606

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -47,6 +47,7 @@ export default createRule({
     },
     schema: [],
     type: 'suggestion',
+    hasSuggestion: true,
   },
   defaultOptions: [],
   create(context) {

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -49,6 +49,7 @@ export default createRule({
     },
     schema: [],
     type: 'suggestion',
+    hasSuggestion: true,
   },
   defaultOptions: [],
   create: context => ({

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -84,6 +84,7 @@ export default createRule<[RuleOptions], MessageIds>({
       suggestRemovingExtraArguments: 'Remove extra arguments',
     },
     type: 'suggestion',
+    hasSuggestion: true,
     schema: [
       {
         type: 'object',

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -21,6 +21,7 @@ export default createRule({
     },
     type: 'suggestion',
     schema: [],
+    hasSuggestion: true,
   },
   defaultOptions: [],
   create(context) {

--- a/tools/regenerate-docs.ts
+++ b/tools/regenerate-docs.ts
@@ -114,7 +114,7 @@ const details: RuleDetails[] = Object.keys(config.configs.all.rules)
       description: rule.meta.docs.description,
       fixable: rule.meta.fixable
         ? 'fixable'
-        : rule.meta.docs.suggestion
+        : rule.meta.hasSuggestion
         ? 'suggest'
         : false,
       requiresTypeChecking: rule.meta.docs.requiresTypeChecking ?? false,


### PR DESCRIPTION
We can land this ahead of time to reduce the overhead a little.