### PR TITLE
feat: create `prefer-snapshot-hint` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ installations requiring long-term consistency.
 | [prefer-expect-resolves](docs/rules/prefer-expect-resolves.md)               | Prefer `await expect(...).resolves` over `expect(await ...)` syntax |                  | ![fixable][] |
 | [prefer-hooks-on-top](docs/rules/prefer-hooks-on-top.md)                     | Suggest having hooks before any test cases                          |                  |              |
 | [prefer-lowercase-title](docs/rules/prefer-lowercase-title.md)               | Enforce lowercase test names                                        |                  | ![fixable][] |
+| [prefer-snapshot-hint](docs/rules/prefer-snapshot-hint.md)                   | Prefer including a hint with external snapshots                     |                  |              |
 | [prefer-spy-on](docs/rules/prefer-spy-on.md)                                 | Suggest using `jest.spyOn()`                                        |                  | ![fixable][] |
 | [prefer-strict-equal](docs/rules/prefer-strict-equal.md)                     | Suggest using `toStrictEqual()`                                     |                  | ![suggest][] |
 | [prefer-to-be](docs/rules/prefer-to-be.md)                                   | Suggest using `toBe()` for primitive literals                       | ![style][]       | ![fixable][] |

--- a/docs/rules/prefer-snapshot-hint.md
+++ b/docs/rules/prefer-snapshot-hint.md
@@ -1,0 +1,181 @@
+# Prefer including a hint with external snapshots (`prefer-snapshot-hint`)
+
+When working with external snapshot matchers it's considered best practice to
+provide a hint (as the last argument to the matcher) describing the expected
+snapshot content that will be included in the snapshots name by Jest.
+
+This makes it easier for reviewers to verify the snapshots during review, and
+for anyone to know whether an outdated snapshot is the correct behavior before
+updating.
+
+## Rule details
+
+This rule looks for any use of an external snapshot matcher (e.g.
+`toMatchSnapshot` and `toThrowErrorMatchingSnapshot`) and checks if they include
+a snapshot hint.
+
+## Options
+
+### `'always'`
+
+Require a hint to _always_ be provided when using external snapshot matchers.
+
+Examples of **incorrect** code for the `'always'` option:
+
+```js
+const snapshotOutput = ({ stdout, stderr }) => {
+  expect(stdout).toMatchSnapshot();
+  expect(stderr).toMatchSnapshot();
+};
+
+describe('cli', () => {
+  describe('--version flag', () => {
+    it('prints the version', async () => {
+      snapshotOutput(await runCli(['--version']));
+    });
+  });
+
+  describe('--config flag', () => {
+    it('reads the config', async () => {
+      const { stdout, parsedConfig } = await runCli([
+        '--config',
+        'jest.config.js',
+      ]);
+
+      expect(stdout).toMatchSnapshot();
+      expect(parsedConfig).toMatchSnapshot();
+    });
+
+    it('prints nothing to stderr', async () => {
+      const { stderr } = await runCli(['--config', 'jest.config.js']);
+
+      expect(stderr).toMatchSnapshot();
+    });
+
+    describe('when the file does not exist', () => {
+      it('throws an error', async () => {
+        await expect(
+          runCli(['--config', 'does-not-exist.js']),
+        ).rejects.toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+});
+```
+
+Examples of **correct** code for the `'always'` option:
+
+```js
+const snapshotOutput = ({ stdout, stderr }, hints) => {
+  expect(stdout).toMatchSnapshot({}, `stdout: ${hints.stdout}`);
+  expect(stderr).toMatchSnapshot({}, `stderr: ${hints.stderr}`);
+};
+
+describe('cli', () => {
+  describe('--version flag', () => {
+    it('prints the version', async () => {
+      snapshotOutput(await runCli(['--version']), {
+        stdout: 'version string',
+        stderr: 'empty',
+      });
+    });
+  });
+
+  describe('--config flag', () => {
+    it('reads the config', async () => {
+      const { stdout } = await runCli(['--config', 'jest.config.js']);
+
+      expect(stdout).toMatchSnapshot({}, 'stdout: config settings');
+    });
+
+    it('prints nothing to stderr', async () => {
+      const { stderr } = await runCli(['--config', 'jest.config.js']);
+
+      expect(stderr).toMatchInlineSnapshot();
+    });
+
+    describe('when the file does not exist', () => {
+      it('throws an error', async () => {
+        await expect(
+          runCli(['--config', 'does-not-exist.js']),
+        ).rejects.toThrowErrorMatchingSnapshot('stderr: config error');
+      });
+    });
+  });
+});
+```
+
+### `'multi'` (default)
+
+Require a hint to be provided when there are multiple external snapshot matchers
+within the same test body.
+
+Examples of **incorrect** code for the `'multi'` option:
+
+```js
+describe('cli', () => {
+  describe('--version flag', () => {
+    it('prints the version', async () => {
+      const { stdout, stderr } = await runCli(['--version']);
+
+      expect(stdout).toMatchSnapshot();
+      expect(stderr).toMatchSnapshot();
+    });
+  });
+
+  describe('--config flag', () => {
+    it('reads the config', async () => {
+      const { stdout, parsedConfig } = await runCli([
+        '--config',
+        'jest.config.js',
+      ]);
+
+      expect(stdout).toMatchSnapshot();
+      expect(parsedConfig).toMatchSnapshot();
+    });
+
+    it('prints nothing to stderr', async () => {
+      const { stderr } = await runCli(['--config', 'jest.config.js']);
+
+      expect(stderr).toMatchSnapshot();
+    });
+  });
+});
+```
+
+Examples of **correct** code for the `'multi'` option:
+
+```js
+describe('cli', () => {
+  describe('--version flag', () => {
+    it('prints the version', async () => {
+      const { stdout, stderr } = await runCli(['--version']);
+
+      expect(stdout).toMatchSnapshot('stdout: version string');
+      expect(stderr).toMatchSnapshot('stderr: empty');
+    });
+  });
+
+  describe('--config flag', () => {
+    it('reads the config', async () => {
+      const { stdout } = await runCli(['--config', 'jest.config.js']);
+
+      expect(stdout).toMatchSnapshot();
+    });
+
+    it('prints nothing to stderr', async () => {
+      const { stderr } = await runCli(['--config', 'jest.config.js']);
+
+      expect(stderr).toMatchInlineSnapshot();
+    });
+
+    describe('when the file does not exist', () => {
+      it('throws an error', async () => {
+        await expect(
+          runCli(['--config', 'does-not-exist.js']),
+        ).rejects.toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+});
+```

--- a/docs/rules/prefer-snapshot-hint.md
+++ b/docs/rules/prefer-snapshot-hint.md
@@ -108,18 +108,20 @@ describe('cli', () => {
 ### `'multi'` (default)
 
 Require a hint to be provided when there are multiple external snapshot matchers
-within the same test body.
+within the scope (meaning it includes nested calls).
 
 Examples of **incorrect** code for the `'multi'` option:
 
 ```js
+const snapshotOutput = ({ stdout, stderr }) => {
+  expect(stdout).toMatchSnapshot();
+  expect(stderr).toMatchSnapshot();
+};
+
 describe('cli', () => {
   describe('--version flag', () => {
     it('prints the version', async () => {
-      const { stdout, stderr } = await runCli(['--version']);
-
-      expect(stdout).toMatchSnapshot();
-      expect(stderr).toMatchSnapshot();
+      snapshotOutput(await runCli(['--version']));
     });
   });
 
@@ -146,13 +148,18 @@ describe('cli', () => {
 Examples of **correct** code for the `'multi'` option:
 
 ```js
+const snapshotOutput = ({ stdout, stderr }, hints) => {
+  expect(stdout).toMatchSnapshot({}, `stdout: ${hints.stdout}`);
+  expect(stderr).toMatchSnapshot({}, `stderr: ${hints.stderr}`);
+};
+
 describe('cli', () => {
   describe('--version flag', () => {
     it('prints the version', async () => {
-      const { stdout, stderr } = await runCli(['--version']);
-
-      expect(stdout).toMatchSnapshot('stdout: version string');
-      expect(stderr).toMatchSnapshot('stderr: empty');
+      snapshotOutput(await runCli(['--version']), {
+        stdout: 'version string',
+        stderr: 'empty',
+      });
     });
   });
 

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -41,6 +41,7 @@ Object {
       "jest/prefer-expect-resolves": "error",
       "jest/prefer-hooks-on-top": "error",
       "jest/prefer-lowercase-title": "error",
+      "jest/prefer-snapshot-hint": "error",
       "jest/prefer-spy-on": "error",
       "jest/prefer-strict-equal": "error",
       "jest/prefer-to-be": "error",

--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { resolve } from 'path';
 import plugin from '../';
 
-const numberOfRules = 46;
+const numberOfRules = 47;
 const ruleNames = Object.keys(plugin.rules);
 const deprecatedRules = Object.entries(plugin.rules)
   .filter(([, rule]) => rule.meta.deprecated)

--- a/src/rules/__tests__/prefer-snapshot-hint.test.ts
+++ b/src/rules/__tests__/prefer-snapshot-hint.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../prefer-snapshot-hint';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/prefer-snapshot-hint.test.ts
+++ b/src/rules/__tests__/prefer-snapshot-hint.test.ts
@@ -1,0 +1,464 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import dedent from 'dedent';
+import rule from '../prefer-snapshot-hint';
+import { espreeParser } from './test-utils';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: espreeParser,
+  parserOptions: {
+    ecmaVersion: 2015,
+  },
+});
+
+ruleTester.run('prefer-snapshot-hint (always)', rule, {
+  valid: [
+    {
+      code: 'expect(something).toStrictEqual(somethingElse);',
+      options: ['always'],
+    },
+    {
+      code: "a().toEqual('b')",
+      options: ['always'],
+    },
+    {
+      code: 'expect(a);',
+      options: ['always'],
+    },
+    {
+      code: 'expect(1).toMatchSnapshot({}, "my snapshot");',
+      options: ['always'],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingSnapshot("my snapshot");',
+      options: ['always'],
+    },
+    {
+      code: 'expect(1).toMatchInlineSnapshot();',
+      options: ['always'],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingInlineSnapshot();',
+      options: ['always'],
+    },
+  ],
+  invalid: [
+    {
+      code: 'expect(1).toMatchSnapshot();',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1).toMatchSnapshot({});',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingSnapshot();',
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+        });
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+          expect(2).toMatchSnapshot();
+        });
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+          expect(2).toThrowErrorMatchingSnapshot("my error");
+        });
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const expectSnapshot = value => {
+          expect(value).toMatchSnapshot();
+        };
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const expectSnapshot = value => {
+          expect(value).toThrowErrorMatchingSnapshot();
+        };
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 2,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('prefer-snapshot-hint (multi)', rule, {
+  valid: [
+    {
+      code: 'expect(something).toStrictEqual(somethingElse);',
+      options: ['multi'],
+    },
+    {
+      code: "a().toEqual('b')",
+      options: ['multi'],
+    },
+    {
+      code: 'expect(a);',
+      options: ['multi'],
+    },
+    {
+      code: 'expect(1).toMatchSnapshot({}, "my snapshot");',
+      options: ['multi'],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingSnapshot("my snapshot");',
+      options: ['multi'],
+    },
+    {
+      code: 'expect(1).toMatchSnapshot({});',
+      options: ['multi'],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingSnapshot();',
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot(undefined, 'my first snapshot');
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+        });
+
+        it('is false', () => {
+          expect(2).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+        });
+
+        it('is false', () => {
+          expect(2).toThrowErrorMatchingSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toStrictEqual(1);
+          expect(1).toStrictEqual(2);
+          expect(1).toMatchSnapshot();
+        });
+
+        it('is false', () => {
+          expect(1).toStrictEqual(1);
+          expect(1).toStrictEqual(2);
+          expect(2).toThrowErrorMatchingSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchInlineSnapshot();
+        });
+
+        it('is false', () => {
+          expect(1).toMatchInlineSnapshot();
+          expect(1).toMatchInlineSnapshot();
+          expect(1).toThrowErrorMatchingInlineSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+          expect(2).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+          expect(2).toThrowErrorMatchingSnapshot();
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toThrowErrorMatchingSnapshot();
+          expect(2).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot({});
+          expect(2).toMatchSnapshot({});
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+          expect(2).toMatchSnapshot(undefined, 'my second snapshot');
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot({});
+          expect(2).toMatchSnapshot(undefined, 'my second snapshot');
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot({}, 'my first snapshot');
+          expect(2).toMatchSnapshot(undefined);
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot({}, 'my first snapshot');
+          expect(2).toMatchSnapshot(undefined);
+          expect(2).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(2).toMatchSnapshot();
+          expect(1).toMatchSnapshot({}, 'my second snapshot');
+          expect(2).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(2).toMatchSnapshot(undefined);
+          expect(2).toMatchSnapshot();
+          expect(1).toMatchSnapshot(null, 'my third snapshot');
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 3,
+        },
+      ],
+    },
+  ],
+});

--- a/src/rules/__tests__/prefer-snapshot-hint.test.ts
+++ b/src/rules/__tests__/prefer-snapshot-hint.test.ts
@@ -157,6 +157,21 @@ ruleTester.run('prefer-snapshot-hint (always)', rule, {
         },
       ],
     },
+    {
+      code: dedent`
+        it('is true', () => {
+          { expect(1).toMatchSnapshot(); }
+        });
+      `,
+      options: ['always'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 15,
+          line: 2,
+        },
+      ],
+    },
   ],
 });
 
@@ -260,6 +275,57 @@ ruleTester.run('prefer-snapshot-hint (multi)', rule, {
       `,
       options: ['multi'],
     },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          const innerFn = anotherValue => {
+            expect(anotherValue).toMatchSnapshot();
+
+            expect(value).toBe(1);
+          };
+
+          expect(value).toBe(1);
+        };
+
+        it('my test', () => {
+          expect(1).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          const innerFn = anotherValue => {
+            expect(value).toBe(1);
+          };
+
+          expect(value).toBe(1);
+          expect(anotherValue).toMatchSnapshot();
+        };
+
+        it('my test', () => {
+          expect(1).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          const innerFn = anotherValue => {
+            expect(anotherValue).toMatchSnapshot();
+
+            expect(value).toBe(1);
+          };
+
+          expect(value).toBe(1);
+        };
+
+        expect(1).toMatchSnapshot();
+      `,
+      options: ['multi'],
+    },
   ],
   invalid: [
     {
@@ -342,6 +408,50 @@ ruleTester.run('prefer-snapshot-hint (multi)', rule, {
         {
           messageId: 'missingHint',
           column: 13,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          expect(1).toMatchSnapshot({});
+          {
+            expect(2).toMatchSnapshot({});
+          }
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 13,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 15,
+          line: 4,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('is true', () => {
+          { expect(1).toMatchSnapshot(); }
+          { expect(2).toMatchSnapshot(); }
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 15,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 15,
           line: 3,
         },
       ],
@@ -457,6 +567,158 @@ ruleTester.run('prefer-snapshot-hint (multi)', rule, {
           messageId: 'missingHint',
           column: 13,
           line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          expect(value).toMatchSnapshot();
+
+          const innerFn = anotherValue => {
+            expect(anotherValue).toMatchSnapshot();
+          };
+
+          expect(value).toBe(1);
+          expect(value + 1).toMatchSnapshot(null);
+          expect(value + 2).toThrowErrorMatchingSnapshot(snapshotHint);
+        };
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 26,
+          line: 5,
+        },
+        {
+          messageId: 'missingHint',
+          column: 21,
+          line: 9,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          expect(value).toMatchSnapshot();
+
+          const innerFn = anotherValue => {
+            expect(anotherValue).toMatchSnapshot();
+
+            expect(value).toBe(1);
+            expect(value + 1).toMatchSnapshot(null);
+            expect(value + 2).toMatchSnapshot(null, snapshotHint);
+          };
+        };
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 2,
+        },
+        {
+          messageId: 'missingHint',
+          column: 26,
+          line: 5,
+        },
+        {
+          messageId: 'missingHint',
+          column: 23,
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          const innerFn = anotherValue => {
+            expect(anotherValue).toMatchSnapshot();
+
+            expect(value).toBe(1);
+            expect(value + 1).toMatchSnapshot(null);
+            expect(value + 2).toMatchSnapshot(null, snapshotHint);
+          };
+
+          expect(value).toThrowErrorMatchingSnapshot();
+        };
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 26,
+          line: 3,
+        },
+        {
+          messageId: 'missingHint',
+          column: 23,
+          line: 6,
+        },
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 10,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = (value, snapshotHint) => {
+          const innerFn = anotherValue => {
+            expect(anotherValue).toMatchSnapshot();
+
+            expect(value).toBe(1);
+          };
+
+          expect(value).toMatchSnapshot();
+        };
+
+        it('my test', () => {
+          expect(1).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 26,
+          line: 3,
+        },
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 8,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const myReusableTestBody = value => {
+          expect(value).toMatchSnapshot();
+        };
+
+        expect(1).toMatchSnapshot();
+        expect(1).toThrowErrorMatchingSnapshot();
+      `,
+      options: ['multi'],
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 11,
+          line: 5,
+        },
+        {
+          messageId: 'missingHint',
+          column: 11,
+          line: 6,
         },
       ],
     },

--- a/src/rules/prefer-snapshot-hint.ts
+++ b/src/rules/prefer-snapshot-hint.ts
@@ -1,0 +1,118 @@
+import {
+  ParsedExpectMatcher,
+  createRule,
+  isExpectCall,
+  isTestCaseCall,
+  parseExpectCall,
+} from './utils';
+
+const snapshotMatchers = ['toMatchSnapshot', 'toThrowErrorMatchingSnapshot'];
+
+const isSnapshotMatcher = (matcher: ParsedExpectMatcher) => {
+  return snapshotMatchers.includes(matcher.name);
+};
+
+const isSnapshotMatcherWithoutHint = (matcher: ParsedExpectMatcher) => {
+  if (!isSnapshotMatcher(matcher)) {
+    return false;
+  }
+
+  const expectedNumberOfArgumentsWithHint =
+    1 + Number(matcher.name === 'toMatchSnapshot');
+
+  return matcher.arguments?.length !== expectedNumberOfArgumentsWithHint;
+};
+
+const messages = {
+  missingHint: 'You should provide a hint for this snapshot',
+};
+
+export default createRule<[('always' | 'multi')?], keyof typeof messages>({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Prefer including a hint with external snapshots',
+      recommended: false,
+    },
+    messages,
+    type: 'suggestion',
+    schema: [
+      {
+        type: 'string',
+        enum: ['always', 'multi'],
+      },
+    ],
+  },
+  defaultOptions: ['multi'],
+  create(context, [mode]) {
+    let withinTestBody = false;
+    let previousSnapshotMatcher: ParsedExpectMatcher | null = null;
+    let hasReportedPreviousSnapshotMatcher = false;
+
+    return {
+      CallExpression(node) {
+        if (isTestCaseCall(node)) {
+          withinTestBody = true;
+
+          return;
+        }
+
+        if (!isExpectCall(node)) {
+          return;
+        }
+
+        const { matcher } = parseExpectCall(node);
+
+        if (!matcher) {
+          return;
+        }
+
+        if (mode === 'always' && isSnapshotMatcherWithoutHint(matcher)) {
+          context.report({
+            messageId: 'missingHint',
+            node: matcher.node.property,
+          });
+
+          return;
+        }
+
+        if (!withinTestBody || !isSnapshotMatcher(matcher)) {
+          return;
+        }
+
+        if (!previousSnapshotMatcher) {
+          previousSnapshotMatcher = matcher;
+
+          return;
+        }
+
+        if (isSnapshotMatcherWithoutHint(matcher)) {
+          context.report({
+            messageId: 'missingHint',
+            node: matcher.node.property,
+          });
+        }
+
+        if (
+          isSnapshotMatcherWithoutHint(previousSnapshotMatcher) &&
+          !hasReportedPreviousSnapshotMatcher
+        ) {
+          context.report({
+            messageId: 'missingHint',
+            node: previousSnapshotMatcher.node.property,
+          });
+
+          hasReportedPreviousSnapshotMatcher = true;
+        }
+      },
+      'CallExpression:exit'(node) {
+        if (isTestCaseCall(node)) {
+          withinTestBody = false;
+          previousSnapshotMatcher = null;
+          hasReportedPreviousSnapshotMatcher = false;
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
* I've gone with `hint` instead of `name` as that's what the argument is called in the docs - however the docs do refer to it in a few places as "snapshot name" and it is used as part of the name. @SimenB imo it would be good to be consistent, so would be good if you could weigh in on if you'd prefer `hint` or `name` and I can do the legwork of making a PR to `jest` updating the docs and argument(s) to match
* I've not implemented the `never` option because I really don't think that is something people should be doing since there's no gain in not having a hint.
* I've set `multi` as the default because I think that is reasonable to assume the test title has enough context for one external snapshot matcher, but as soon as you have multiple in a single test you can't tell what each snapshot actually is from the snap along without a hint.

Resolves #103 