### PR TITLE
Adding optional settings to require-hook rule

### DIFF
--- a/docs/rules/require-hook.md
+++ b/docs/rules/require-hook.md
@@ -148,3 +148,40 @@ afterEach(() => {
   clearCityDatabase();
 });
 ```
+
+## Options
+
+If there are methods that you want to call outside of hooks and tests, you can
+mark them as allowed using the `allowedFunctionCalls` option.
+
+```json
+{
+  "jest/require-hook": [
+    "error",
+    {
+      "allowedFunctionCalls": ["enableAutoDestroy"]
+    }
+  ]
+}
+```
+
+Examples of **correct** code when using
+`{ "allowedFunctionCalls": ["enableAutoDestroy"] }` option:
+
+```js
+/* eslint jest/require-hook: ["error", { "allowedFunctionCalls": ["enableAutoDestroy"] }] */
+
+import { enableAutoDestroy, mount } from '@vue/test-utils';
+import { initDatabase, tearDownDatabase } from './databaseUtils';
+
+enableAutoDestroy(afterEach);
+
+beforeEach(initDatabase);
+afterEach(tearDownDatabase);
+
+describe('Foo', () => {
+  test('always returns 42', () => {
+    expect(global.getAnswer()).toBe(42);
+  });
+});
+```

--- a/src/rules/__tests__/require-hook.test.ts
+++ b/src/rules/__tests__/require-hook.test.ts
@@ -152,6 +152,18 @@ ruleTester.run('require-hook', rule, {
         });
       });
     `,
+    {
+      code: dedent`
+        enableAutoDestroy(afterEach);
+        
+        describe('some tests', () => {
+          it('is false', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      options: [{ allowedFunctionCalls: ['enableAutoDestroy'] }],
+    },
   ],
   invalid: [
     {
@@ -370,6 +382,25 @@ ruleTester.run('require-hook', rule, {
         {
           messageId: 'useHook',
           line: 50,
+          column: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        enableAutoDestroy(afterEach);
+        
+        describe('some tests', () => {
+          it('is false', () => {
+            expect(true).toBe(true);
+          });
+        });
+      `,
+      options: [{ allowedFunctionCalls: ['someOtherName'] }],
+      errors: [
+        {
+          messageId: 'useHook',
+          line: 1,
           column: 1,
         },
       ],


### PR DESCRIPTION
### The problem
Some testing libs provide methods which takes hook as an argument and should be executed outside of a hook. The greatest example is using [`enableAutoDestroyHook` from `@vue/test-utils` lib ](https://vue-test-utils.vuejs.org/api/#enableautodestroy-hook). 
By default `jest/require-hook` rule throws an error in such correct code
```js
import {
  enableAutoDestroy,
  resetAutoDestroyState,
  mount
} from '@vue/test-utils'
import Foo from './Foo.vue'

// calls wrapper.destroy() after each test
enableAutoDestroy(afterEach)
// resets auto-destroy after suite completes
afterAll(resetAutoDestroyState)

describe('Foo', () => {
  it('renders a div', () => {
    const wrapper = mount(Foo)
    expect(wrapper.contains('div')).toBe(true)
    // no need to call wrapper.destroy() here
  })
})
```

To deal with it you must ignore `jest/require-hook` rule (or mark it as warn). Which is absolutely wrong and causing all the problems described in original rule's docs.

### The solution
In this PR I added addtional settings for the rule to exclude such tools as `enableAutoDestroy` with additional settings to reduce or maybe extend allowed hooks.