### PR TITLE
fix(expect-expect): don't error on `it.todo` & `test.todo` calls

### DIFF
--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -15,6 +15,8 @@ const ruleTester = new TSESLint.RuleTester({
 
 ruleTester.run('expect-expect', rule, {
   valid: [
+    'it.todo("will test something eventually")',
+    'test.todo("will test something eventually")',
     "['x']();",
     'it("should pass", () => expect(true).toBeDefined())',
     'test("should pass", () => expect(true).toBeDefined())',

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -11,6 +11,7 @@ import {
   createRule,
   getNodeName,
   getTestCallExpressionsFromDeclaredVariables,
+  isSupportedAccessor,
   isTestCaseCall,
 } from './utils';
 
@@ -116,6 +117,13 @@ export default createRule<
           isTestCaseCall(node) ||
           additionalTestBlockFunctions.includes(name)
         ) {
+          if (
+            node.callee.type === AST_NODE_TYPES.MemberExpression &&
+            isSupportedAccessor(node.callee.property, 'todo')
+          ) {
+            return;
+          }
+
           unchecked.push(node);
         } else if (matchesAssertFunctionName(name, assertFunctionNames)) {
           // Return early in case of nested `it` statements.


### PR DESCRIPTION
Fixes #953