### PR TITLE
fix: use correct scope for checking references

### DIFF
--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -1,4 +1,5 @@
 import { TSESLint } from '@typescript-eslint/utils';
+import dedent from 'dedent';
 import rule from '../no-focused-tests';
 import { espreeParser } from './test-utils';
 
@@ -312,6 +313,95 @@ ruleTester.run('no-focused-tests', rule, {
             {
               messageId: 'suggestRemoveFocus',
               output: 'it.each`table`()',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('no-focused-tests (with imports)', rule, {
+  valid: [
+    {
+      code: dedent`
+        import { fdescribe as describeJustThis } from '@jest/globals';
+
+        describeJustThis()
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
+  ],
+
+  invalid: [
+    {
+      code: dedent`
+        const { describe } = require('@jest/globals');
+
+        describe.only()
+      `,
+      errors: [
+        {
+          messageId: 'focusedTest',
+          column: 10,
+          line: 3,
+          suggestions: [
+            {
+              messageId: 'suggestRemoveFocus',
+              output: dedent`
+                const { describe } = require('@jest/globals');
+
+                describe()
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { describe as describeThis } from '@jest/globals';
+
+        describeThis.only()
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          messageId: 'focusedTest',
+          column: 14,
+          line: 3,
+          suggestions: [
+            {
+              messageId: 'suggestRemoveFocus',
+              output: dedent`
+                import { describe as describeThis } from '@jest/globals';
+
+                describeThis()
+              `,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const { fdescribe } = require('@jest/globals');
+
+        fdescribe()
+      `,
+      errors: [
+        {
+          messageId: 'focusedTest',
+          column: 1,
+          line: 3,
+          suggestions: [
+            {
+              messageId: 'suggestRemoveFocus',
+              output: dedent`
+                const { fdescribe } = require('@jest/globals');
+
+                describe()
+              `,
             },
           ],
         },

--- a/src/rules/__tests__/prefer-snapshot-hint.test.ts
+++ b/src/rules/__tests__/prefer-snapshot-hint.test.ts
@@ -341,6 +341,21 @@ ruleTester.run('prefer-snapshot-hint (multi)', rule, {
     },
     {
       code: dedent`
+        import { it as itIs } from '@jest/globals';
+
+        it('is true', () => {
+          expect(1).toMatchSnapshot();
+        });
+
+        itIs('false', () => {
+          expect(1).toMatchSnapshot();
+        });
+      `,
+      options: ['multi'],
+      parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: dedent`
         const myReusableTestBody = (value, snapshotHint) => {
           const innerFn = anotherValue => {
             expect(anotherValue).toMatchSnapshot();
@@ -728,6 +743,33 @@ ruleTester.run('prefer-snapshot-hint (multi)', rule, {
           messageId: 'missingHint',
           column: 17,
           line: 8,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { describe as context, it as itIs } from '@jest/globals';
+
+        describe('my tests', () => {
+          it('is true', () => {
+            expect(1).toMatchSnapshot();
+          });
+
+          context('more tests', () => {
+            itIs('false', () => {
+              expect(2).toMatchSnapshot();
+              expect(2).toMatchSnapshot('hello world');
+            });
+          });
+        });
+      `,
+      options: ['multi'],
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          messageId: 'missingHint',
+          column: 17,
+          line: 10,
         },
       ],
     },

--- a/src/rules/__tests__/valid-describe-callback.test.ts
+++ b/src/rules/__tests__/valid-describe-callback.test.ts
@@ -115,6 +115,15 @@ ruleTester.run('valid-describe-callback', rule, {
       errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 18 }],
     },
     {
+      code: dedent`
+        import { fdescribe } from '@jest/globals';
+
+        fdescribe("foo", async function () {})
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [{ messageId: 'noAsyncDescribeCallback', line: 3, column: 18 }],
+    },
+    {
       code: 'describe.only("foo", async function () {})',
       errors: [{ messageId: 'noAsyncDescribeCallback', line: 1, column: 22 }],
     },

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -1389,6 +1389,21 @@ ruleTester.run('valid-expect-in-promise', rule, {
     },
     {
       code: dedent`
+        import { test } from '@jest/globals';
+
+        test('later return', async () => {
+          const x = 1, promise = something().then(value => {
+            expect(value).toBe('red');
+          });
+        });
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        { column: 16, endColumn: 5, messageId: 'expectInFloatingPromise' },
+      ],
+    },
+    {
+      code: dedent`
         it('promise test', () => {
           const somePromise = getThatPromise();
           somePromise.then((data) => {

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -64,7 +64,6 @@ export default createRule<
   },
   defaultOptions: [{ fn: TestCaseName.test, withinDescribe: TestCaseName.it }],
   create(context) {
-    const scope = context.getScope();
     const configObj = context.options[0] || {};
     const testKeyword = configObj.fn || TestCaseName.test;
     const testKeywordWithinDescribe =
@@ -74,6 +73,7 @@ export default createRule<
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
+        const scope = context.getScope();
         const nodeName = getNodeName(node.callee);
 
         if (!nodeName) {
@@ -124,7 +124,7 @@ export default createRule<
         }
       },
       'CallExpression:exit'(node) {
-        if (isDescribeCall(node, scope)) {
+        if (isDescribeCall(node, context.getScope())) {
           describeNestingLevel--;
         }
       },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -82,7 +82,6 @@ export default createRule<
     context,
     [{ assertFunctionNames = ['expect'], additionalTestBlockFunctions = [] }],
   ) {
-    const scope = context.getScope();
     const unchecked: TSESTree.CallExpression[] = [];
 
     function checkCallExpressionUsed(nodes: TSESTree.Node[]) {
@@ -97,7 +96,7 @@ export default createRule<
           const testCallExpressions =
             getTestCallExpressionsFromDeclaredVariables(
               declaredVariables,
-              scope,
+              context.getScope(),
             );
 
           checkCallExpressionUsed(testCallExpressions);
@@ -115,7 +114,7 @@ export default createRule<
         const name = getNodeName(node.callee) ?? '';
 
         if (
-          isTestCaseCall(node, scope) ||
+          isTestCaseCall(node, context.getScope()) ||
           additionalTestBlockFunctions.includes(name)
         ) {
           if (

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -29,7 +29,6 @@ export default createRule({
   },
   defaultOptions: [{ max: 5 }],
   create(context, [{ max }]) {
-    const scope = context.getScope();
     const describeCallbackStack: number[] = [];
 
     function pushDescribeCallback(
@@ -39,7 +38,7 @@ export default createRule({
 
       if (
         parent?.type !== AST_NODE_TYPES.CallExpression ||
-        !isDescribeCall(parent, scope)
+        !isDescribeCall(parent, context.getScope())
       ) {
         return;
       }
@@ -62,7 +61,7 @@ export default createRule({
 
       if (
         parent?.type === AST_NODE_TYPES.CallExpression &&
-        isDescribeCall(parent, scope)
+        isDescribeCall(parent, context.getScope())
       ) {
         describeCallbackStack.pop();
       }

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -30,7 +30,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     let conditionalDepth = 0;
     let inTestCase = false;
     let inPromiseCatch = false;
@@ -43,7 +42,7 @@ export default createRule({
         const declaredVariables = context.getDeclaredVariables(node);
         const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
           declaredVariables,
-          scope,
+          context.getScope(),
         );
 
         if (testCallExpressions.length > 0) {
@@ -51,7 +50,7 @@ export default createRule({
         }
       },
       CallExpression(node: TSESTree.CallExpression) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           inTestCase = true;
         }
 
@@ -74,7 +73,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           inTestCase = false;
         }
 

--- a/src/rules/no-conditional-in-test.ts
+++ b/src/rules/no-conditional-in-test.ts
@@ -17,7 +17,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     let inTestCase = false;
 
     const maybeReportConditional = (node: TSESTree.Node) => {
@@ -31,12 +30,12 @@ export default createRule({
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           inTestCase = true;
         }
       },
       'CallExpression:exit'(node) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           inTestCase = false;
         }
       },

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -49,8 +49,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
         // done is the second argument for it.each, not the first
@@ -66,7 +64,7 @@ export default createRule({
           return;
         }
 
-        const callback = findCallbackArg(node, isJestEach, scope);
+        const callback = findCallbackArg(node, isJestEach, context.getScope());
         const callbackArgIndex = Number(isJestEach);
 
         if (

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -23,11 +23,12 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     const hookContexts = [newHookContext()];
 
     return {
       CallExpression(node) {
+        const scope = context.getScope();
+
         if (isDescribeCall(node, scope)) {
           hookContexts.push(newHookContext());
         }
@@ -46,7 +47,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isDescribeCall(node, scope)) {
+        if (isDescribeCall(node, context.getScope())) {
           hookContexts.pop();
         }
       },

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -17,7 +17,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     const exportNodes: Array<
       | TSESTree.ExportNamedDeclaration
       | TSESTree.ExportDefaultDeclaration
@@ -35,7 +34,7 @@ export default createRule({
       },
 
       CallExpression(node) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           hasTestCase = true;
         }
       },

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -53,10 +53,10 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
+        const scope = context.getScope();
+
         if (!isDescribeCall(node, scope) && !isTestCaseCall(node, scope)) {
           return;
         }

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -30,11 +30,12 @@ export default createRule<
   },
   defaultOptions: [{ allow: [] }],
   create(context, [{ allow = [] }]) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
-        if (isHookCall(node, scope) && !allow.includes(node.callee.name)) {
+        if (
+          isHookCall(node, context.getScope()) &&
+          !allow.includes(node.callee.name)
+        ) {
           context.report({
             node,
             messageId: 'unexpectedHook',

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -36,11 +36,11 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     const contexts = [newDescribeContext()];
 
     return {
       CallExpression(node) {
+        const scope = context.getScope();
         const currentLayer = contexts[contexts.length - 1];
 
         if (isDescribeCall(node, scope)) {
@@ -81,7 +81,7 @@ export default createRule({
         currentLayer.describeTitles.push(title);
       },
       'CallExpression:exit'(node) {
-        if (isDescribeCall(node, scope)) {
+        if (isDescribeCall(node, context.getScope())) {
           contexts.pop();
         }
       },

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -51,7 +51,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     const stack: boolean[] = [];
 
     function validate(
@@ -75,7 +74,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           stack.push(true);
 
           if (getNodeName(node).endsWith('each')) {
@@ -90,7 +89,7 @@ export default createRule({
         const declaredVariables = context.getDeclaredVariables(node);
         const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
           declaredVariables,
-          scope,
+          context.getScope(),
         );
 
         stack.push(testCallExpressions.length > 0);

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -78,7 +78,6 @@ export default createRule<
   },
   defaultOptions: [{ additionalTestBlockFunctions: [] }],
   create(context, [{ additionalTestBlockFunctions = [] }]) {
-    const scope = context.getScope();
     const callStack: BlockType[] = [];
 
     const isCustomTestBlockFunction = (
@@ -87,7 +86,8 @@ export default createRule<
       additionalTestBlockFunctions.includes(getNodeName(node) || '');
 
     const isTestBlock = (node: TSESTree.CallExpression): boolean =>
-      isTestCaseCall(node, scope) || isCustomTestBlockFunction(node);
+      isTestCaseCall(node, context.getScope()) ||
+      isCustomTestBlockFunction(node);
 
     return {
       CallExpression(node) {
@@ -124,7 +124,7 @@ export default createRule<
       },
 
       BlockStatement(statement) {
-        const blockType = getBlockType(statement, scope);
+        const blockType = getBlockType(statement, context.getScope());
 
         if (blockType) {
           callStack.push(blockType);
@@ -132,7 +132,8 @@ export default createRule<
       },
       'BlockStatement:exit'(statement: TSESTree.BlockStatement) {
         if (
-          callStack[callStack.length - 1] === getBlockType(statement, scope)
+          callStack[callStack.length - 1] ===
+          getBlockType(statement, context.getScope())
         ) {
           callStack.pop();
         }

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -23,10 +23,9 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
+        const scope = context.getScope();
         const nodeName = getNodeName(node.callee);
 
         if (

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -36,11 +36,9 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
-        if (!isTestCaseCall(node, scope)) return;
+        if (!isTestCaseCall(node, context.getScope())) return;
         const body = getBody(node.arguments);
         const returnStmt = body.find(
           t => t.type === AST_NODE_TYPES.ReturnStatement,
@@ -54,7 +52,7 @@ export default createRule({
         const declaredVariables = context.getDeclaredVariables(node);
         const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
           declaredVariables,
-          scope,
+          context.getScope(),
         );
 
         if (testCallExpressions.length === 0) return;

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -104,8 +104,6 @@ export default createRule<[RuleOptions], MessageIds>({
     },
   ],
   create(context, [options]) {
-    const scope = context.getScope();
-
     let expressionDepth = 0;
     let hasExpectInCallback = false;
     let hasExpectInLoop = false;
@@ -159,7 +157,7 @@ export default createRule<[RuleOptions], MessageIds>({
       ForOfStatement: enterForLoop,
       'ForOfStatement:exit': exitForLoop,
       CallExpression(node) {
-        if (isTestCaseCall(node, scope)) {
+        if (isTestCaseCall(node, context.getScope())) {
           inTestCaseCall = true;
 
           return;
@@ -176,7 +174,7 @@ export default createRule<[RuleOptions], MessageIds>({
         }
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (!isTestCaseCall(node, scope)) {
+        if (!isTestCaseCall(node, context.getScope())) {
           return;
         }
 

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -16,11 +16,12 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     const hooksContext = [false];
 
     return {
       CallExpression(node) {
+        const scope = context.getScope();
+
         if (!isHookCall(node, scope) && isTestCaseCall(node, scope)) {
           hooksContext[hooksContext.length - 1] = true;
         }

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -115,12 +115,13 @@ export default createRule<
     context,
     [{ ignore = [], allowedPrefixes = [], ignoreTopLevelDescribe }],
   ) {
-    const scope = context.getScope();
     const ignores = populateIgnores(ignore);
     let numberOfDescribeBlocks = 0;
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
+        const scope = context.getScope();
+
         if (isDescribeCall(node, scope)) {
           numberOfDescribeBlocks++;
 
@@ -175,7 +176,7 @@ export default createRule<
         });
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isDescribeCall(node, scope)) {
+        if (isDescribeCall(node, context.getScope())) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/prefer-snapshot-hint.ts
+++ b/src/rules/prefer-snapshot-hint.ts
@@ -61,7 +61,6 @@ export default createRule<[('always' | 'multi')?], keyof typeof messages>({
   },
   defaultOptions: ['multi'],
   create(context, [mode]) {
-    const scope = context.getScope();
     const snapshotMatchers: ParsedExpectMatcher[] = [];
     const depths: number[] = [];
     let expressionDepth = 0;
@@ -108,12 +107,16 @@ export default createRule<[('always' | 'multi')?], keyof typeof messages>({
       ArrowFunctionExpression: enterExpression,
       'ArrowFunctionExpression:exit': exitExpression,
       'CallExpression:exit'(node) {
+        const scope = context.getScope();
+
         if (isDescribeCall(node, scope) || isTestCaseCall(node, scope)) {
           /* istanbul ignore next */
           expressionDepth = depths.pop() ?? 0;
         }
       },
       CallExpression(node) {
+        const scope = context.getScope();
+
         if (isDescribeCall(node, scope) || isTestCaseCall(node, scope)) {
           depths.push(expressionDepth);
           expressionDepth = 0;

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -56,15 +56,13 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
         const [title, callback] = node.arguments;
 
         if (
           !title ||
-          !isTargetedTestCase(node, scope) ||
+          !isTargetedTestCase(node, context.getScope()) ||
           !isStringNode(title)
         ) {
           return;

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -93,12 +93,13 @@ export default createRule<
     },
   ],
   create(context) {
-    const scope = context.getScope();
     const { allowedFunctionCalls } = context.options[0] ?? {};
 
     const checkBlockBody = (body: TSESTree.BlockStatement['body']) => {
       for (const statement of body) {
-        if (shouldBeInHook(statement, scope, allowedFunctionCalls)) {
+        if (
+          shouldBeInHook(statement, context.getScope(), allowedFunctionCalls)
+        ) {
           context.report({
             node: statement,
             messageId: 'useHook',
@@ -112,7 +113,10 @@ export default createRule<
         checkBlockBody(program.body);
       },
       CallExpression(node) {
-        if (!isDescribeCall(node, scope) || node.arguments.length < 2) {
+        if (
+          !isDescribeCall(node, context.getScope()) ||
+          node.arguments.length < 2
+        ) {
           return;
         }
 

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -44,12 +44,13 @@ export default createRule<
   create(context) {
     const { maxNumberOfTopLevelDescribes = Infinity } =
       context.options[0] ?? {};
-    const scope = context.getScope();
     let numberOfTopLevelDescribeBlocks = 0;
     let numberOfDescribeBlocks = 0;
 
     return {
       CallExpression(node) {
+        const scope = context.getScope();
+
         if (isDescribeCall(node, scope)) {
           numberOfDescribeBlocks++;
 
@@ -85,7 +86,7 @@ export default createRule<
         }
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isDescribeCall(node, scope)) {
+        if (isDescribeCall(node, context.getScope())) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -34,11 +34,9 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
-
     return {
       CallExpression(node) {
-        if (!isDescribeCall(node, scope)) {
+        if (!isDescribeCall(node, context.getScope())) {
           return;
         }
 

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -375,7 +375,6 @@ export default createRule({
   },
   defaultOptions: [],
   create(context) {
-    const scope = context.getScope();
     let inTestCaseWithDoneCallback = false;
     // an array of booleans representing each promise chain we enter, with the
     // boolean value representing if we think a given chain contains an expect
@@ -390,7 +389,7 @@ export default createRule({
       CallExpression(node: TSESTree.CallExpression) {
         // there are too many ways that the done argument could be used with
         // promises that contain expect that would make the promise safe for us
-        if (isTestCaseCallWithCallbackArg(node, scope)) {
+        if (isTestCaseCallWithCallbackArg(node, context.getScope())) {
           inTestCaseWithDoneCallback = true;
 
           return;
@@ -415,7 +414,7 @@ export default createRule({
         // make promises containing expects safe in a test for us to be able to
         // accurately check, so we just bail out completely if it's present
         if (inTestCaseWithDoneCallback) {
-          if (isTestCaseCall(node, scope)) {
+          if (isTestCaseCall(node, context.getScope())) {
             inTestCaseWithDoneCallback = false;
           }
 
@@ -442,7 +441,10 @@ export default createRule({
         // or our parent is not directly within the test case, we stop checking
         // because we're most likely in the body of a function being defined
         // within the test, which we can't track
-        if (!parent || !isDirectlyWithinTestCaseCall(parent, scope)) {
+        if (
+          !parent ||
+          !isDirectlyWithinTestCaseCall(parent, context.getScope())
+        ) {
           return;
         }
 

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -171,7 +171,6 @@ export default createRule<[Options], MessageIds>({
       },
     ],
   ) {
-    const scope = context.getScope();
     const disallowedWordsRegexp = new RegExp(
       `\\b(${disallowedWords.join('|')})\\b`,
       'iu',
@@ -182,6 +181,8 @@ export default createRule<[Options], MessageIds>({
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
+        const scope = context.getScope();
+
         if (!isDescribeCall(node, scope) && !isTestCaseCall(node, scope)) {
           return;
         }


### PR DESCRIPTION
Per https://github.com/jest-community/eslint-plugin-jest/pull/1094#issuecomment-1126603712:

Turns out that `context.getScope` is stateful, being based on the same logic that the AST walker follows - effectively it should be through of as an argument like `node`, e.g. `CallExpression(node, scope)`.

I've chucked in some tests for a few rules, but I don't want to over saturate our tests with the same extensive subset of tests - I'll add a few more in once I've done #1106 because then the logic should be a bit easier to think about anyway (right now it's a little weird as it's still name-based).