### PR TITLE
feat(expect-expect): support using wildcards in `additionalTestBlockFunctions`

### DIFF
--- a/docs/rules/expect-expect.md
+++ b/docs/rules/expect-expect.md
@@ -107,14 +107,15 @@ describe('GET /user', function () {
 ### `additionalTestBlockFunctions`
 
 This array can be used to specify the names of functions that should also be
-treated as test blocks:
+treated as test blocks. Function names can use wildcards i.e `expect*`,
+`expectUtils.**`, `*.expect*`
 
 ```json
 {
   "rules": {
     "jest/expect-expect": [
       "error",
-      { "additionalTestBlockFunctions": ["theoretically"] }
+      { "additionalTestBlockFunctions": ["theoretically", "expect*"] }
     ]
   }
 }
@@ -124,6 +125,10 @@ The following is _correct_ when using the above configuration:
 
 ```js
 import theoretically from 'jest-theories';
+
+function expectToBeCorrectString(result, expectedString) {
+  return expect(result).toBe(expectedString);
+}
 
 describe('NumberToLongString', () => {
   const theories = [
@@ -141,5 +146,38 @@ describe('NumberToLongString', () => {
       expect(output).toBe(theory.expected);
     },
   );
+
+  it('should be correctly translated to string', () =>
+    expectToBeCorrectString(NumberToLongString(100), 'One hundred'));
+});
+```
+
+The following is _incorrect_ when using the above configuration:
+
+```js
+import theoretically from 'jest-theories';
+
+function expectToBeCorrectString(result, expectedString) {
+  return true;
+}
+
+describe('NumberToLongString', () => {
+  const theories = [
+    { input: 100, expected: 'One hundred' },
+    { input: 1000, expected: 'One thousand' },
+    { input: 10000, expected: 'Ten thousand' },
+    { input: 100000, expected: 'One hundred thousand' },
+  ];
+
+  theoretically(
+    'the number {input} is correctly translated to string',
+    theories,
+    theory => {
+      const output = NumberToLongString(theory.input);
+    },
+  );
+
+  it('should be correctly translated to string', () =>
+    expectToBeCorrectString(NumberToLongString(100), 'One hundred'));
 });
 ```

--- a/docs/rules/no-standalone-expect.md
+++ b/docs/rules/no-standalone-expect.md
@@ -69,7 +69,8 @@ this case.
 #### `additionalTestBlockFunctions`
 
 This array can be used to specify the names of functions that should also be
-treated as test blocks:
+treated as test blocks. Function names can use wildcards i.e `expect*`,
+`expectUtils.**`, `*.expect*`
 
 ```json
 {

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -88,6 +88,20 @@ ruleTester.run('expect-expect', rule, {
       `,
       options: [{ additionalTestBlockFunctions: ['theoretically'] }],
     },
+    {
+      code: dedent`
+        const assertFoo = (input) => {
+          expect(input).toBe("foo");
+        }
+        it("should pass", () => assertFoo("foo"))
+      `,
+      options: [
+        {
+          assertFunctionNames: ['assert*'],
+          additionalTestBlockFunctions: ['assert*'],
+        },
+      ],
+    },
   ],
 
   invalid: [
@@ -144,6 +158,26 @@ ruleTester.run('expect-expect', rule, {
         })
       `,
       options: [{ additionalTestBlockFunctions: ['theoretically'] }],
+      errors: [
+        {
+          messageId: 'noAssertions',
+          type: AST_NODE_TYPES.CallExpression,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const assertFoo = (input) => {
+          var valid = input === "foo"
+        }
+        it("should pass", () => assertFoo("foo"))
+      `,
+      options: [
+        {
+          assertFunctionNames: ['assert*'],
+          additionalTestBlockFunctions: ['assert*'],
+        },
+      ],
       errors: [
         {
           messageId: 'noAssertions',

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -56,6 +56,17 @@ ruleTester.run('no-standalone-expect', rule, {
       `,
       options: [{ additionalTestBlockFunctions: ['each.test'] }],
     },
+    {
+      code: dedent`
+        function expectToBeFoo(value) {
+          return expect(value).toBe("foo")
+        }
+        describe('scenario', () => {
+          expectToBeFoo("foo")
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['expect*'] }],
+    },
   ],
   invalid: [
     {
@@ -118,6 +129,20 @@ ruleTester.run('no-standalone-expect', rule, {
       `,
       options: [{ additionalTestBlockFunctions: ['test'] }],
       errors: [{ endColumn: 16, column: 3, messageId: 'unexpectedExpect' }],
+    },
+    {
+      code: dedent`
+        function expectToBeFoo(value) {
+          return expect(value)
+        }
+        describe('scenario', () => {
+          expectToBeFoo("foo")
+        });
+      `,
+      options: [{ additionalTestBlockFunctions: ['expect*'] }],
+      errors: [
+        { line: 2, endColumn: 17, column: 9, messageId: 'unexpectedExpect' },
+      ],
     },
     {
       code: 'describe("a test", () => { expect(1).toBe(1); });',

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -13,33 +13,8 @@ import {
   getTestCallExpressionsFromDeclaredVariables,
   isSupportedAccessor,
   isTestCaseCall,
+  matchesFunctionName,
 } from './utils';
-
-/**
- * Checks if node names returned by getNodeName matches any of the given star patterns
- * Pattern examples:
- *   request.*.expect
- *   request.**.expect
- *   request.**.expect*
- */
-function matchesFunctionName(
-  nodeName: string,
-  patterns: readonly string[],
-): boolean {
-  return patterns.some(p =>
-    new RegExp(
-      `^${p
-        .split('.')
-        .map(x => {
-          if (x === '**') return '[a-z\\.]*';
-
-          return x.replace(/\*/gu, '[a-z]*');
-        })
-        .join('\\.')}(\\.|$)`,
-      'ui',
-    ).test(nodeName),
-  );
-}
 
 export default createRule<
   [

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -22,7 +22,7 @@ import {
  *   request.**.expect
  *   request.**.expect*
  */
-function matchesAssertFunctionName(
+function matchesFunctionName(
   nodeName: string,
   patterns: readonly string[],
 ): boolean {
@@ -115,7 +115,7 @@ export default createRule<
 
         if (
           isTestCaseCall(node) ||
-          additionalTestBlockFunctions.includes(name)
+          matchesFunctionName(name, additionalTestBlockFunctions)
         ) {
           if (
             node.callee.type === AST_NODE_TYPES.MemberExpression &&
@@ -125,7 +125,7 @@ export default createRule<
           }
 
           unchecked.push(node);
-        } else if (matchesAssertFunctionName(name, assertFunctionNames)) {
+        } else if (matchesFunctionName(name, assertFunctionNames)) {
           // Return early in case of nested `it` statements.
           checkCallExpressionUsed(context.getAncestors());
         }

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -10,6 +10,7 @@ import {
   isExpectCall,
   isFunction,
   isTestCaseCall,
+  matchesFunctionName,
 } from './utils';
 
 const getBlockType = (
@@ -82,7 +83,10 @@ export default createRule<
     const isCustomTestBlockFunction = (
       node: TSESTree.CallExpression,
     ): boolean =>
-      additionalTestBlockFunctions.includes(getNodeName(node) || '');
+      matchesFunctionName(
+        getNodeName(node) || '',
+        additionalTestBlockFunctions,
+      );
 
     const isTestBlock = (node: TSESTree.CallExpression): boolean =>
       isTestCaseCall(node) || isCustomTestBlockFunction(node);

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -829,3 +829,31 @@ export const scopeHasLocalReference = (
     !references.unresolved.has(referenceName)
   );
 };
+
+/**
+ * Checks if node names returned by getNodeName matches any of the given star patterns
+ * Pattern examples:
+ *   request.*.expect
+ *   request.**.expect
+ *   request.**.expect*
+ */
+export function matchesFunctionName(
+  nodeName: string,
+  patterns: readonly string[],
+): boolean {
+  if (patterns.includes(nodeName)) return true;
+
+  return patterns.some(p =>
+    new RegExp(
+      `^${p
+        .split('.')
+        .map(x => {
+          if (x === '**') return '[a-z\\.]*';
+
+          return x.replace(/\*/gu, '[a-z]*');
+        })
+        .join('\\.')}(\\.|$)`,
+      'ui',
+    ).test(nodeName),
+  );
+}


### PR DESCRIPTION
TODO
- [x] - update `no-standalone-expect`
- [x] - update tests
- [x] - update docs
- [ ] - fix tests 😦 

Fixes #993