### PR TITLE
ci: use legacy peer dependencies for smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: 16
       - run: |
-          npm install
+          npm install --legacy-peer-deps
           npm run build
           npm link
           npm link eslint-plugin-jest


### PR DESCRIPTION
Currently smoke-test is failing because we're on jest v28 which isn't yet supported by `jest-runner-eslint` (it needs a new release) and npm v7+ enforces peer dependencies - I'd like to try and run the smoke test before I merge #1109 to see if there's any other cases, so this switches us to use `--legacy-peer-deps` which'll hopefully unblock the smoke test workflow