### PR TITLE
fix(no-identical-title): always consider `.each` titles unique

### DIFF
--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -124,12 +124,12 @@ ruleTester.run('no-identical-title', rule, {
     dedent`
       describe.each\`
         description
-        ${'b'}
+        $\{'b'}
       \`('$description', () => {});
 
       describe.each\`
         description
-        ${'a'}
+        $\{'a'}
       \`('$description', () => {});
     `,
     dedent`
@@ -140,6 +140,16 @@ ruleTester.run('no-identical-title', rule, {
 
         describe('nested', () => {});
       });
+    `,
+    dedent`
+      describe.each\`\`('my title', value => {});
+      describe.each\`\`('my title', value => {});
+      describe.each([])('my title', value => {});
+      describe.each([])('my title', value => {});
+    `,
+    dedent`
+      describe.each([])('when the value is %s', value => {});
+      describe.each([])('when the value is %s', value => {});
     `,
   ],
   invalid: [

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -1,6 +1,6 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
 import {
   createRule,
+  getNodeName,
   getStringValue,
   isDescribeCall,
   isStringNode,
@@ -46,7 +46,7 @@ export default createRule({
           contexts.push(newDescribeContext());
         }
 
-        if (node.callee.type === AST_NODE_TYPES.TaggedTemplateExpression) {
+        if (getNodeName(node.callee)?.endsWith('.each')) {
           return;
         }
 


### PR DESCRIPTION
@SimenB I think we should try and get this sorted before the next major too, as
it has been similarly disruptive to a small subset of users.

I'd be interested in your opinion on this - my understanding of the rule is that
it's trying to enforce this:

> "you should be able to differentiate between two tests by their title alone"

As the title should always be provided to reporters whereas other information
(like what line in code the test is on) isn't guaranteed, and so having titles
that are identical on the same nesting level makes it very hard to tell which is
what test in code.

This is easy to handle with static titles, but `.each` supports injecting values
into their static titles, making it harder to decide if a title is unique or not
since we cannot predict the final title(s).

I think this boils down to deciding which of these cases we should consider
unique:

```
.each()('go') // (function, no injection)
.each``('go') // (template, no injection)
.each()('%s') // (function, %-based injection)
.each()('$s') // (function, $-based injection)
.each``('$s') // (template, $-based injection)
```

Ideally we should be treating all "no injection"s as identical, but the general
issue is how reliably can we determine if there is an injection or not (which I
think we can, we just need the time to implement it).

I think for now we should say for this rule that any `.each` title is unique
(which is what this change does), and then follow-up with implementing logic to
handle injections - either as a new rule (e.g. `require-injection-in-each`) or
as an option on this rule (e.g. `ignoreEachWithInjections`), or maybe both
depending on how it plays out.

Fixes #836