### PR TITLE
fix(prefer-to-contain): support square bracket accessors

### DIFF
--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -33,11 +33,26 @@ ruleTester.run('prefer-to-contain', rule, {
       errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     // todo: support this, as it's counted by isSupportedAccessor
-    // {
-    //   code: "expect(a['includes'](b)).toEqual(true);",
-    //   errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
-    //   output: 'expect(a).toContain(b);',
-    // },
+    {
+      code: "expect(a['includes'](b)).toEqual(true);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b)).toEqual(false);",
+      output: 'expect(a).not.toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b)).not.toEqual(false);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b))['not'].toEqual(false);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
     {
       code: 'expect(a.includes(b)).toEqual(false);',
       output: 'expect(a).not.toContain(b);',

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -32,9 +32,13 @@ ruleTester.run('prefer-to-contain', rule, {
       output: 'expect(a).toContain(b);',
       errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
-    // todo: support this, as it's counted by isSupportedAccessor
     {
       code: "expect(a['includes'](b)).toEqual(true);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b))['toEqual'](true);",
       output: 'expect(a).toContain(b);',
       errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
     },
@@ -50,6 +54,11 @@ ruleTester.run('prefer-to-contain', rule, {
     },
     {
       code: "expect(a['includes'](b))['not'].toEqual(false);",
+      output: 'expect(a).toContain(b);',
+      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+    },
+    {
+      code: "expect(a['includes'](b))['not']['toEqual'](false);",
       output: 'expect(a).toContain(b);',
       errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
     },

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -123,17 +123,17 @@ export default createRule({
                 includesCall.callee.property.range[0] - 1,
                 includesCall.range[1],
               ]),
-              // replace the matcher argument with the value from the "includes"
-              fixer.replaceText(
-                matcher.arguments[0],
-                sourceCode.getText(includesCall.arguments[0]),
-              ),
               // replace the current matcher with "toContain", adding "not" if needed
               fixer.replaceTextRange(
                 [expectCallEnd, matcher.node.range[1]],
                 addNotModifier
                   ? `.${ModifierName.not}.toContain`
                   : '.toContain',
+              ),
+              // replace the matcher argument with the value from the "includes"
+              fixer.replaceText(
+                matcher.arguments[0],
+                sourceCode.getText(includesCall.arguments[0]),
               ),
             ];
           },

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -111,19 +111,24 @@ export default createRule({
           fix(fixer) {
             const sourceCode = context.getSourceCode();
 
+            // we need to negate the expectation if the current expected
+            // value is itself negated by the "not" modifier
             const addNotModifier =
               followTypeAssertionChain(matcher.arguments[0]).value ===
               !!modifier;
 
             return [
+              // remove the "includes" call entirely
               fixer.removeRange([
                 includesCall.callee.property.range[0] - 1,
                 includesCall.range[1],
               ]),
+              // replace the matcher argument with the value from the "includes"
               fixer.replaceText(
                 matcher.arguments[0],
                 sourceCode.getText(includesCall.arguments[0]),
               ),
+              // replace the current matcher with "toContain", adding "not" if needed
               fixer.replaceTextRange(
                 [expectCallEnd, matcher.node.range[1]],
                 addNotModifier

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -15,17 +15,6 @@ export const createRule = ESLintUtils.RuleCreator(name => {
   return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
 });
 
-export function assertNotNull<T>(
-  value: T | null,
-  fileName: string,
-): asserts value is T {
-  if (value === null) {
-    throw new Error(
-      `Unexpected null when attempting to fix ${fileName} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-    );
-  }
-}
-
 export type MaybeTypeCast<Expression extends TSESTree.Expression> =
   | TSTypeCastExpression<Expression>
   | Expression;

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -15,6 +15,17 @@ export const createRule = ESLintUtils.RuleCreator(name => {
   return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
 });
 
+export function assertNotNull<T>(
+  value: T | null,
+  fileName: string,
+): asserts value is T {
+  if (value === null) {
+    throw new Error(
+      `Unexpected null when attempting to fix ${fileName} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
+    );
+  }
+}
+
 export type MaybeTypeCast<Expression extends TSESTree.Expression> =
   | TSTypeCastExpression<Expression>
   | Expression;


### PR DESCRIPTION
Pretty happy with this - while the "feature" itself isn't one I think we really need, implementing it wasn't too hard and it made me realise how to _greatly_ simplify the fixer so now we're getting support for square bracket accessors for free + no longer have a couple of theoretical throws 🎉 

Fixes #369