### PR TITLE
fix(valid-expect-in-promise): support `await` in arrays

### DIFF
--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -76,6 +76,28 @@ ruleTester.run('valid-expect-in-promise', rule, {
           return number + 1;
         });
 
+        expect([await promise]).toHaveLength(1);
+      });
+    `,
+    dedent`
+      it('is valid', async () => {
+        const promise = loadNumber().then(number => {
+          expect(typeof number).toBe('number');
+
+          return number + 1;
+        });
+
+        expect([[await promise]]).toHaveLength(1);
+      });
+    `,
+    dedent`
+      it('is valid', async () => {
+        const promise = loadNumber().then(number => {
+          expect(typeof number).toBe('number');
+
+          return number + 1;
+        });
+
         logValue(await promise);
       });
     `,

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -143,6 +143,35 @@ const isPromiseMethodThatUsesValue = (
 
 /**
  * Attempts to determine if the runtime value represented by the given `identifier`
+ * is `await`ed within the given array of elements
+ */
+const isValueAwaitedInElements = (
+  name: string,
+  elements:
+    | TSESTree.ArrayExpression['elements']
+    | TSESTree.CallExpression['arguments'],
+): boolean => {
+  for (const element of elements) {
+    if (
+      element.type === AST_NODE_TYPES.AwaitExpression &&
+      isIdentifier(element.argument, name)
+    ) {
+      return true;
+    }
+
+    if (
+      element.type === AST_NODE_TYPES.ArrayExpression &&
+      isValueAwaitedInElements(name, element.elements)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * Attempts to determine if the runtime value represented by the given `identifier`
  * is `await`ed as an argument along the given call expression
  */
 const isValueAwaitedInArguments = (
@@ -153,13 +182,8 @@ const isValueAwaitedInArguments = (
 
   while (node) {
     if (node.type === AST_NODE_TYPES.CallExpression) {
-      for (const argument of node.arguments) {
-        if (
-          argument.type === AST_NODE_TYPES.AwaitExpression &&
-          isIdentifier(argument.argument, name)
-        ) {
-          return true;
-        }
+      if (isValueAwaitedInElements(name, node.arguments)) {
+        return true;
       }
 
       node = node.callee;


### PR DESCRIPTION
I think this is around where I'm ready to call it on how far we take this rule in terms of the level of complexity we support e.g. I'm not going to chase down supporting `const obj = { property: await promiseWithExpect }` (I'll review a PR if someone wants to chase that)