### PR TITLE
refactor(valid-expect-in-promise): remove duplicate check

### DIFF
--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -138,10 +138,7 @@ const isPromiseMethodThatUsesValue = (
     }
   }
 
-  return (
-    node.argument.type === AST_NODE_TYPES.Identifier &&
-    isIdentifier(node.argument, name)
-  );
+  return isIdentifier(node.argument, name);
 };
 
 /**


### PR DESCRIPTION
Noticed while working on #936 - `isIdentifier` already checks this