### PR TITLE
fix: use the last reference definition when checking jest fn scope

### DIFF
--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -1002,6 +1002,16 @@ describe('reference checking', () => {
       },
       {
         code: dedent`
+          interface it {}
+          function it(...all: any[]): void {}
+  
+          it('is not a jest function', () => {});
+        `,
+        parser: require.resolve('@typescript-eslint/parser'),
+        parserOptions: { sourceType: 'module' },
+      },
+      {
+        code: dedent`
           import { it } from '@jest/globals';
           import { it } from '../it-utils';
 

--- a/src/rules/__tests__/utils.test.ts
+++ b/src/rules/__tests__/utils.test.ts
@@ -989,7 +989,51 @@ describe('reference checking', () => {
         parser: require.resolve('@typescript-eslint/parser'),
         parserOptions: { sourceType: 'module' },
       },
+      {
+        code: dedent`
+          function it(message: string, fn: () => void): void;
+          function it(cases: unknown[], message: string, fn: () => void): void;
+          function it(...all: any[]): void {}
+  
+          it('is not a jest function', () => {});
+        `,
+        parser: require.resolve('@typescript-eslint/parser'),
+        parserOptions: { sourceType: 'module' },
+      },
+      {
+        code: dedent`
+          import { it } from '@jest/globals';
+          import { it } from '../it-utils';
+
+          it('is not a jest function', () => {});
+        `,
+        parser: require.resolve('@typescript-eslint/parser'),
+        parserOptions: { sourceType: 'module' },
+      },
     ],
-    invalid: [],
+    invalid: [
+      {
+        code: dedent`
+          import { it } from '../it-utils';
+          import { it } from '@jest/globals';
+
+          it('is a jest function', () => {});
+        `,
+        parser: require.resolve('@typescript-eslint/parser'),
+        parserOptions: { sourceType: 'module' },
+        errors: [
+          {
+            messageId: 'details' as const,
+            data: {
+              callType: 'test',
+              numOfArgs: 2,
+              nodeName: 'it',
+            },
+            column: 1,
+            line: 4,
+          },
+        ],
+      },
+    ],
   });
 });

--- a/src/rules/utils.ts
+++ b/src/rules/utils.ts
@@ -893,14 +893,7 @@ const collectReferences = (scope: TSESLint.Scope.Scope) => {
         continue;
       }
 
-      /* istanbul ignore if */
-      if (ref.defs.length > 1) {
-        throw new Error(
-          `Reference unexpected had more than one definition - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-        );
-      }
-
-      const [def] = ref.defs;
+      const def = ref.defs[ref.defs.length - 1];
 
       const importDetails = describePossibleImportDef(def);
 


### PR DESCRIPTION
I've thought up a few more theoretical ways that you can have multiple definitions but so far none that are actually valid so vanilla ESLint errors on them and while TypeScript parses them they're not valid.

I have changed the code to grab the _last_ definition, because I think that is technically the more correct one (e.g. for function overloads the last definition has to be the implementation, even though there's no way that'll be something we care about here) & it's cheap.

Resolves #1108