### PR TITLE
chore(ci): specify only majors for GH Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Danger
-        uses: danger/danger-js@10
+        uses: danger/danger-js@v10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Danger
-        uses: danger/danger-js@10.6.6
+        uses: danger/danger-js@10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Danger
-        uses: danger/danger-js@v10
+        uses: danger/danger-js@10.6.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2.4.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
 
       - name: Validate cache
@@ -36,9 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.4.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
       - name: install
         run: yarn
@@ -50,9 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.4.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
       - name: install
         run: yarn
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
@@ -100,9 +100,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.4.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
       - name: install
         run: yarn
@@ -117,9 +117,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.4.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
       - name: install
         run: yarn
@@ -140,9 +140,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2.4.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16
           cache: yarn
       - name: install
         run: yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -110,6 +110,8 @@ jobs:
         run: yarn test --coverage
         env:
           CI: true
+      - uses: codecov/codecov-action@v2
+        if: ${{ matrix.eslint-version >= 6 }}
 
   docs:
     if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -87,7 +87,7 @@ jobs:
         run: yarn test --coverage ${{ matrix.eslint-version >= 6 }}
         env:
           CI: true
-      - uses: codecov/codecov-action@v2.1.0
+      - uses: codecov/codecov-action@v2
         if: ${{ matrix.eslint-version >= 6 }}
   test-os:
     name: Test on ${{ matrix.os }} using Node.js LTS

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14.x
           cache: yarn
 
       - name: Validate cache
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14.x
           cache: yarn
       - name: install
         run: yarn
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14.x
           cache: yarn
       - name: install
         run: yarn
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14.x
           cache: yarn
       - name: install
         run: yarn
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14.x
           cache: yarn
       - name: install
         run: yarn
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14.x
           cache: yarn
       - name: install
         run: yarn


### PR DESCRIPTION
- Set action versions to major
  This will create less PRs to update their versions
- ~Set node version to 16~

---

Taken from #903