### PR TITLE
refactor: simplify or remove a couple of conditions

### DIFF
--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -122,7 +122,7 @@ export default createRule<[RuleOptions], MessageId>({
 
         const { matcher } = parseExpectCall(node);
 
-        if (matcher?.node.parent?.type !== AST_NODE_TYPES.CallExpression) {
+        if (matcher?.node.parent.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -418,7 +418,6 @@ const reparseAsMatcher = (
    * If this matcher isn't called, this will be `null`.
    */
   arguments:
-    parsedMember.node.parent &&
     parsedMember.node.parent.type === AST_NODE_TYPES.CallExpression
       ? parsedMember.node.parent.arguments
       : null,
@@ -453,11 +452,9 @@ const reparseMemberAsModifier = (
     );
   }
 
-  const negation =
-    parsedMember.node.parent &&
-    isExpectMember(parsedMember.node.parent, ModifierName.not)
-      ? parsedMember.node.parent
-      : undefined;
+  const negation = isExpectMember(parsedMember.node.parent, ModifierName.not)
+    ? parsedMember.node.parent
+    : undefined;
 
   return {
     ...parsedMember,
@@ -506,7 +503,7 @@ export const parseExpectCall = <ExpectNode extends ExpectCall>(
 
   const memberNode = modifier.negation || modifier.node;
 
-  if (!memberNode.parent || !isExpectMember(memberNode.parent)) {
+  if (!isExpectMember(memberNode.parent)) {
     return expectation;
   }
 

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -35,7 +35,6 @@ const getPromiseCallExpressionNode = (node: TSESTree.Node) => {
 
   if (
     node.type === AST_NODE_TYPES.CallExpression &&
-    node.callee &&
     node.callee.type === AST_NODE_TYPES.MemberExpression &&
     isSupportedAccessor(node.callee.object) &&
     getAccessorValue(node.callee.object) === 'Promise' &&
@@ -48,8 +47,7 @@ const getPromiseCallExpressionNode = (node: TSESTree.Node) => {
 };
 
 const findPromiseCallExpressionNode = (node: TSESTree.Node) =>
-  node.parent &&
-  node.parent.parent &&
+  node.parent?.parent &&
   [AST_NODE_TYPES.CallExpression, AST_NODE_TYPES.ArrayExpression].includes(
     node.parent.type,
   )
@@ -57,12 +55,11 @@ const findPromiseCallExpressionNode = (node: TSESTree.Node) =>
     : null;
 
 const getParentIfThenified = (node: TSESTree.Node): TSESTree.Node => {
-  const grandParentNode = node.parent && node.parent.parent;
+  const grandParentNode = node.parent?.parent;
 
   if (
     grandParentNode &&
     grandParentNode.type === AST_NODE_TYPES.CallExpression &&
-    grandParentNode.callee &&
     isExpectMember(grandParentNode.callee) &&
     ['then', 'catch'].includes(
       getAccessorValue(grandParentNode.callee.property),


### PR DESCRIPTION
Every so often I like to run some of the type-checking powered `@typescript-eslint` rules over the codebase, to check for things like unneeded conditions and potential optional chaining usages.