### PR TITLE
fix(require-hook): check variables are either `const` or declarations

### DIFF
--- a/docs/rules/require-hook.md
+++ b/docs/rules/require-hook.md
@@ -19,7 +19,7 @@ directly within the body of a `describe`, _except_ for the following:
 
 - `import` statements
 - `const` variables
-- `let` _declarations_
+- `let` _declarations_, and initializations to `null` or `undefined`
 - Types
 - Calls to the standard Jest globals
 

--- a/src/rules/__tests__/require-hook.test.ts
+++ b/src/rules/__tests__/require-hook.test.ts
@@ -77,6 +77,20 @@ ruleTester.run('require-hook', rule, {
       });
     `,
     dedent`
+      let consoleErrorSpy = null; 
+
+      beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error');
+      });
+    `,
+    dedent`
+      let consoleErrorSpy = undefined; 
+
+      beforeEach(() => {
+        consoleErrorSpy = jest.spyOn(console, 'error');
+      });
+    `,
+    dedent`
       describe('some tests', () => {
         beforeEach(() => {
           setup();
@@ -215,6 +229,32 @@ ruleTester.run('require-hook', rule, {
           messageId: 'useHook',
           line: 4,
           column: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        let consoleErrorSpy = null;
+
+        describe('when loading cities from the api', () => {
+          let consoleWarnSpy = jest.spyOn(console, 'warn');
+        });
+      `,
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 4,
+          column: 3,
+        },
+      ],
+    },
+    {
+      code: 'let value = 1',
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
+          column: 1,
         },
       ],
     },

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -8,6 +8,7 @@ import {
   isDescribeCall,
   isFunction,
   isHook,
+  isIdentifier,
   isTestCaseCall,
 } from './utils';
 
@@ -17,6 +18,13 @@ const isJestFnCall = (node: TSESTree.CallExpression): boolean => {
   }
 
   return !!getNodeName(node)?.startsWith('jest.');
+};
+
+const isNullOrUndefined = (node: TSESTree.Expression): boolean => {
+  return (
+    (node.type === AST_NODE_TYPES.Literal && node.value === null) ||
+    isIdentifier(node, 'undefined')
+  );
 };
 
 const shouldBeInHook = (node: TSESTree.Node): boolean => {
@@ -30,7 +38,9 @@ const shouldBeInHook = (node: TSESTree.Node): boolean => {
         return false;
       }
 
-      return node.declarations.some(({ init }) => init !== null);
+      return node.declarations.some(
+        ({ init }) => init !== null && !isNullOrUndefined(init),
+      );
     }
 
     default:


### PR DESCRIPTION
While I documented it, I completely forgot to actually implement checking for this 🤦 (likewise for re-assignments, which I'll do in a follow-up PR).

Right now I'm _not_ allowing initialization, but wouldn't be surprised if we supported that in the future since some people like doing that explicitly.