### PR TITLE
feat(valid-title): allow custom matcher messages

### DIFF
--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -198,8 +198,9 @@ describe('the proper way to handle things', () => {});
 Defaults: `{}`
 
 Allows enforcing that titles must match or must not match a given Regular
-Expression. An object can be provided to apply different Regular Expressions to
-specific Jest test function groups (`describe`, `test`, and `it`).
+Expression, with an optional message. An object can be provided to apply
+different Regular Expressions (with optional messages) to specific Jest test
+function groups (`describe`, `test`, and `it`).
 
 Examples of **incorrect** code when using `mustMatch`:
 
@@ -225,4 +226,31 @@ fit('that this there!', () => {});
 describe('the tests that will be run', () => {});
 test('that the stuff works', () => {});
 xtest('that errors that thrown have messages', () => {});
+```
+
+Optionally you can provide a custom message to show for a particular matcher by
+using a tuple at any level where you can provide a matcher:
+
+```js
+const prefixes = ['when', 'with', 'without', 'if', 'unless', 'for'];
+const prefixesList = prefixes.join('  - \n');
+
+module.exports = {
+  rules: {
+    'jest/valid-title': [
+      'error',
+      {
+        mustNotMatch: ['\\.$', 'Titles should not end with a full-stop'],
+        mustMatch: {
+          describe: [
+            new RegExp(`^(?:[A-Z]|\\b(${prefixes.join('|')})\\b`, 'u').source,
+            `Describe titles should either start with a capital letter or one of the following prefixes: ${prefixesList}`,
+          ],
+          test: [/[^A-Z]/u.source],
+          it: /[^A-Z]/u.source,
+        },
+      },
+    ],
+  },
+};
 ```

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -232,6 +232,44 @@ ruleTester.run('mustMatch & mustNotMatch options', rule, {
       `,
       options: [
         {
+          mustNotMatch: {
+            describe: [
+              /(?:#(?!unit|e2e))\w+/u.source,
+              'Please include "#unit" or "#e2e" in describe titles',
+            ],
+          },
+          mustMatch: { describe: /^[^#]+$|(?:#(?:unit|e2e))/u.source },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'mustNotMatchCustom',
+          data: {
+            jestFunctionName: 'describe',
+            pattern: /(?:#(?!unit|e2e))\w+/u,
+            message: 'Please include "#unit" or "#e2e" in describe titles',
+          },
+          column: 12,
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe('things to test', () => {
+          describe('unit tests #unit', () => {
+            it('is true', () => {
+              expect(true).toBe(true);
+            });
+          });
+
+          describe('e2e tests #e4e', () => {
+            it('is another test #e2e #jest4life', () => {});
+          });
+        });
+      `,
+      options: [
+        {
           mustNotMatch: { describe: /(?:#(?!unit|e2e))\w+/u.source },
           mustMatch: { it: /^[^#]+$|(?:#(?:unit|e2e))/u.source },
         },
@@ -242,6 +280,59 @@ ruleTester.run('mustMatch & mustNotMatch options', rule, {
           data: {
             jestFunctionName: 'describe',
             pattern: /(?:#(?!unit|e2e))\w+/u,
+          },
+          column: 12,
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe('things to test', () => {
+          describe('unit tests #unit', () => {
+            it('is true #jest4life', () => {
+              expect(true).toBe(true);
+            });
+          });
+
+          describe('e2e tests #e4e', () => {
+            it('is another test #e2e #jest4life', () => {});
+          });
+        });
+      `,
+      options: [
+        {
+          mustNotMatch: {
+            describe: [
+              /(?:#(?!unit|e2e))\w+/u.source,
+              'Please include "#unit" or "#e2e" in describe titles',
+            ],
+          },
+          mustMatch: {
+            it: [
+              /^[^#]+$|(?:#(?:unit|e2e))/u.source,
+              'Please include "#unit" or "#e2e" in it titles',
+            ],
+          },
+        },
+      ],
+      errors: [
+        {
+          messageId: 'mustMatchCustom',
+          data: {
+            jestFunctionName: 'it',
+            pattern: /^[^#]+$|(?:#(?:unit|e2e))/u,
+            message: 'Please include "#unit" or "#e2e" in it titles',
+          },
+          column: 8,
+          line: 3,
+        },
+        {
+          messageId: 'mustNotMatchCustom',
+          data: {
+            jestFunctionName: 'describe',
+            pattern: /(?:#(?!unit|e2e))\w+/u,
+            message: 'Please include "#unit" or "#e2e" in describe titles',
           },
           column: 12,
           line: 8,

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -200,6 +200,55 @@ ruleTester.run('mustMatch & mustNotMatch options', rule, {
       `,
       options: [
         {
+          mustNotMatch: [
+            /(?:#(?!unit|e2e))\w+/u.source,
+            'Please include "#unit" or "#e2e" in titles',
+          ],
+          mustMatch: [
+            /^[^#]+$|(?:#(?:unit|e2e))/u.source,
+            'Please include "#unit" or "#e2e" in titles',
+          ],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'mustNotMatchCustom',
+          data: {
+            jestFunctionName: 'describe',
+            pattern: /(?:#(?!unit|e2e))\w+/u,
+            message: 'Please include "#unit" or "#e2e" in titles',
+          },
+          column: 12,
+          line: 8,
+        },
+        {
+          messageId: 'mustNotMatchCustom',
+          data: {
+            jestFunctionName: 'it',
+            pattern: /(?:#(?!unit|e2e))\w+/u,
+            message: 'Please include "#unit" or "#e2e" in titles',
+          },
+          column: 8,
+          line: 9,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        describe('things to test', () => {
+          describe('unit tests #unit', () => {
+            it('is true', () => {
+              expect(true).toBe(true);
+            });
+          });
+
+          describe('e2e tests #e4e', () => {
+            it('is another test #e2e #jest4life', () => {});
+          });
+        });
+      `,
+      options: [
+        {
           mustNotMatch: { describe: /(?:#(?!unit|e2e))\w+/u.source },
           mustMatch: { describe: /^[^#]+$|(?:#(?:unit|e2e))/u.source },
         },

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -107,7 +107,7 @@ ruleTester.run('mustMatch & mustNotMatch options', rule, {
     'test("that all is as it should be", () => {});',
     {
       code: 'it("correctly sets the value", () => {});',
-      options: [{ mustMatch: undefined }],
+      options: [{ mustMatch: {} }],
     },
     {
       code: 'it("correctly sets the value", () => {});',

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -114,6 +114,10 @@ ruleTester.run('mustMatch & mustNotMatch options', rule, {
       options: [{ mustMatch: / /u.source }],
     },
     {
+      code: 'it("correctly sets the value", () => {});',
+      options: [{ mustMatch: [/ /u.source] }],
+    },
+    {
       code: 'it("correctly sets the value #unit", () => {});',
       options: [{ mustMatch: /#(?:unit|integration|e2e)/u.source }],
     },
@@ -249,7 +253,7 @@ ruleTester.run('mustMatch & mustNotMatch options', rule, {
       `,
       options: [
         {
-          mustNotMatch: { describe: /(?:#(?!unit|e2e))\w+/u.source },
+          mustNotMatch: { describe: [/(?:#(?!unit|e2e))\w+/u.source] },
           mustMatch: { describe: /^[^#]+$|(?:#(?:unit|e2e))/u.source },
         },
       ],

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -145,45 +145,21 @@ export default createRule<[Options], MessageIds>({
               },
               {
                 type: 'object',
-                properties: {
-                  describe: {
-                    oneOf: [
-                      { type: 'string' },
-                      {
-                        type: 'array',
-                        items: { type: 'string' },
-                        minItems: 1,
-                        maxItems: 2,
-                        additionalItems: false,
-                      },
-                    ],
-                  },
-                  test: {
-                    oneOf: [
-                      { type: 'string' },
-                      {
-                        type: 'array',
-                        items: { type: 'string' },
-                        minItems: 1,
-                        maxItems: 2,
-                        additionalItems: false,
-                      },
-                    ],
-                  },
-                  it: {
-                    oneOf: [
-                      { type: 'string' },
-                      {
-                        type: 'array',
-                        items: { type: 'string' },
-                        minItems: 1,
-                        maxItems: 2,
-                        additionalItems: false,
-                      },
-                    ],
-                  },
+                propertyNames: {
+                  enum: ['describe', 'test', 'it'],
                 },
-                additionalProperties: false,
+                additionalProperties: {
+                  oneOf: [
+                    { type: 'string' },
+                    {
+                      type: 'array',
+                      items: { type: 'string' },
+                      minItems: 1,
+                      maxItems: 2,
+                      additionalItems: false,
+                    },
+                  ],
+                },
               },
             ],
           },
@@ -199,45 +175,21 @@ export default createRule<[Options], MessageIds>({
               },
               {
                 type: 'object',
-                properties: {
-                  describe: {
-                    oneOf: [
-                      { type: 'string' },
-                      {
-                        type: 'array',
-                        items: { type: 'string' },
-                        minItems: 1,
-                        maxItems: 2,
-                        additionalItems: false,
-                      },
-                    ],
-                  },
-                  test: {
-                    oneOf: [
-                      { type: 'string' },
-                      {
-                        type: 'array',
-                        items: { type: 'string' },
-                        minItems: 1,
-                        maxItems: 2,
-                        additionalItems: false,
-                      },
-                    ],
-                  },
-                  it: {
-                    oneOf: [
-                      { type: 'string' },
-                      {
-                        type: 'array',
-                        items: { type: 'string' },
-                        minItems: 1,
-                        maxItems: 2,
-                        additionalItems: false,
-                      },
-                    ],
-                  },
+                propertyNames: {
+                  enum: ['describe', 'test', 'it'],
                 },
-                additionalProperties: false,
+                additionalProperties: {
+                  oneOf: [
+                    { type: 'string' },
+                    {
+                      type: 'array',
+                      items: { type: 'string' },
+                      minItems: 1,
+                      maxItems: 2,
+                      additionalItems: false,
+                    },
+                  ],
+                },
               },
             ],
           },

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -47,10 +47,13 @@ const compileMatcherPattern = (
 };
 
 const compileMatcherPatterns = (
-  matchers: Partial<Record<MatcherGroups, string | MatcherAndMessage>> | string,
+  matchers:
+    | Partial<Record<MatcherGroups, string | MatcherAndMessage>>
+    | MatcherAndMessage
+    | string,
 ): Record<MatcherGroups, CompiledMatcherAndMessage | null> &
   Record<string, CompiledMatcherAndMessage | null> => {
-  if (typeof matchers === 'string') {
+  if (typeof matchers === 'string' || Array.isArray(matchers)) {
     const compiledMatcher = compileMatcherPattern(matchers);
 
     return {
@@ -79,9 +82,11 @@ interface Options {
   disallowedWords?: string[];
   mustNotMatch?:
     | Partial<Record<MatcherGroups, string | MatcherAndMessage>>
+    | MatcherAndMessage
     | string;
   mustMatch?:
     | Partial<Record<MatcherGroups, string | MatcherAndMessage>>
+    | MatcherAndMessage
     | string;
 }
 
@@ -132,6 +137,13 @@ export default createRule<[Options], MessageIds>({
             oneOf: [
               { type: 'string' },
               {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+                maxItems: 2,
+                additionalItems: false,
+              },
+              {
                 type: 'object',
                 properties: {
                   describe: {
@@ -178,6 +190,13 @@ export default createRule<[Options], MessageIds>({
           mustMatch: {
             oneOf: [
               { type: 'string' },
+              {
+                type: 'array',
+                items: { type: 'string' },
+                minItems: 1,
+                maxItems: 2,
+                additionalItems: false,
+              },
               {
                 type: 'object',
                 properties: {

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -133,37 +133,9 @@ export default createRule<[Options], MessageIds>({
             type: 'array',
             items: { type: 'string' },
           },
-          mustNotMatch: {
-            oneOf: [
-              { type: 'string' },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                minItems: 1,
-                maxItems: 2,
-                additionalItems: false,
-              },
-              {
-                type: 'object',
-                propertyNames: {
-                  enum: ['describe', 'test', 'it'],
-                },
-                additionalProperties: {
-                  oneOf: [
-                    { type: 'string' },
-                    {
-                      type: 'array',
-                      items: { type: 'string' },
-                      minItems: 1,
-                      maxItems: 2,
-                      additionalItems: false,
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-          mustMatch: {
+        },
+        patternProperties: {
+          [/^must(?:Not)?Match$/u.source]: {
             oneOf: [
               { type: 'string' },
               {

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -1,5 +1,6 @@
 import {
   AST_NODE_TYPES,
+  JSONSchema,
   TSESTree,
 } from '@typescript-eslint/experimental-utils';
 import {
@@ -75,6 +76,14 @@ const compileMatcherPatterns = (
 type CompiledMatcherAndMessage = [matcher: RegExp, message?: string];
 type MatcherAndMessage = [matcher: string, message?: string];
 
+const MatcherAndMessageSchema: JSONSchema.JSONSchema7 = {
+  type: 'array',
+  items: { type: 'string' },
+  minItems: 1,
+  maxItems: 2,
+  additionalItems: false,
+} as const;
+
 type MatcherGroups = 'describe' | 'test' | 'it';
 
 interface Options {
@@ -138,29 +147,12 @@ export default createRule<[Options], MessageIds>({
           [/^must(?:Not)?Match$/u.source]: {
             oneOf: [
               { type: 'string' },
-              {
-                type: 'array',
-                items: { type: 'string' },
-                minItems: 1,
-                maxItems: 2,
-                additionalItems: false,
-              },
+              MatcherAndMessageSchema,
               {
                 type: 'object',
-                propertyNames: {
-                  enum: ['describe', 'test', 'it'],
-                },
+                propertyNames: { enum: ['describe', 'test', 'it'] },
                 additionalProperties: {
-                  oneOf: [
-                    { type: 'string' },
-                    {
-                      type: 'array',
-                      items: { type: 'string' },
-                      minItems: 1,
-                      maxItems: 2,
-                      additionalItems: false,
-                    },
-                  ],
+                  oneOf: [{ type: 'string' }, MatcherAndMessageSchema],
                 },
               },
             ],


### PR DESCRIPTION
I'm wondering if maybe we should drop support for taking a string in favor of always passing a tuple (with or without the second item), as it'd make things a bit lighter for us by making the usage more consistent (both in code and docs) 🤔

I think a good follow-up feature would be to support _multiple_ matchers, so that you can reduce the complexity of single regexps + have more specific messages (implementation wise, this'd be that we support taking in an array of `MatcherAndMessage` & change our logic to do iterate over each `MatcherAndMessage`).

Slightly annoyingly, we could _almost_ deprecate `lowercase-name` in favor of this rule since you could use `/[^A-Z]/u.source` except that would also apply to top-level describes.

Fixes #688