### PR TITLE
fix(no-disabled-tests): use jest function call parser for checking number of args

### DIFF
--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -60,6 +60,14 @@ ruleTester.run('no-disabled-tests', rule, {
         return {}
       }
     `,
+    {
+      code: dedent`
+        import { test } from './test-utils';
+
+        test('something');
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
   ],
 
   invalid: [
@@ -170,6 +178,15 @@ ruleTester.run('no-disabled-tests', rule, {
     {
       code: 'describe("contains a call to pending", function () { pending() })',
       errors: [{ messageId: 'pendingSuite', column: 54, line: 1 }],
+    },
+    {
+      code: dedent`
+        import { test } from '@jest/globals';
+
+        test('something');
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [{ messageId: 'missingFunction', column: 1, line: 3 }],
     },
   ],
 });

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -30,9 +30,6 @@ export default createRule({
     let testDepth = 0;
 
     return {
-      'CallExpression[callee.name=/^(it|test)$/][arguments.length<2]'(node) {
-        context.report({ messageId: 'missingFunction', node });
-      },
       CallExpression(node) {
         const jestFnCall = parseJestFnCall(node, context.getScope());
 
@@ -46,6 +43,10 @@ export default createRule({
 
         if (jestFnCall.type === 'test') {
           testDepth++;
+
+          if (node.arguments.length < 2) {
+            context.report({ messageId: 'missingFunction', node });
+          }
         }
 
         if (


### PR DESCRIPTION
I somehow missed this when doing #1125