### PR TITLE
fix(prefer-hooks-on-top): improve message & docs

### DIFF
--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -1,6 +1,10 @@
 # Suggest having hooks before any test cases (`prefer-hooks-on-top`)
 
-All hooks should be defined before the start of the tests
+While hooks can be setup anywhere in a test file, they are always called in a
+specific order which means it can be confusing if they're intermixed with test
+cases.
+
+This rule helps to ensure that hooks are always defined before test cases.
 
 ## Rule Details
 

--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -11,46 +11,50 @@ Examples of **incorrect** code for this rule
 
 describe('foo', () => {
   beforeEach(() => {
-    //some hook code
+    seedMyDatabase();
   });
-  test('bar', () => {
-    some_fn();
-  });
-  beforeAll(() => {
-    //some hook code
-  });
-  test('bar', () => {
-    some_fn();
-  });
-});
 
-// Nested describe scenario
-describe('foo', () => {
+  it('accepts this input', () => {
+    // ...
+  });
+
   beforeAll(() => {
-    //some hook code
+    createMyDatabase();
   });
-  test('bar', () => {
-    some_fn();
+
+  it('returns that value', () => {
+    // ...
   });
-  describe('inner_foo', () => {
+
+  describe('when the database has specific values', () => {
+    const specificValue = '...';
+
     beforeEach(() => {
-      //some hook code
+      seedMyDatabase(specificValue);
     });
-    test('inner bar', () => {
-      some_fn();
+
+    it('accepts that input', () => {
+      // ...
     });
-    test('inner bar', () => {
-      some_fn();
+
+    it('throws an error', () => {
+      // ...
     });
-    beforeAll(() => {
-      //some hook code
+
+    afterEach(() => {
+      clearLogger();
     });
-    afterAll(() => {
-      //some hook code
+    beforeEach(() => {
+      mockLogger();
     });
-    test('inner bar', () => {
-      some_fn();
+
+    it('logs a message', () => {
+      // ...
     });
+  });
+
+  afterAll(() => {
+    removeMyDatabase();
   });
 });
 ```
@@ -61,35 +65,51 @@ Examples of **correct** code for this rule
 /* eslint jest/prefer-hooks-on-top: "error" */
 
 describe('foo', () => {
+  beforeAll(() => {
+    createMyDatabase();
+  });
+
   beforeEach(() => {
-    //some hook code
+    seedMyDatabase();
   });
 
-  // Not affected by rule
-  someSetup();
+  afterAll(() => {
+    clearMyDatabase();
+  });
 
-  afterEach(() => {
-    //some hook code
+  it('accepts this input', () => {
+    // ...
   });
-  test('bar', () => {
-    some_fn();
-  });
-});
 
-// Nested describe scenario
-describe('foo', () => {
-  beforeEach(() => {
-    //some hook code
+  it('returns that value', () => {
+    // ...
   });
-  test('bar', () => {
-    some_fn();
-  });
-  describe('inner_foo', () => {
+
+  describe('when the database has specific values', () => {
+    const specificValue = '...';
+
     beforeEach(() => {
-      //some hook code
+      seedMyDatabase(specificValue);
     });
-    test('inner bar', () => {
-      some_fn();
+
+    beforeEach(() => {
+      mockLogger();
+    });
+
+    afterEach(() => {
+      clearLogger();
+    });
+
+    it('accepts that input', () => {
+      // ...
+    });
+
+    it('throws an error', () => {
+      // ...
+    });
+
+    it('logs a message', () => {
+      // ...
     });
   });
 });

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -17,6 +17,7 @@ ruleTester.run('basic describe block', rule, {
         beforeEach(() => {});
         someSetupFn();
         afterEach(() => {});
+
         test('bar', () => {
           someFn();
         });
@@ -42,6 +43,7 @@ ruleTester.run('basic describe block', rule, {
           test('bar', () => {
             someFn();
           });
+
           beforeAll(() => {});
           test('bar', () => {
             someFn();
@@ -52,7 +54,7 @@ ruleTester.run('basic describe block', rule, {
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 6,
+          line: 7,
         },
       ],
     },
@@ -63,6 +65,7 @@ ruleTester.run('basic describe block', rule, {
           test.each\`\`('bar', () => {
             someFn();
           });
+
           beforeAll(() => {});
           test.only('bar', () => {
             someFn();
@@ -73,7 +76,7 @@ ruleTester.run('basic describe block', rule, {
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 6,
+          line: 7,
         },
       ],
     },
@@ -84,6 +87,7 @@ ruleTester.run('basic describe block', rule, {
           test.only.each\`\`('bar', () => {
             someFn();
           });
+
           beforeAll(() => {});
           test.only('bar', () => {
             someFn();
@@ -94,7 +98,7 @@ ruleTester.run('basic describe block', rule, {
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 6,
+          line: 7,
         },
       ],
     },
@@ -107,19 +111,21 @@ ruleTester.run('multiple describe blocks', rule, {
       describe.skip('foo', () => {
         beforeEach(() => {});
         beforeAll(() => {});
+
         test('bar', () => {
           someFn();
         });
       });
+
       describe('foo', () => {
         beforeEach(() => {});
+
         test('bar', () => {
           someFn();
         });
       });
     `,
   ],
-
   invalid: [
     {
       code: dedent`
@@ -128,6 +134,7 @@ ruleTester.run('multiple describe blocks', rule, {
           test('bar', () => {
             someFn();
           });
+
           beforeAll(() => {});
           test('bar', () => {
             someFn();
@@ -137,14 +144,17 @@ ruleTester.run('multiple describe blocks', rule, {
           beforeEach(() => {});
           beforeEach(() => {});
           beforeAll(() => {});
+
           test('bar', () => {
             someFn();
           });
         });
+
         describe('foo', () => {
           test('bar', () => {
             someFn();
           });
+
           beforeEach(() => {});
           beforeEach(() => {});
           beforeAll(() => {});
@@ -154,22 +164,22 @@ ruleTester.run('multiple describe blocks', rule, {
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 6,
+          line: 7,
         },
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 23,
+          line: 27,
         },
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 24,
+          line: 28,
         },
         {
           messageId: 'noHookOnTop',
           column: 3,
-          line: 25,
+          line: 29,
         },
       ],
     },
@@ -184,6 +194,7 @@ ruleTester.run('nested describe blocks', rule, {
         test('bar', () => {
           someFn();
         });
+
         describe('inner_foo', () => {
           beforeEach(() => {});
           test('inner bar', () => {
@@ -193,7 +204,6 @@ ruleTester.run('nested describe blocks', rule, {
       });
     `,
   ],
-
   invalid: [
     {
       code: dedent`
@@ -202,14 +212,17 @@ ruleTester.run('nested describe blocks', rule, {
           test('bar', () => {
             someFn();
           });
+
           describe('inner_foo', () => {
             beforeEach(() => {});
             test('inner bar', () => {
               someFn();
             });
+
             test('inner bar', () => {
               someFn();
             });
+
             beforeAll(() => {});
             afterAll(() => {});
             test('inner bar', () => {
@@ -222,12 +235,12 @@ ruleTester.run('nested describe blocks', rule, {
         {
           messageId: 'noHookOnTop',
           column: 5,
-          line: 14,
+          line: 17,
         },
         {
           messageId: 'noHookOnTop',
           column: 5,
-          line: 15,
+          line: 18,
         },
       ],
     },

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -22,6 +22,17 @@ ruleTester.run('basic describe block', rule, {
         });
       });
     `,
+    dedent`
+      describe('foo', () => {
+        someSetupFn();
+        beforeEach(() => {});
+        afterEach(() => {});
+
+        test('bar', () => {
+          someFn();
+        });
+      });
+    `,
   ],
   invalid: [
     {

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -9,7 +9,7 @@ export default createRule({
       recommended: false,
     },
     messages: {
-      noHookOnTop: 'Move all hooks before test cases',
+      noHookOnTop: 'Hooks should come before test cases',
     },
     schema: [],
     type: 'suggestion',


### PR DESCRIPTION
Noticed this rule was looking a little messy when looking into #992.

tbh this rule should probably be renamed to something like `prefer-hooks-before-tests`.