### PR TITLE
fix(no-deprecated-functions): mark jest as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,9 @@
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {
       "optional": true
+    },
+    "jest": {
+      "optional": true
     }
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4419,6 +4419,8 @@ __metadata:
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":
       optional: true
+    jest:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`jest/no-deprecated-functions` requires `jest` if a version isn't explicitly set in the config to automatically detect it from jest's `package.json` manifest file.

As `jest` isn't declared as a dependency of `eslint-plugin-jest`, stricter node linkers like pnp and pnpm throw errors when trying to run the rule.

I opted to add it as an optional peer dependency as some consumers may explicitly declare their jest version in their eslint config, may not be using this specific rule, or `eslint-plugin-jest` may be included in a shareable eslint config that runs on some packages that may not include jest tests.