### PR TITLE
docs: grammar and spelling fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ adjust your eslint config as outlined
 
 Note that unlike the type-checking rules in `@typescript-eslint/eslint-plugin`,
 the rules here will fallback to doing nothing if type information is not
-available, meaning its safe to include them in shared configs that could be used
-on JavaScript and TypeScript projects.
+available, meaning it's safe to include them in shared configs that could be
+used on JavaScript and TypeScript projects.
 
 Also note that `unbound-method` depends on `@typescript-eslint/eslint-plugin`,
 as it extends the original `unbound-method` rule from that plugin.

--- a/docs/rules/no-conditional-expect.md
+++ b/docs/rules/no-conditional-expect.md
@@ -107,7 +107,7 @@ While you can use `expect.assertions` & `expect.hasAssertions` for these
 situations, they only work with `expect`.
 
 A better way to handle this situation is to introduce a wrapper to handle the
-catching, and otherwise returns a specific "no error thrown" error if nothing is
+catching, and otherwise return a specific "no error thrown" error if nothing is
 thrown by the wrapped function:
 
 ```typescript

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -37,8 +37,7 @@ Originally, the `requireActual` & `requireMock` the `requireActual`&
 
 These functions were later moved onto the `jest` object in order to be easier
 for type checkers to handle, and their use via `require` deprecated. Finally,
-the release of Jest 26 saw them removed from the `require` function all
-together.
+the release of Jest 26 saw them removed from the `require` function altogether.
 
 ### `jest.runTimersToTime`
 

--- a/docs/rules/no-identical-title.md
+++ b/docs/rules/no-identical-title.md
@@ -7,7 +7,7 @@ fix.
 
 ## Rule Details
 
-This rule looks at the title of every test and test suites. It will report when
+This rule looks at the title of every test and test suite. It will report when
 two test suites or two test cases at the same level of a test suite have the
 same title.
 

--- a/docs/rules/no-jasmine-globals.md
+++ b/docs/rules/no-jasmine-globals.md
@@ -9,8 +9,8 @@ API.
 
 ### Rule details
 
-This rule reports on any usage of Jasmine globals which is not ported to Jest,
-and suggests alternative from Jest's own API.
+This rule reports on any usage of Jasmine globals, which is not ported to Jest,
+and suggests alternatives from Jest's own API.
 
 ### Default configuration
 

--- a/docs/rules/no-jest-import.md
+++ b/docs/rules/no-jest-import.md
@@ -17,4 +17,4 @@ first place.
 
 ## Further Reading
 
-\*[The Jest Object](https://facebook.github.io/jest/docs/en/jest-object.html)
+- [The Jest Object](https://facebook.github.io/jest/docs/en/jest-object.html)

--- a/docs/rules/no-large-snapshots.md
+++ b/docs/rules/no-large-snapshots.md
@@ -118,8 +118,8 @@ External). Use `inlineMaxSize` for
 [Inline Snapshots](https://jestjs.io/docs/en/snapshot-testing#inline-snapshots)
 size and `maxSize` for
 [External Snapshots](https://jestjs.io/docs/en/snapshot-testing#snapshot-testing-with-jest).
-If only `maxSize` is provided on options, the value of `maxSize` will be used to
-both snapshot types (Inline and External).
+If only `maxSize` is provided on options, the value of `maxSize` will be used
+for both snapshot types (Inline and External).
 
 Since `eslint-disable` comments are not preserved by Jest when updating
 snapshots, you can use the `allowedSnapshots` option to have specific snapshots

--- a/docs/rules/no-standalone-expect.md
+++ b/docs/rules/no-standalone-expect.md
@@ -61,7 +61,7 @@ describe('a test', () => {
 ```
 
 \*Note that this rule will not trigger if the helper function is never used even
-thought the `expect` will not execute. Rely on a rule like no-unused-vars for
+though the `expect` will not execute. Rely on a rule like no-unused-vars for
 this case.
 
 ### Options

--- a/docs/rules/prefer-comparison-matcher.md
+++ b/docs/rules/prefer-comparison-matcher.md
@@ -1,6 +1,6 @@
 # Suggest using the built-in comparison matchers (`prefer-comparison-matcher`)
 
-Jest has a number of built-in matchers for comparing numbers which allow for
+Jest has a number of built-in matchers for comparing numbers, which allow for
 more readable tests and error messages if an expectation fails.
 
 ## Rule details

--- a/docs/rules/prefer-equality-matcher.md
+++ b/docs/rules/prefer-equality-matcher.md
@@ -1,6 +1,6 @@
 # Suggest using the built-in equality matchers (`prefer-equality-matcher`)
 
-Jest has built-in matchers for expecting equality which allow for more readable
+Jest has built-in matchers for expecting equality, which allow for more readable
 tests and error messages if an expectation fails.
 
 ## Rule details

--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -1,7 +1,7 @@
 # Suggest having hooks before any test cases (`prefer-hooks-on-top`)
 
-While hooks can be setup anywhere in a test file, they are always called in a
-specific order which means it can be confusing if they're intermixed with test
+While hooks can be setup anywhere in a test file they are always called in a
+specific order, which means it can be confusing if they're intermixed with test
 cases.
 
 This rule helps to ensure that hooks are always defined before test cases.

--- a/docs/rules/prefer-hooks-on-top.md
+++ b/docs/rules/prefer-hooks-on-top.md
@@ -1,6 +1,6 @@
 # Suggest having hooks before any test cases (`prefer-hooks-on-top`)
 
-While hooks can be setup anywhere in a test file they are always called in a
+While hooks can be setup anywhere in a test file, they are always called in a
 specific order, which means it can be confusing if they're intermixed with test
 cases.
 

--- a/docs/rules/prefer-lowercase-title.md
+++ b/docs/rules/prefer-lowercase-title.md
@@ -73,8 +73,8 @@ it('Uppercase description');
 
 ### `allowedPrefixes`
 
-This array option allows specifying prefixes which contain capitals that titles
-can start with. This can be useful when writing tests for api endpoints, where
+This array option allows specifying prefixes, which contain capitals that titles
+can start with. This can be useful when writing tests for API endpoints, where
 you'd like to prefix with the HTTP method.
 
 By default, nothing is allowed (the equivalent of `{ "allowedPrefixes": [] }`).


### PR DESCRIPTION
Only contains spelling and grammar fixes, and not opinion-based conciseness or sentence structure changes.