### PR TITLE
fix: migrate to non-experimental ts-eslint utils

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -62,18 +62,13 @@ jobs:
   test-node:
     name:
       # prettier-ignore
-      Test on Node.js v${{ matrix.node-version }}, eslint v${{ matrix.eslint-version }} and ts-eslint/plugin v${{ matrix.ts-eslint-plugin-version }}
+      Test on Node.js v${{ matrix.node-version }}, eslint v${{ matrix.eslint-version }}
     needs: prepare-yarn-cache
     strategy:
       fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x]
         eslint-version: [6, 7, 8]
-        ts-eslint-plugin-version: [4, 5]
-        exclude:
-          # ts-eslint/plugin@4 doesn't support eslint@8
-          - eslint-version: 8
-            ts-eslint-plugin-version: 4
     runs-on: ubuntu-latest
 
     steps:
@@ -85,10 +80,10 @@ jobs:
           cache: yarn
       - name:
           # prettier-ignore
-          install with eslint v${{ matrix.eslint-version }} and ts-eslint/plugin v${{ matrix.ts-eslint-plugin-version }}
+          install with eslint v${{ matrix.eslint-version }}
         run: |
           yarn
-          yarn add --dev eslint@${{ matrix.eslint-version }} @typescript-eslint/eslint-plugin@${{ matrix.ts-eslint-plugin-version }} @typescript-eslint/parser@${{ matrix.ts-eslint-plugin-version }}
+          yarn add --dev eslint@${{ matrix.eslint-version }}
       - name: run tests
         run: yarn test --coverage
         env:

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "typescript": "^4.4.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.0.0"
+    "@typescript-eslint/utils": "^5.10.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import globals from './globals.json';
 import * as snapshotProcessor from './processors/snapshot-processor';
 
@@ -9,7 +9,7 @@ type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
 };
 
 // v5 of `@typescript-eslint/experimental-utils` removed this
-declare module '@typescript-eslint/experimental-utils/dist/ts-eslint/Rule' {
+declare module '@typescript-eslint/utils/dist/ts-eslint/Rule' {
   export interface RuleMetaDataDocs {
     category: 'Best Practices' | 'Possible Errors';
   }

--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../consistent-test-it';
 import { TestCaseName } from '../utils';

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../expect-expect';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/max-nested-describe.test.ts
+++ b/src/rules/__tests__/max-nested-describe.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../max-nested-describe';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-alias-methods.test.ts
+++ b/src/rules/__tests__/no-alias-methods.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-alias-methods';
 
 const ruleTester = new TSESLint.RuleTester();

--- a/src/rules/__tests__/no-commented-out-tests.test.ts
+++ b/src/rules/__tests__/no-commented-out-tests.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-commented-out-tests';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-conditional-expect.test.ts
+++ b/src/rules/__tests__/no-conditional-expect.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-conditional-expect';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import { JestVersion, detectJestVersion } from '../detectJestVersion';
 import rule from '../no-deprecated-functions';
 

--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-disabled-tests';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-done-callback.test.ts
+++ b/src/rules/__tests__/no-done-callback.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-done-callback';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-duplicate-hooks.test.ts
+++ b/src/rules/__tests__/no-duplicate-hooks.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-duplicate-hooks';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-export';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-focused-tests';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/no-hooks.test.ts
+++ b/src/rules/__tests__/no-hooks.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-hooks';
 import { HookName } from '../utils';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-identical-title';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-if.test.ts
+++ b/src/rules/__tests__/no-if.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-if';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-interpolation-in-snapshots.test.ts
+++ b/src/rules/__tests__/no-interpolation-in-snapshots.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-interpolation-in-snapshots';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/no-jasmine-globals.test.ts
+++ b/src/rules/__tests__/no-jasmine-globals.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-jasmine-globals';
 
 const ruleTester = new TSESLint.RuleTester();

--- a/src/rules/__tests__/no-jest-import.test.ts
+++ b/src/rules/__tests__/no-jest-import.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-jest-import';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-large-snapshots';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-mocks-import.test.ts
+++ b/src/rules/__tests__/no-mocks-import.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-mocks-import';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/no-restricted-matchers.test.ts
+++ b/src/rules/__tests__/no-restricted-matchers.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-restricted-matchers';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-standalone-expect';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/no-test-prefixes.test.ts
+++ b/src/rules/__tests__/no-test-prefixes.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../no-test-prefixes';
 
 const ruleTester = new TSESLint.RuleTester();

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-test-return-statement';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/prefer-called-with.test.ts
+++ b/src/rules/__tests__/prefer-called-with.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-called-with';
 
 const ruleTester = new TSESLint.RuleTester();

--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-comparison-matcher';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/prefer-equality-matcher.test.ts
+++ b/src/rules/__tests__/prefer-equality-matcher.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-equality-matcher';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../prefer-expect-assertions';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/prefer-expect-resolves.test.ts
+++ b/src/rules/__tests__/prefer-expect-resolves.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../prefer-expect-resolves';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../prefer-hooks-on-top';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/prefer-lowercase-title.test.ts
+++ b/src/rules/__tests__/prefer-lowercase-title.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../prefer-lowercase-title';
 import { DescribeAlias, TestCaseName } from '../utils';

--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-spy-on';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/prefer-strict-equal.test.ts
+++ b/src/rules/__tests__/prefer-strict-equal.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-strict-equal';
 
 const ruleTester = new TSESLint.RuleTester();

--- a/src/rules/__tests__/prefer-to-be.test.ts
+++ b/src/rules/__tests__/prefer-to-be.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-to-be';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-to-contain';
 
 const ruleTester = new TSESLint.RuleTester();

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-to-have-length';
 import { espreeParser } from './test-utils';
 

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../prefer-todo';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/require-hook.test.ts
+++ b/src/rules/__tests__/require-hook.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../require-hook';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/require-to-throw-message.test.ts
+++ b/src/rules/__tests__/require-to-throw-message.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../require-to-throw-message';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/require-top-level-describe.test.ts
+++ b/src/rules/__tests__/require-top-level-describe.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../require-top-level-describe';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { ESLintUtils, TSESLint } from '@typescript-eslint/experimental-utils';
+import { ESLintUtils, TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import type { MessageIds, Options } from '../unbound-method';
 

--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import {
   createRule,
   getNodeName,

--- a/src/rules/__tests__/valid-describe-callback.test.ts
+++ b/src/rules/__tests__/valid-describe-callback.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../valid-describe-callback';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../valid-expect-in-promise';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../valid-expect';
 import { espreeParser } from './test-utils';

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../valid-title';
 import { espreeParser } from './test-utils';

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   TestCaseName,
   createRule,

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -3,10 +3,7 @@
  * MIT license, Remco Haszing.
  */
 
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   createRule,
   getNodeName,

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { createRule, isDescribeCall } from './utils';
 
 export default createRule({

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 import { createRule } from './utils';
 
 function hasTests(node: TSESTree.Comment) {

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   KnownCallExpression,
   createRule,

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { JestVersion, detectJestVersion } from './detectJestVersion';
 import { createRule, getNodeName } from './utils';
 

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   createRule,
   getNodeName,

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { createRule, isTestCaseCall } from './utils';
 
 export default createRule({

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   AccessorNode,
   JestFunctionCallExpression,

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   TestCaseName,
   createRule,

--- a/src/rules/no-interpolation-in-snapshots.ts
+++ b/src/rules/no-interpolation-in-snapshots.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import { createRule, isExpectCall, parseExpectCall } from './utils';
 
 export default createRule({

--- a/src/rules/no-jasmine-globals.ts
+++ b/src/rules/no-jasmine-globals.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   createRule,
   getNodeName,

--- a/src/rules/no-jest-import.ts
+++ b/src/rules/no-jest-import.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 import { createRule } from './utils';
 
 export default createRule({

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -1,9 +1,5 @@
 import { isAbsolute } from 'path';
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   createRule,
   getAccessorValue,

--- a/src/rules/no-mocks-import.ts
+++ b/src/rules/no-mocks-import.ts
@@ -1,5 +1,5 @@
 import { posix } from 'path';
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 import { createRule, getStringValue, isStringNode } from './utils';
 
 const mocksDirName = '__mocks__';

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   DescribeAlias,
   createRule,

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   createRule,
   getNodeName,

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   createRule,
   getTestCallExpressionsFromDeclaredVariables,

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   MaybeTypeCast,
   ParsedEqualityMatcherCall,

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   MaybeTypeCast,
   ModifierName,

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   KnownCallExpression,
   createRule,

--- a/src/rules/prefer-expect-resolves.ts
+++ b/src/rules/prefer-expect-resolves.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { createRule, isExpectCall } from './utils';
 
 export default createRule({

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -1,4 +1,4 @@
-import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   CallExpressionWithSingleArgument,
   DescribeAlias,

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { createRule, getNodeName } from './utils';
 
 const findNodeObject = (

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   EqualityMatcher,
   MaybeTypeCast,

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   CallExpressionWithSingleArgument,
   KnownCallExpression,

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   createRule,
   isExpectCall,

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   JestFunctionCallExpression,
   TestCaseName,

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   createRule,
   getNodeName,

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESTree } from '@typescript-eslint/utils';
 import { createRule, isDescribeCall, isHook, isTestCaseCall } from './utils';
 
 const messages = {

--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -1,4 +1,4 @@
-import { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils';
+import { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { createRule, isExpectCall, parseExpectCall } from './utils';
 
 const toThrowMatchers = [

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -4,7 +4,7 @@ import {
   ESLintUtils,
   TSESLint,
   TSESTree,
-} from '@typescript-eslint/experimental-utils';
+} from '@typescript-eslint/utils';
 import { version } from '../../package.json';
 
 const REPO_URL = 'https://github.com/jest-community/eslint-plugin-jest';

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import { createRule, getNodeName, isDescribeCall, isFunction } from './utils';
 
 const paramsLocation = (

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -1,7 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   KnownCallExpression,
   ModifierName,

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -3,10 +3,7 @@
  * MIT license, Tom Vincent.
  */
 
-import {
-  AST_NODE_TYPES,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
 import {
   ModifierName,
   createRule,

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -1,8 +1,4 @@
-import {
-  AST_NODE_TYPES,
-  JSONSchema,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { AST_NODE_TYPES, JSONSchema, TSESTree } from '@typescript-eslint/utils';
 import {
   DescribeAlias,
   StringNode,

--- a/tools/regenerate-docs.ts
+++ b/tools/regenerate-docs.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import prettier, { Options } from 'prettier';
 import { prettier as prettierRC } from '../package.json';
 import config from '../src/index';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,7 +4454,7 @@ __metadata:
     ts-node: ^10.2.1
     typescript: ^4.4.0
   peerDependencies:
-    "@typescript-eslint/eslint-plugin": ^4.0.0 || ^5.0.0
+    "@typescript-eslint/eslint-plugin": ^5.0.0
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,12 +2550,12 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^5.0.0":
-  version: 5.9.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.9.1"
+  version: 5.10.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.10.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 5.9.1
-    "@typescript-eslint/scope-manager": 5.9.1
-    "@typescript-eslint/type-utils": 5.9.1
+    "@typescript-eslint/scope-manager": 5.10.0
+    "@typescript-eslint/type-utils": 5.10.0
+    "@typescript-eslint/utils": 5.10.0
     debug: ^4.3.2
     functional-red-black-tree: ^1.0.1
     ignore: ^5.1.8
@@ -2568,58 +2568,53 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 75119682f9fa14afc093983be0f477fc21c85c700a47889e3fc5b6d4efe98750b99b0667a8ff371d02153814658ae552d2032e1d0c590c983fe6a74f282d51fb
+  checksum: 675b79c519e5287a184720317d309c55e308c19eb52f1f062e3851168a9b6e4768363bd31bdcbf897c080f1c21cb39736cd522408620818dd9ce483d1573bf89
   languageName: node
   linkType: hard
 
 "@typescript-eslint/experimental-utils@npm:^5.0.0":
-  version: 5.9.1
-  resolution: "@typescript-eslint/experimental-utils@npm:5.9.1"
+  version: 5.10.0
+  resolution: "@typescript-eslint/experimental-utils@npm:5.10.0"
   dependencies:
-    "@types/json-schema": ^7.0.9
-    "@typescript-eslint/scope-manager": 5.9.1
-    "@typescript-eslint/types": 5.9.1
-    "@typescript-eslint/typescript-estree": 5.9.1
-    eslint-scope: ^5.1.1
-    eslint-utils: ^3.0.0
+    "@typescript-eslint/utils": 5.10.0
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: ff8d38fc572aa4395116df82a596a8632b25bbd490c9f6337a58b95cfd878def1f8e1b431ebbb58bfa3e2b746ac63f59bf78d8b424c3eb3cadf4b3128b758d4c
+  checksum: 10937fcbd0a693c076f054ca64e3e483deb6d917787f4e323c34457878b95a730e20ae34a5fdcd84d8954d9fa2c3cd0b1bf91f3e0db418783f08b6e33b4d69ad
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^5.0.0":
-  version: 5.9.1
-  resolution: "@typescript-eslint/parser@npm:5.9.1"
+  version: 5.10.0
+  resolution: "@typescript-eslint/parser@npm:5.10.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.9.1
-    "@typescript-eslint/types": 5.9.1
-    "@typescript-eslint/typescript-estree": 5.9.1
+    "@typescript-eslint/scope-manager": 5.10.0
+    "@typescript-eslint/types": 5.10.0
+    "@typescript-eslint/typescript-estree": 5.10.0
     debug: ^4.3.2
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 138b31115ccae574d25525389537da71e9bd628e367c136da77f8cf3b4a11ebea138f9851dc6d7df3da163db791aeb8a1ef6d2de557a4248ca8e3ecea6b379f1
+  checksum: 127aaa807659bbd4b2b274263d1ef821b8d0746f0a18ae55466718d070ba43c94e5575849954271f0d6582d2114c96a0ff6645189015a6522c4d8682d4d20a1b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.9.1":
-  version: 5.9.1
-  resolution: "@typescript-eslint/scope-manager@npm:5.9.1"
+"@typescript-eslint/scope-manager@npm:5.10.0":
+  version: 5.10.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.10.0"
   dependencies:
-    "@typescript-eslint/types": 5.9.1
-    "@typescript-eslint/visitor-keys": 5.9.1
-  checksum: 2b532d355885f8b4691fc4726e3d1abe16325c660735eb9d0dc47739ce9259a30ab3f8bfaec1abacf9713d80efdb6a5da6db7e9f96188c61dfe076689b9a4459
+    "@typescript-eslint/types": 5.10.0
+    "@typescript-eslint/visitor-keys": 5.10.0
+  checksum: 934cbb4a03d383537fda05b926eeba0597d63ef1c65328d55abe20a060b6559ba2017825e167dc2093a23d675c37aaa2056dec1747b17f0fbca419fba68f8d0f
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.9.1":
-  version: 5.9.1
-  resolution: "@typescript-eslint/type-utils@npm:5.9.1"
+"@typescript-eslint/type-utils@npm:5.10.0":
+  version: 5.10.0
+  resolution: "@typescript-eslint/type-utils@npm:5.10.0"
   dependencies:
-    "@typescript-eslint/experimental-utils": 5.9.1
+    "@typescript-eslint/utils": 5.10.0
     debug: ^4.3.2
     tsutils: ^3.21.0
   peerDependencies:
@@ -2627,23 +2622,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 23df02c241334a7d53cbb1fea911d381db009fc06b38c16b7f48d1789f9ab76a8007f34d03664d15683c87668ba8d0300c4579413b4aeaa5863ee73a4c7f797c
+  checksum: aa6bf7fcac7aa956ccf938b8d93d1ecd8956ea1f5690046967fe69f0bd2592cd8e29a992f5a252990b8e13c1e09c3f9efb6375d0551f4b4c08c69cd662be2e73
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.9.1":
-  version: 5.9.1
-  resolution: "@typescript-eslint/types@npm:5.9.1"
-  checksum: 99b90da0cad9e8db75c3870adf6457291a93e7bedcdcebcc31ffb0c71db6f82c22845fd1c890684b542c7764b41eb9cbfb6e8c55feaf7692669f334f786b3f14
+"@typescript-eslint/types@npm:5.10.0":
+  version: 5.10.0
+  resolution: "@typescript-eslint/types@npm:5.10.0"
+  checksum: 269988cbb1772616ade3af5f70a3c4d7871c90fa04fbc4ed8b1148ec0a6853f2d51609fe51aa797486bfe9b704a4c4a3410e6225470db18850d3469a7db5a63b
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.9.1":
-  version: 5.9.1
-  resolution: "@typescript-eslint/typescript-estree@npm:5.9.1"
+"@typescript-eslint/typescript-estree@npm:5.10.0":
+  version: 5.10.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.10.0"
   dependencies:
-    "@typescript-eslint/types": 5.9.1
-    "@typescript-eslint/visitor-keys": 5.9.1
+    "@typescript-eslint/types": 5.10.0
+    "@typescript-eslint/visitor-keys": 5.10.0
     debug: ^4.3.2
     globby: ^11.0.4
     is-glob: ^4.0.3
@@ -2652,17 +2647,33 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: a13dabebf8223ddd2f6e8114e6edbb062eb094002ee16d269d901a8c64b9fde6105bf1a8ad491d0abdb770be0641da0022d4bec64e786e4f114c688723ad39ba
+  checksum: 1097fd5a96857a285020a2c5ee7abb7e5984771ac44b61b5d500724dc3ff88030e4e5340fcd872779b1307fbb224240d6543babb901559675efcab20a2dc70dc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.9.1":
-  version: 5.9.1
-  resolution: "@typescript-eslint/visitor-keys@npm:5.9.1"
+"@typescript-eslint/utils@npm:5.10.0, @typescript-eslint/utils@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "@typescript-eslint/utils@npm:5.10.0"
   dependencies:
-    "@typescript-eslint/types": 5.9.1
+    "@types/json-schema": ^7.0.9
+    "@typescript-eslint/scope-manager": 5.10.0
+    "@typescript-eslint/types": 5.10.0
+    "@typescript-eslint/typescript-estree": 5.10.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 9c53b0e47b922210c5dc0c7ac045206062ad4f21f9bf03ef091894d3fcfe9fde7e72c70a97b5073a54a42b7628943dd8dcef00bd3285ebd63039909888dea84a
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.10.0":
+  version: 5.10.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.10.0"
+  dependencies:
+    "@typescript-eslint/types": 5.10.0
     eslint-visitor-keys: ^3.0.0
-  checksum: 9eb6902161fc9120907d514ed9f4c0237349904e17436571a8ab1820b0426c47de1b8d65eb9804a6544f80b714ffec89f9ed8bf386cb9881f909ef58c145752d
+  checksum: 9b99c6be709c59be6a1705f0244aad732a5e523af8b8eb87e5dd6a3d27a027329bf2617aa6f15a36f79bce4215ac09277e144737a0d8d674e93b073b36fd963e
   languageName: node
   linkType: hard
 
@@ -4415,8 +4426,8 @@ __metadata:
     "@types/node": ^16.0.0
     "@types/prettier": ^2.0.0
     "@typescript-eslint/eslint-plugin": ^5.0.0
-    "@typescript-eslint/experimental-utils": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
+    "@typescript-eslint/utils": ^5.10.0
     babel-jest: ^27.0.0
     babel-plugin-replace-ts-export-assignment: ^0.0.2
     dedent: ^0.7.0


### PR DESCRIPTION
Newest version breaks us due to some interface merging we do, so upgrading seems sensible

BREAKING CHANGE: Drop support for `@typescript-eslint/eslint-plugin@4`