### PR TITLE
perf(utils): reduce complexity of getTestCallExpressionsFromDeclaredV…

### DIFF
--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -660,20 +660,22 @@ export const getTestCallExpressionsFromDeclaredVariables = (
 ): Array<JestFunctionCallExpression<TestCaseName>> => {
   return declaredVariables.reduce<
     Array<JestFunctionCallExpression<TestCaseName>>
-  >(
-    (acc, { references }) =>
-      acc.concat(
-        references
-          .map(({ identifier }) => identifier.parent)
-          .filter(
-            (node): node is JestFunctionCallExpression<TestCaseName> =>
-              !!node &&
-              node.type === AST_NODE_TYPES.CallExpression &&
-              isTestCaseCall(node),
-          ),
-      ),
-    [],
-  );
+  >((acc, { references }) => {
+    references.forEach(({ identifier }) => {
+      const node =
+        identifier.parent as JestFunctionCallExpression<TestCaseName>;
+
+      if (
+        !!node &&
+        node.type === AST_NODE_TYPES.CallExpression &&
+        isTestCaseCall(node)
+      ) {
+        acc.push(node);
+      }
+    });
+
+    return acc;
+  }, []);
 };
 
 const isTestCaseName = (node: TSESTree.LeftHandSideExpression) =>


### PR DESCRIPTION
I refactored `getTestCallExpressionsFromDeclaredVariables` to avoid performance impact.

- `concat` creates new array on each iteration(It means squad complexity). `acc.push()` more preferable, because it doesn't create new collection.
- Avoided creating an intermediate collection with chain `map`+`filter`