### PR TITLE
fix(prefer-to-be): don't consider RegExp literals as `toBe`-able

### DIFF
--- a/src/rules/__tests__/prefer-to-be.test.ts
+++ b/src/rules/__tests__/prefer-to-be.test.ts
@@ -14,6 +14,8 @@ ruleTester.run('prefer-to-be', rule, {
     'expect(value).toMatchSnapshot();',
     "expect(catchError()).toStrictEqual({ message: 'oh noes!' })",
     'expect("something");',
+    'expect(token).toStrictEqual(/[abc]+/g);',
+    "expect(token).toStrictEqual(new RegExp('[abc]+', 'g'));",
   ],
   invalid: [
     {

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -35,8 +35,11 @@ const isFirstArgumentIdentifier = (
   name: string,
 ) => isIdentifier(getFirstArgument(matcher), name);
 
-const isPrimitiveLiteral = (matcher: ParsedEqualityMatcherCall) =>
-  getFirstArgument(matcher).type === AST_NODE_TYPES.Literal;
+const isPrimitiveLiteral = (matcher: ParsedEqualityMatcherCall): boolean => {
+  const firstArg = getFirstArgument(matcher);
+
+  return firstArg.type === AST_NODE_TYPES.Literal && !('regex' in firstArg);
+};
 
 const getFirstArgument = (matcher: ParsedEqualityMatcherCall) => {
   return followTypeAssertionChain(matcher.arguments[0]);


### PR DESCRIPTION
Fixes #921 