### PR TITLE
fix(no-large-snapshots): only count size of template string for inline snapshots

### DIFF
--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
 import rule from '../no-large-snapshots';
 import { espreeParser } from './test-utils';
 
@@ -27,6 +28,7 @@ ruleTester.run('no-large-snapshots', rule, {
     'expect(something)',
     'expect(something).toBe(1)',
     'expect(something).toMatchInlineSnapshot',
+    'expect(something).toMatchInlineSnapshot()',
     {
       filename: 'mock.js',
       code: generateExpectInlineSnapsCode(2, 'toMatchInlineSnapshot'),
@@ -51,6 +53,23 @@ ruleTester.run('no-large-snapshots', rule, {
     {
       filename: 'mock.jsx',
       code: generateExpectInlineSnapsCode(60, 'toMatchInlineSnapshot'),
+      options: [
+        {
+          maxSize: 61,
+        },
+      ],
+    },
+    {
+      filename: 'mock.jsx',
+      code: dedent`
+        expect(
+          functionUnderTest(
+            arg1,
+            arg2,
+            arg3
+          )
+        ).toMatchInlineSnapshot(${generateSnapshotLines(60)});
+      `,
       options: [
         {
           maxSize: 61,

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -24,7 +24,7 @@ type RuleContext = TSESLint.RuleContext<MessageId, [RuleOptions]>;
 
 const reportOnViolation = (
   context: RuleContext,
-  node: TSESTree.CallExpression | TSESTree.ExpressionStatement,
+  node: TSESTree.CallExpressionArgument | TSESTree.ExpressionStatement,
   { maxSize: lineLimit = 50, allowedSnapshots = {} }: RuleOptions,
 ) => {
   const startLine = node.loc.start.line;
@@ -130,9 +130,10 @@ export default createRule<[RuleOptions], MessageId>({
           [
             'toMatchInlineSnapshot',
             'toThrowErrorMatchingInlineSnapshot',
-          ].includes(matcher.name)
+          ].includes(matcher.name) &&
+          matcher.arguments?.length
         ) {
-          reportOnViolation(context, matcher.node.parent, {
+          reportOnViolation(context, matcher.arguments[0], {
             ...options,
             maxSize: options.inlineMaxSize ?? options.maxSize,
           });


### PR DESCRIPTION
Fixes #969