### PR TITLE
chore: upgrade `eslint-plugin-eslint-plugin`

### DIFF
--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -58,8 +58,8 @@ describe('the rule', () => {
   // a few sanity checks before doing our massive loop
   ruleTester.run('no-deprecated-functions', rule, {
     valid: [
-      { settings: { jest: { version: 14 } }, code: 'jest' },
-      { settings: { jest: { version: 14 } }, code: 'require("fs")' },
+      { code: 'jest', settings: { jest: { version: 14 } } },
+      { code: 'require("fs")', settings: { jest: { version: 14 } } },
       ...generateValidCases(14, 'jest.resetModuleRegistry'),
       ...generateValidCases(17, 'require.requireActual'),
       ...generateValidCases(25, 'jest.genMockFromModule'),

--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -145,7 +145,6 @@ const testComparisonOperator = (
       `expect(value).${preferredMatcherWhenNegated}(1);`,
       `expect(value).not.${preferredMatcher}(1);`,
       `expect(value).not.${preferredMatcherWhenNegated}(1);`,
-      `expect(value).${preferredMatcher}(1);`,
       ...['toBe', 'toEqual', 'toStrictEqual'].reduce<string[]>(
         (cases, equalityMatcher) => [
           ...cases,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4474,14 +4474,14 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-eslint-plugin@npm:^4.0.1":
-  version: 4.1.0
-  resolution: "eslint-plugin-eslint-plugin@npm:4.1.0"
+  version: 4.2.0
+  resolution: "eslint-plugin-eslint-plugin@npm:4.2.0"
   dependencies:
     eslint-utils: ^3.0.0
     estraverse: ^5.2.0
   peerDependencies:
     eslint: ">=6.0.0"
-  checksum: bf1d2b136a1f85bc12dca574f0acf80802e9ea7991069c41922849b00834d37d0888c098324c68a2f1600d30c725bb31e88b56b797e533cb64d8463ef69d7791
+  checksum: 753bb131b0c7297528e345af9e5fe39c9fc53dc84d91a9acbe078ea16ed15cd41cb7b2e78a13d20ef270bc6b33fc0e09d80e6231acfa9e46286b8a7d144c4660
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
I [improved the logic in `eslint-plugin-eslint-plugin` for detecting uses of `RuleTester`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/249), so now it checks in sub-blocks 🎉 