### PR TITLE
feat(prefer-expect-assertions): support requiring only if `expect` is used in a loop

### DIFF
--- a/docs/rules/prefer-expect-assertions.md
+++ b/docs/rules/prefer-expect-assertions.md
@@ -58,6 +58,16 @@ test('my test', () => {
 
 ## Options
 
+This rule can be configured to only check tests that match certain patterns that
+typically look like `expect` calls might be missed, such as in promises or
+loops.
+
+By default, none of these options are enabled meaning the rule checks _every_
+test for a call to either `expect.hasAssertions` or `expect.assertions`. If any
+of the options are enabled the rule checks any test that matches _at least one_
+of the patterns represented by the enabled options (think "OR" rather than
+"AND").
+
 #### `onlyFunctionsWithAsyncKeyword`
 
 When `true`, this rule will only warn for tests that use the `async` keyword.
@@ -95,5 +105,55 @@ test('my test', async () => {
   expect.assertions(1);
   const result = await someAsyncFunc();
   expect(result).toBe('foo');
+});
+```
+
+#### `onlyFunctionsWithExpectInLoop`
+
+When `true`, this rule will only warn for tests that have `expect` calls within
+a native loop.
+
+```json
+{
+  "rules": {
+    "jest/prefer-expect-assertions": [
+      "warn",
+      { "onlyFunctionsWithAsyncKeyword": true }
+    ]
+  }
+}
+```
+
+Examples of **incorrect** code when `'onlyFunctionsWithExpectInLoop'` is `true`:
+
+```js
+describe('getNumbers', () => {
+  it('only returns numbers that are greater than zero', () => {
+    const numbers = getNumbers();
+
+    for (const number in numbers) {
+      expect(number).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+Examples of **correct** code when `'onlyFunctionsWithExpectInLoop'` is `true`:
+
+```js
+describe('getNumbers', () => {
+  it('only returns numbers that are greater than zero', () => {
+    expect.hasAssertions();
+
+    const numbers = getNumbers();
+
+    for (const number in numbers) {
+      expect(number).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns more than one number', () => {
+    expect(getNumbers().length).toBeGreaterThan(1);
+  });
 });
 ```

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -517,6 +517,27 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
     },
     {
       code: dedent`
+        it.each([1, 2, 3])("returns numbers that are greater than four", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        });
+
+        it("is a number that is greater than four", () => {
+          expect(number).toBeGreaterThan(4);
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
         it("returns numbers that are greater than four", () => {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
@@ -615,6 +636,31 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
     {
       code: dedent`
         it("it1", async () => {
+          expect.hasAssertions();
+
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+
+        it("it1", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 9,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it.skip.each\`\`("it1", async () => {
           expect.hasAssertions();
 
           for (const number of getNumbers()) {

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -376,20 +376,6 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
     },
     {
       code: dedent`
-        it('returns numbers that are greater than two', function () {
-          const expectNumbersToBeGreaterThan = (numbers, value) => {
-            for (let number of numbers) {
-              expect(number).toBeGreaterThan(value);
-            }
-          };
-
-          expectNumbersToBeGreaterThan(getNumbers(), 2);
-        });
-      `,
-      options: [{ onlyFunctionsWithExpectInLoop: true }],
-    },
-    {
-      code: dedent`
         it("returns numbers that are greater than five", function () {
           expect.assertions(2);
 
@@ -420,6 +406,27 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(6);
           }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('returns numbers that are greater than two', function () {
+          const expectNumbersToBeGreaterThan = (numbers, value) => {
+            for (let number of numbers) {
+              expect(number).toBeGreaterThan(value);
+            }
+          };
+
+          expectNumbersToBeGreaterThan(getNumbers(), 2);
         });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -27,6 +27,24 @@ ruleTester.run('prefer-expect-assertions', rule, {
     'itHappensToStartWithIt("foo", function() {})',
     'testSomething("bar", function() {})',
     'it(async () => {expect.assertions(0);})',
+    dedent`
+      it("returns numbers that are greater than four", function() {
+        expect.assertions(2);
+
+        for(let thing in things) {
+          expect(number).toBeGreaterThan(4);
+        }
+      })
+    `,
+    dedent`
+      it("returns numbers that are greater than four", function() {
+        expect.hasAssertions();
+
+        for (let i = 0; i < things.length; i++) {
+          expect(number).toBeGreaterThan(4);
+        }
+      })
+    `,
     {
       code: dedent`
         it("it1", async () => {
@@ -46,6 +64,28 @@ ruleTester.run('prefer-expect-assertions', rule, {
     },
     {
       code: 'it("it1", () => {})',
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", async () => {
+          expect.assertions(2);
+
+          for(let thing in things) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", () => {
+          for(let thing in things) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
     },
   ],
@@ -250,6 +290,501 @@ ruleTester.run('prefer-expect-assertions', rule, {
         })
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", async () => {
+          for(let thing in things) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", async () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", async () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+
+        it("returns numbers that are greater than five", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(5);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithAsyncKeyword: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('prefer-expect-assertions (loops)', rule, {
+  valid: [
+    {
+      code: dedent`
+        const expectNumbersToBeGreaterThan = (numbers, value) => {
+          for (let number of getNumbers()()) {
+            expect(number).toBeGreaterThan(value);
+          }
+        };
+
+        it('returns numbers that are greater than two', function () {
+          expectNumbersToBeGreaterThan(getNumbers(), 2);
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+    },
+    {
+      code: dedent`
+        it('returns numbers that are greater than two', function () {
+          const expectNumbersToBeGreaterThan = (numbers, value) => {
+            for (let number of getNumbers()()) {
+              expect(number).toBeGreaterThan(value);
+            }
+          };
+
+          expectNumbersToBeGreaterThan(getNumbers(), 2);
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than five", function () {
+          expect.assertions(2);
+
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(5);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+    },
+    {
+      code: dedent`
+        it("returns things that are less than ten", function () {
+          expect.hasAssertions();
+
+          for (const thing in things) {
+            expect(thing).toBeLessThan(10);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        it('only returns numbers that are greater than six', () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(6);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("only returns numbers that are greater than seven", function () {
+          const numbers = getNumbers();
+
+          for (let i = 0; i < numbers.length; i++) {
+            expect(numbers[i]).toBeGreaterThan(7);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('has the number two', () => {
+          expect(number).toBe(2);
+        })
+
+        it('only returns numbers that are less than twenty', () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeLessThan(20);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("is wrong");
+
+        it("is a test", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("is a number that is greater than four", () => {
+          expect(number).toBeGreaterThan(4);
+        })
+
+        it("returns numbers that are greater than four", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+
+        it("returns numbers that are greater than five", () => {
+          expect(number).toBeGreaterThan(5);
+        })
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        });
+
+        it("is a number that is greater than four", () => {
+          expect(number).toBeGreaterThan(4);
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        });
+
+        it("is a number that is greater than four", () => {
+          expect.hasAssertions();
+
+          expect(number).toBeGreaterThan(4);
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("it1", () => {
+          expect.hasAssertions();
+
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        });
+
+        it("it1", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 9,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("returns numbers that are greater than four", async () => {
+          for (const number of await getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        });
+
+        it("returns numbers that are greater than five", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(5);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 7,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("it1", async () => {
+          expect.hasAssertions();
+
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+
+        it("it1", () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 9,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("it1", async () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+
+        it("it1", () => {
+          expect.hasAssertions();
+
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(4);
+          }
+        })
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('prefer-expect-assertions (mixed)', rule, {
+  valid: [
+    {
+      code: dedent`
+        it('only returns numbers that are greater than zero', async () => {
+          expect.hasAssertions();
+
+          for (const number of await getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        })
+      `,
+      options: [
+        {
+          onlyFunctionsWithAsyncKeyword: true,
+          onlyFunctionsWithExpectInLoop: true,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('only returns numbers that are greater than zero', async () => {
+          expect.assertions(2);
+
+          for (const number of await getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        })
+      `,
+      options: [
+        {
+          onlyFunctionsWithAsyncKeyword: true,
+          onlyFunctionsWithExpectInLoop: true,
+        },
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        it('only returns numbers that are greater than zero', () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        });
+
+        it("is zero", () => {
+          expect.hasAssertions();
+
+          expect(0).toBe(0);
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('only returns numbers that are greater than zero', () => {
+          expect.hasAssertions();
+
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        });
+
+        it('only returns numbers that are less than 100', () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeLessThan(0);
+          }
+        });
+      `,
+      options: [{ onlyFunctionsWithExpectInLoop: true }],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 9,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it("to be true", async function() {
+          expect(someValue).toBe(true);
+        });
+      `,
+      options: [
+        {
+          onlyFunctionsWithAsyncKeyword: true,
+          onlyFunctionsWithExpectInLoop: true,
+        },
+      ],
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        it('only returns numbers that are greater than zero', async () => {
+          for (const number of getNumbers()) {
+            expect(number).toBeGreaterThan(0);
+          }
+        })
+      `,
+      options: [
+        {
+          onlyFunctionsWithAsyncKeyword: true,
+          onlyFunctionsWithExpectInLoop: true,
+        },
+      ],
       errors: [
         {
           messageId: 'haveExpectAssertions',

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -363,7 +363,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
     {
       code: dedent`
         const expectNumbersToBeGreaterThan = (numbers, value) => {
-          for (let number of getNumbers()()) {
+          for (let number of numbers) {
             expect(number).toBeGreaterThan(value);
           }
         };
@@ -378,7 +378,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
       code: dedent`
         it('returns numbers that are greater than two', function () {
           const expectNumbersToBeGreaterThan = (numbers, value) => {
-            for (let number of getNumbers()()) {
+            for (let number of numbers) {
               expect(number).toBeGreaterThan(value);
             }
           };

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -21,7 +21,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
       it("it1", function() {
         expect.assertions(1);
         expect(someValue).toBe(true)
-      })
+      });
     `,
     'test("it1")',
     'itHappensToStartWithIt("foo", function() {})',
@@ -34,7 +34,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
         for(let thing in things) {
           expect(number).toBeGreaterThan(4);
         }
-      })
+      });
     `,
     dedent`
       it("returns numbers that are greater than four", function() {
@@ -43,14 +43,14 @@ ruleTester.run('prefer-expect-assertions', rule, {
         for (let i = 0; i < things.length; i++) {
           expect(number).toBeGreaterThan(4);
         }
-      })
+      });
     `,
     {
       code: dedent`
         it("it1", async () => {
           expect.assertions(1);
           expect(someValue).toBe(true)
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
     },
@@ -58,7 +58,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
       code: dedent`
         it("it1", function() {
           expect(someValue).toBe(true)
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
     },
@@ -74,7 +74,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
           for(let thing in things) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
     },
@@ -84,7 +84,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
           for(let thing in things) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
     },
@@ -135,7 +135,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
         it("it1", function() {
           someFunctionToDo();
           someFunctionToDo2();
-        })
+        });
       `,
       errors: [
         {
@@ -149,7 +149,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
                 it("it1", function() {
                   expect.hasAssertions();someFunctionToDo();
                   someFunctionToDo2();
-                })
+                });
               `,
             },
             {
@@ -158,7 +158,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
                 it("it1", function() {
                   expect.assertions();someFunctionToDo();
                   someFunctionToDo2();
-                })
+                });
               `,
             },
           ],
@@ -263,7 +263,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
             someFunctionToDo();
             someFunctionToDo2();
           });
-        })
+        });
       `,
       errors: [
         {
@@ -276,7 +276,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
               output: dedent`
                 it("it1", function() {
                   expect.hasAssertions();
-                })
+                });
               `,
             },
           ],
@@ -287,7 +287,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
       code: dedent`
         it("it1", async function() {
           expect(someValue).toBe(true);
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
       errors: [
@@ -304,7 +304,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
           for(let thing in things) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
       errors: [
@@ -321,7 +321,7 @@ ruleTester.run('prefer-expect-assertions', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
       errors: [
@@ -338,13 +338,13 @@ ruleTester.run('prefer-expect-assertions', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
 
         it("returns numbers that are greater than five", () => {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(5);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithAsyncKeyword: true }],
       errors: [
@@ -446,7 +446,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (let i = 0; i < numbers.length; i++) {
             expect(numbers[i]).toBeGreaterThan(7);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],
       errors: [
@@ -461,7 +461,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
       code: dedent`
         it('has the number two', () => {
           expect(number).toBe(2);
-        })
+        });
 
         it('only returns numbers that are less than twenty', () => {
           for (const number of getNumbers()) {
@@ -486,7 +486,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],
       errors: [
@@ -501,17 +501,17 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
       code: dedent`
         it("is a number that is greater than four", () => {
           expect(number).toBeGreaterThan(4);
-        })
+        });
 
         it("returns numbers that are greater than four", () => {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
 
         it("returns numbers that are greater than five", () => {
           expect(number).toBeGreaterThan(5);
-        })
+        });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],
       errors: [
@@ -648,13 +648,13 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
 
         it("it1", () => {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],
       errors: [
@@ -673,13 +673,13 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
 
         it("it1", () => {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],
       errors: [
@@ -696,7 +696,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
 
         it("it1", () => {
           expect.hasAssertions();
@@ -704,7 +704,7 @@ ruleTester.run('prefer-expect-assertions (loops)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(4);
           }
-        })
+        });
       `,
       options: [{ onlyFunctionsWithExpectInLoop: true }],
       errors: [
@@ -728,7 +728,7 @@ ruleTester.run('prefer-expect-assertions (mixed)', rule, {
           for (const number of await getNumbers()) {
             expect(number).toBeGreaterThan(0);
           }
-        })
+        });
       `,
       options: [
         {
@@ -745,7 +745,7 @@ ruleTester.run('prefer-expect-assertions (mixed)', rule, {
           for (const number of await getNumbers()) {
             expect(number).toBeGreaterThan(0);
           }
-        })
+        });
       `,
       options: [
         {
@@ -830,7 +830,7 @@ ruleTester.run('prefer-expect-assertions (mixed)', rule, {
           for (const number of getNumbers()) {
             expect(number).toBeGreaterThan(0);
           }
-        })
+        });
       `,
       options: [
         {

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -98,7 +98,12 @@ export default createRule<[RuleOptions], MessageIds>({
       },
     ],
   },
-  defaultOptions: [{ onlyFunctionsWithAsyncKeyword: false }],
+  defaultOptions: [
+    {
+      onlyFunctionsWithAsyncKeyword: false,
+      onlyFunctionsWithExpectInLoop: false,
+    },
+  ],
   create(context, [options]) {
     let expressionDepth = 0;
     let hasExpectInLoop = false;

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -105,7 +105,6 @@ export default createRule<[RuleOptions], MessageIds>({
     },
   ],
   create(context, [options]) {
-    let expressionDepth = 0;
     let hasExpectInLoop = false;
     let inTestCaseCall = false;
     let inForLoop = false;
@@ -133,16 +132,10 @@ export default createRule<[RuleOptions], MessageIds>({
       return false;
     };
 
-    const enterExpression = () => inTestCaseCall && expressionDepth++;
-    const exitExpression = () => inTestCaseCall && expressionDepth--;
     const enterForLoop = () => (inForLoop = true);
     const exitForLoop = () => (inForLoop = false);
 
     return {
-      FunctionExpression: enterExpression,
-      'FunctionExpression:exit': exitExpression,
-      ArrowFunctionExpression: enterExpression,
-      'ArrowFunctionExpression:exit': exitExpression,
       ForStatement: enterForLoop,
       'ForStatement:exit': exitForLoop,
       ForInStatement: enterForLoop,
@@ -156,7 +149,7 @@ export default createRule<[RuleOptions], MessageIds>({
           return;
         }
 
-        if (isExpectCall(node) && expressionDepth === 1 && inForLoop) {
+        if (isExpectCall(node) && inTestCaseCall && inForLoop) {
           hasExpectInLoop = true;
         }
       },


### PR DESCRIPTION
This only checks for native loops - while we could try and check for calls to methods with names like `forEach`, I realised it actually makes sense to just have a whole third option for if `expect` is in a callback since they represent the same sort of situation as with promises and would cover `forEach`, `reduce`, `map`, etc without as many edge-cases or false negatives.

I'll do a follow-up PR for that option.

Resolves #540