### PR TITLE
fix(valid-expect-in-promise): support additional test functions

### DIFF
--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -36,6 +36,13 @@ ruleTester.run('valid-expect-in-promise', rule, {
       });
     `,
     dedent`
+      xtest('it1', function() {
+        return somePromise.catch(function() {
+          expect(someThing).toEqual(true);
+        });
+      });
+    `,
+    dedent`
       it('it1', function() {
         return somePromise.then(function() {
           doSomeThingButNotExpect();
@@ -136,7 +143,16 @@ ruleTester.run('valid-expect-in-promise', rule, {
         const promise = something().then(value => {
           expect(value).toBe('red');
         });
-        
+
+        return promise;
+      });
+    `,
+    dedent`
+      test.only('later return', () => {
+        const promise = something().then(value => {
+          expect(value).toBe('red');
+        });
+
         return promise;
       });
     `,
@@ -276,6 +292,16 @@ ruleTester.run('valid-expect-in-promise', rule, {
     },
     {
       code: dedent`
+        xtest('it1', function() {
+          somePromise.catch(function() {
+            expect(someThing).toEqual(true)
+          })
+        })
+      `,
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
+    },
+    {
+      code: dedent`
         it('it1', function() {
           somePromise.then(function() {
             expect(someThing).toEqual(true)
@@ -336,6 +362,28 @@ ruleTester.run('valid-expect-in-promise', rule, {
         });
       `,
       errors: [{ column: 9, endColumn: 5, messageId: 'returnPromise' }],
+    },
+    {
+      code: dedent`
+        fit('it1', () => {
+          somePromise.then(() => {
+            doSomeOperation();
+            expect(someThing).toEqual(true);
+          })
+        });
+      `,
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
+    },
+    {
+      code: dedent`
+        it.skip('it1', () => {
+          somePromise.then(() => {
+            doSomeOperation();
+            expect(someThing).toEqual(true);
+          })
+        });
+      `,
+      errors: [{ column: 3, endColumn: 5, messageId: 'returnPromise' }],
     },
   ],
 });

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -7,12 +7,12 @@ import {
   CalledKnownMemberExpression,
   FunctionExpression,
   KnownCallExpression,
-  TestCaseName,
   createRule,
   getAccessorValue,
   isExpectMember,
   isFunction,
   isSupportedAccessor,
+  isTestCaseCall,
 } from './utils';
 
 type MessageIds = 'returnPromise';
@@ -94,16 +94,13 @@ const isPromiseReturnedLater = (
   );
 };
 
-const isTestFunc = (node: TSESTree.Node) =>
-  node.type === AST_NODE_TYPES.CallExpression &&
-  isSupportedAccessor(node.callee) &&
-  ([TestCaseName.it, TestCaseName.test] as string[]).includes(
-    getAccessorValue(node.callee),
-  );
-
 const findTestFunction = (node: TSESTree.Node | undefined) => {
   while (node) {
-    if (isFunction(node) && node.parent && isTestFunc(node.parent)) {
+    if (
+      isFunction(node) &&
+      node.parent?.type === AST_NODE_TYPES.CallExpression &&
+      isTestCaseCall(node.parent)
+    ) {
       return node;
     }
 


### PR DESCRIPTION
Noticed this while working on #740; tbh during this I noticed how buggy this rule actually is - among other things, it doesn't actually properly check for `expect` so it will match stuff like `myClass.method()`.

I'm going to have a go at seeing if I can re-write some parts of it to try and weed out these bugs, but they're not going to be easy as there's a lot of ways we can have false positives or negatives.