### PR TITLE
fix(valid-expect-in-promise): support awaited promises in arguments

### DIFF
--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -34,6 +34,48 @@ ruleTester.run('valid-expect-in-promise', rule, {
           return number + 1;
         });
 
+        expect(await promise).resolves.toBeGreaterThan(1);
+      });
+    `,
+    dedent`
+      it('is valid', async () => {
+        const promise = loadNumber().then(number => {
+          expect(typeof number).toBe('number');
+
+          return number + 1;
+        });
+
+        expect(1).toBeGreaterThan(await promise);
+      });
+    `,
+    dedent`
+      it('is valid', async () => {
+        const promise = loadNumber().then(number => {
+          expect(typeof number).toBe('number');
+
+          return number + 1;
+        });
+
+        expect.this.that.is(await promise);
+      });
+    `,
+    dedent`
+      it('is valid', async () => {
+        expect(await loadNumber().then(number => {
+          expect(typeof number).toBe('number');
+
+          return number + 1;
+        })).toBeGreaterThan(1);
+      });
+    `,
+    dedent`
+      it('is valid', async () => {
+        const promise = loadNumber().then(number => {
+          expect(typeof number).toBe('number');
+
+          return number + 1;
+        });
+
         logValue(await promise);
       });
     `,

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -147,22 +147,29 @@ const isPromiseMethodThatUsesValue = (
  */
 const isValueAwaitedInArguments = (
   name: string,
-  node: TSESTree.CallExpression,
+  call: TSESTree.CallExpression,
 ): boolean => {
-  for (const argument of node.arguments) {
-    if (
-      argument.type === AST_NODE_TYPES.AwaitExpression &&
-      isIdentifier(argument.argument, name)
-    ) {
-      return true;
-    }
-  }
+  let node: TSESTree.Node = call;
 
-  if (
-    node.callee.type === AST_NODE_TYPES.MemberExpression &&
-    node.callee.object.type === AST_NODE_TYPES.CallExpression
-  ) {
-    return isValueAwaitedInArguments(name, node.callee.object);
+  while (node) {
+    if (node.type === AST_NODE_TYPES.CallExpression) {
+      for (const argument of node.arguments) {
+        if (
+          argument.type === AST_NODE_TYPES.AwaitExpression &&
+          isIdentifier(argument.argument, name)
+        ) {
+          return true;
+        }
+      }
+
+      node = node.callee;
+    }
+
+    if (node.type !== AST_NODE_TYPES.MemberExpression) {
+      break;
+    }
+
+    node = node.object;
   }
 
   return false;


### PR DESCRIPTION
Fixes #930

During this also found another bug, and though up two other cases: `await` within an array (which is an extension of this) and `expect(promise).resolves/rejects` (which is a bit of a special case but think we should be able to support it easily, and it forms a nice bridge over to `valid-expect`, which'll handle ensuring the `expect` is `await`ed).