### PR TITLE
docs(valid-expect): call `Promise.all` in example correctly

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -136,9 +136,9 @@ test('all the things', async () => {
   await Promise.resolve(
     expect(Promise.resolve('hello')).resolves.toEqual('hello'),
   );
-  await Promise.all(
+  await Promise.all([
     expect(Promise.resolve('hello')).resolves.toEqual('hello'),
     expect(Promise.resolve('hi')).resolves.toEqual('hi'),
-  );
+  ]);
 });
 ```


### PR DESCRIPTION
- corrected pattern in `valid-expect` doc