### PR TITLE
fix(prefer-to-have-length): support square bracket accessors

### DIFF
--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -32,6 +32,21 @@ ruleTester.run('prefer-to-have-length', rule, {
       errors: [{ messageId: 'useToHaveLength', column: 32, line: 1 }],
     },
     {
+      code: 'expect(files["length"])["toBe"](1);',
+      output: 'expect(files).toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 25, line: 1 }],
+    },
+    {
+      code: 'expect(files["length"]).not["toBe"](1);',
+      output: 'expect(files).not.toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 29, line: 1 }],
+    },
+    {
+      code: 'expect(files["length"])["not"]["toBe"](1);',
+      output: 'expect(files)["not"].toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 32, line: 1 }],
+    },
+    {
       code: 'expect(files.length).toBe(1);',
       output: 'expect(files).toHaveLength(1);',
       errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -18,16 +18,19 @@ ruleTester.run('prefer-to-have-length', rule, {
     `expect(user.getUserName(5)).resolves.toEqual('Paul')`,
     `expect(user.getUserName(5)).rejects.toEqual('Paul')`,
     'expect(a);',
-    'expect(files["length"]).toBe(1);',
   ],
 
   invalid: [
-    // todo: support this
-    // {
-    //   code: 'expect(files["length"]).toBe(1);',
-    //   errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
-    //   output: 'expect(files).toHaveLength(1);',
-    // },
+    {
+      code: 'expect(files["length"]).toBe(1);',
+      output: 'expect(files).toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 25, line: 1 }],
+    },
+    {
+      code: 'expect(files["length"])["not"].toBe(1);',
+      output: 'expect(files)["not"].toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 32, line: 1 }],
+    },
     {
       code: 'expect(files.length).toBe(1);',
       output: 'expect(files).toHaveLength(1);',
@@ -42,6 +45,11 @@ ruleTester.run('prefer-to-have-length', rule, {
       code: 'expect(files.length).toStrictEqual(1);',
       output: 'expect(files).toHaveLength(1);',
       errors: [{ messageId: 'useToHaveLength', column: 22, line: 1 }],
+    },
+    {
+      code: 'expect(files.length).not.toStrictEqual(1);',
+      output: 'expect(files).not.toHaveLength(1);',
+      errors: [{ messageId: 'useToHaveLength', column: 26, line: 1 }],
     },
   ],
 });

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -49,10 +49,12 @@ export default createRule({
         context.report({
           fix(fixer) {
             return [
+              // remove the "length" property accessor
               fixer.removeRange([
                 argument.property.range[0] - 1,
                 argument.range[1],
               ]),
+              // replace the current matcher with "toHaveLength"
               fixer.replaceTextRange(
                 [matcher.node.object.range[1], matcher.node.range[1]],
                 '.toHaveLength',

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -48,43 +48,13 @@ export default createRule({
 
         context.report({
           fix(fixer) {
-            const accessorStartToken = context
-              .getSourceCode()
-              .getFirstTokenBetween(
-                argument.object,
-                argument.property,
-                token => token.value === '.' || token.value === '[',
-              );
-
-            /* istanbul ignore if */
-            if (accessorStartToken === null) {
-              throw new Error(
-                `Unexpected null when attempting to fix ${context.getFilename()} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-              );
-            }
-
-            const fixers = [
-              fixer.remove(accessorStartToken),
-              fixer.remove(argument.property),
+            return [
+              fixer.removeRange([
+                argument.property.range[0] - 1,
+                argument.range[1],
+              ]),
               fixer.replaceText(matcher.node.property, 'toHaveLength'),
             ];
-
-            if (accessorStartToken.value === '[') {
-              const accessorStopToken = context
-                .getSourceCode()
-                .getTokenAfter(argument.property);
-
-              /* istanbul ignore if */
-              if (accessorStopToken === null) {
-                throw new Error(
-                  `Unexpected null when attempting to fix ${context.getFilename()} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-                );
-              }
-
-              fixers.push(fixer.remove(accessorStopToken));
-            }
-
-            return fixers;
           },
           messageId: 'useToHaveLength',
           node: matcher.node.property,

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -53,7 +53,10 @@ export default createRule({
                 argument.property.range[0] - 1,
                 argument.range[1],
               ]),
-              fixer.replaceText(matcher.node.property, 'toHaveLength'),
+              fixer.replaceTextRange(
+                [matcher.node.object.range[1], matcher.node.range[1]],
+                '.toHaveLength',
+              ),
             ];
           },
           messageId: 'useToHaveLength',


### PR DESCRIPTION
Same as #1009 - the win is less since the fixer was smaller, but still a good one; in particular lets us get rid of the theoretical 
"not null" assertion 🎉 