### PR TITLE
chore: remove `resolve-from` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "projects": [
       {
         "displayName": "test",
-        "testEnvironment": "node",
         "testPathIgnorePatterns": [
           "<rootDir>/lib/.*",
-          "<rootDir>/src/rules/__tests__/fixtures/*"
+          "<rootDir>/src/rules/__tests__/fixtures/*",
+          "<rootDir>/src/rules/__tests__/test-utils.ts"
         ]
       },
       {
@@ -115,7 +115,6 @@
     "lint-staged": "^11.1.2",
     "pinst": "^2.0.0",
     "prettier": "^2.0.5",
-    "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "semantic-release": "^18.0.0",
     "semver": "^7.3.5",

--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -1,11 +1,11 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../consistent-test-it';
 import { TestCaseName } from '../utils';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -3,11 +3,11 @@ import {
   TSESLint,
 } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../expect-expect';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/max-nested-describe.test.ts
+++ b/src/rules/__tests__/max-nested-describe.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../max-nested-describe';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/no-commented-out-tests.test.ts
+++ b/src/rules/__tests__/no-commented-out-tests.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-commented-out-tests';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/src/rules/__tests__/no-conditional-expect.test.ts
+++ b/src/rules/__tests__/no-conditional-expect.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-conditional-expect';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2019,
   },

--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-disabled-tests';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/src/rules/__tests__/no-done-callback.test.ts
+++ b/src/rules/__tests__/no-done-callback.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-done-callback';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/no-duplicate-hooks.test.ts
+++ b/src/rules/__tests__/no-duplicate-hooks.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-duplicate-hooks';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-export';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
     sourceType: 'module',

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-focused-tests';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 6,
   },

--- a/src/rules/__tests__/no-hooks.test.ts
+++ b/src/rules/__tests__/no-hooks.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-hooks';
 import { HookName } from '../utils';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-identical-title';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-if';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-interpolation-in-snapshots.test.ts
+++ b/src/rules/__tests__/no-interpolation-in-snapshots.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-interpolation-in-snapshots';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/no-jest-import.test.ts
+++ b/src/rules/__tests__/no-jest-import.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-jest-import';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-large-snapshots';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-mocks-import.test.ts
+++ b/src/rules/__tests__/no-mocks-import.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-mocks-import';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-restricted-matchers.test.ts
+++ b/src/rules/__tests__/no-restricted-matchers.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../no-restricted-matchers';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-standalone-expect';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../no-test-return-statement';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: { ecmaVersion: 2015 },
 });
 

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-expect-assertions';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/prefer-expect-resolves.test.ts
+++ b/src/rules/__tests__/prefer-expect-resolves.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-expect-resolves';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-hooks-on-top';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/prefer-lowercase-title.test.ts
+++ b/src/rules/__tests__/prefer-lowercase-title.test.ts
@@ -1,11 +1,11 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-lowercase-title';
 import { DescribeAlias, TestCaseName } from '../utils';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -2,11 +2,11 @@ import {
   AST_NODE_TYPES,
   TSESLint,
 } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-spy-on';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -1,9 +1,9 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-to-have-length';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../prefer-todo';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: { ecmaVersion: 2015 },
 });
 

--- a/src/rules/__tests__/require-hook.test.ts
+++ b/src/rules/__tests__/require-hook.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../require-hook';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/require-to-throw-message.test.ts
+++ b/src/rules/__tests__/require-to-throw-message.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../require-to-throw-message';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/require-top-level-describe.test.ts
+++ b/src/rules/__tests__/require-top-level-describe.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../require-top-level-describe';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/test-utils.ts
+++ b/src/rules/__tests__/test-utils.ts
@@ -1,0 +1,6 @@
+import { createRequire } from 'module';
+
+const require = createRequire(__filename);
+const eslintRequire = createRequire(require.resolve('eslint'));
+
+export const espreeParser = eslintRequire.resolve('espree');

--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -1,14 +1,14 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
-import resolveFrom from 'resolve-from';
 import {
   createRule,
   getNodeName,
   isDescribeCall,
   isTestCaseCall,
 } from '../utils';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
   },

--- a/src/rules/__tests__/valid-describe-callback.test.ts
+++ b/src/rules/__tests__/valid-describe-callback.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../valid-describe-callback';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../valid-expect-in-promise';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../valid-expect';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -1,10 +1,10 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
 import dedent from 'dedent';
-import resolveFrom from 'resolve-from';
 import rule from '../valid-title';
+import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({
-  parser: resolveFrom(require.resolve('eslint'), 'espree'),
+  parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4489,7 +4489,6 @@ __metadata:
     lint-staged: ^11.1.2
     pinst: ^2.0.0
     prettier: ^2.0.5
-    resolve-from: ^5.0.0
     rimraf: ^3.0.0
     semantic-release: ^18.0.0
     semver: ^7.3.5


### PR DESCRIPTION
One less dep is nice