### PR TITLE
feat: support aliases for jest globals (e.g. `context`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ doing:
 This is included in all configs shared by this plugin, so can be omitted if
 extending them.
 
+#### Aliased Jest globals
+
+You can tell this plugin about any global Jests you have aliased using the
+`globalAliases` setting:
+
+```json
+{
+  "settings": {
+    "jest": {
+      "globalAliases": {
+        "describe": ["context"],
+        "fdescribe": ["fcontext"],
+        "xdescribe": ["xcontext"]
+      }
+    }
+  }
+}
+```
+
 ### Running rules only on test-related files
 
 The rules provided by this plugin assume that the files they are checking are

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -45,6 +45,23 @@ ruleTester.run('no-focused-tests', rule, {
       ],
     },
     {
+      code: 'context.only()',
+      errors: [
+        {
+          messageId: 'focusedTest',
+          column: 9,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestRemoveFocus',
+              output: 'context()',
+            },
+          ],
+        },
+      ],
+      settings: { jest: { globalAliases: { describe: ['context'] } } },
+    },
+    {
       code: 'describe.only.each()()',
       errors: [
         {

--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -243,5 +243,15 @@ ruleTester.run('no-identical-title', rule, {
       `,
       errors: [{ messageId: 'multipleTestTitle', column: 6, line: 3 }],
     },
+    {
+      code: dedent`
+        context('foo', () => {
+          describe('foe', () => {});
+        });
+        describe('foo', () => {});
+      `,
+      errors: [{ messageId: 'multipleDescribeTitle', column: 10, line: 4 }],
+      settings: { jest: { globalAliases: { describe: ['context'] } } },
+    },
   ],
 });

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -1613,5 +1613,26 @@ ruleTester.run('valid-expect-in-promise', rule, {
         },
       ],
     },
+    {
+      code: dedent`
+        promiseThatThis('is valid', async () => {
+          const promise = loadNumber().then(number => {
+            expect(typeof number).toBe('number');
+
+            return number + 1;
+          });
+
+          expect(anotherPromise).resolves.toBe(1);
+        });
+      `,
+      errors: [
+        {
+          messageId: 'expectInFloatingPromise',
+          line: 2,
+          column: 9,
+        },
+      ],
+      settings: { jest: { globalAliases: { xit: ['promiseThatThis'] } } },
+    },
   ],
 });

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -72,8 +72,7 @@ export default createRule<
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        const scope = context.getScope();
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (!jestFnCall) {
           return;
@@ -129,7 +128,7 @@ export default createRule<
         }
       },
       'CallExpression:exit'(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['describe'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe'])) {
           describeNestingLevel--;
         }
       },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -96,7 +96,7 @@ export default createRule<
           const testCallExpressions =
             getTestCallExpressionsFromDeclaredVariables(
               declaredVariables,
-              context.getScope(),
+              context,
             );
 
           checkCallExpressionUsed(testCallExpressions);
@@ -114,7 +114,7 @@ export default createRule<
         const name = getNodeName(node.callee) ?? '';
 
         if (
-          isTypeOfJestFnCall(node, context.getScope(), ['test']) ||
+          isTypeOfJestFnCall(node, context, ['test']) ||
           additionalTestBlockFunctions.includes(name)
         ) {
           if (

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -38,7 +38,7 @@ export default createRule({
 
       if (
         parent?.type !== AST_NODE_TYPES.CallExpression ||
-        !isTypeOfJestFnCall(parent, context.getScope(), ['describe'])
+        !isTypeOfJestFnCall(parent, context, ['describe'])
       ) {
         return;
       }
@@ -61,7 +61,7 @@ export default createRule({
 
       if (
         parent?.type === AST_NODE_TYPES.CallExpression &&
-        isTypeOfJestFnCall(parent, context.getScope(), ['describe'])
+        isTypeOfJestFnCall(parent, context, ['describe'])
       ) {
         describeCallbackStack.pop();
       }

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -42,7 +42,7 @@ export default createRule({
         const declaredVariables = context.getDeclaredVariables(node);
         const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
           declaredVariables,
-          context.getScope(),
+          context,
         );
 
         if (testCallExpressions.length > 0) {
@@ -50,7 +50,7 @@ export default createRule({
         }
       },
       CallExpression(node: TSESTree.CallExpression) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           inTestCase = true;
         }
 
@@ -73,7 +73,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           inTestCase = false;
         }
 

--- a/src/rules/no-conditional-in-test.ts
+++ b/src/rules/no-conditional-in-test.ts
@@ -30,12 +30,12 @@ export default createRule({
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           inTestCase = true;
         }
       },
       'CallExpression:exit'(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           inTestCase = false;
         }
       },

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -31,7 +31,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (!jestFnCall) {
           return;
@@ -65,7 +65,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (!jestFnCall) {
           return;

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -4,13 +4,13 @@ import { createRule, getNodeName, isFunction, parseJestFnCall } from './utils';
 const findCallbackArg = (
   node: TSESTree.CallExpression,
   isJestEach: boolean,
-  scope: TSESLint.Scope.Scope,
+  context: TSESLint.RuleContext<string, unknown[]>,
 ): TSESTree.CallExpression['arguments'][0] | null => {
   if (isJestEach) {
     return node.arguments[1];
   }
 
-  const jestFnCall = parseJestFnCall(node, scope);
+  const jestFnCall = parseJestFnCall(node, context);
 
   if (jestFnCall?.type === 'hook' && node.arguments.length >= 1) {
     return node.arguments[0];
@@ -60,7 +60,7 @@ export default createRule({
           return;
         }
 
-        const callback = findCallbackArg(node, isJestEach, context.getScope());
+        const callback = findCallbackArg(node, isJestEach, context);
         const callbackArgIndex = Number(isJestEach);
 
         if (

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -20,9 +20,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        const scope = context.getScope();
-
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type === 'describe') {
           hookContexts.push({});
@@ -45,7 +43,7 @@ export default createRule({
         }
       },
       'CallExpression:exit'(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['describe'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe'])) {
           hookContexts.pop();
         }
       },

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -34,7 +34,7 @@ export default createRule({
       },
 
       CallExpression(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           hasTestCase = true;
         }
       },

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -22,9 +22,7 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        const scope = context.getScope();
-
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type !== 'test' && jestFnCall?.type !== 'describe') {
           return;

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -32,7 +32,7 @@ export default createRule<
   create(context, [{ allow = [] }]) {
     return {
       CallExpression(node) {
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (
           jestFnCall?.type === 'hook' &&

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -40,10 +40,9 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        const scope = context.getScope();
         const currentLayer = contexts[contexts.length - 1];
 
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (!jestFnCall) {
           return;
@@ -87,7 +86,7 @@ export default createRule({
         currentLayer.describeTitles.push(title);
       },
       'CallExpression:exit'(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['describe'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe'])) {
           contexts.pop();
         }
       },

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -75,7 +75,7 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type === 'test') {
           stack.push(true);
@@ -92,7 +92,7 @@ export default createRule({
         const declaredVariables = context.getDeclaredVariables(node);
         const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
           declaredVariables,
-          context.getScope(),
+          context,
         );
 
         stack.push(testCallExpressions.length > 0);

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -10,7 +10,7 @@ import {
 
 const getBlockType = (
   statement: TSESTree.BlockStatement,
-  scope: TSESLint.Scope.Scope,
+  context: TSESLint.RuleContext<string, unknown[]>,
 ): 'function' | 'describe' | null => {
   const func = statement.parent;
 
@@ -37,7 +37,7 @@ const getBlockType = (
     // if it's not a variable, it will be callExpr, we only care about describe
     if (
       expr.type === AST_NODE_TYPES.CallExpression &&
-      isTypeOfJestFnCall(expr, scope, ['describe'])
+      isTypeOfJestFnCall(expr, context, ['describe'])
     ) {
       return 'describe';
     }
@@ -85,7 +85,7 @@ export default createRule<
       additionalTestBlockFunctions.includes(getNodeName(node) || '');
 
     const isTestBlock = (node: TSESTree.CallExpression): boolean =>
-      isTypeOfJestFnCall(node, context.getScope(), ['test']) ||
+      isTypeOfJestFnCall(node, context, ['test']) ||
       isCustomTestBlockFunction(node);
 
     return {
@@ -123,7 +123,7 @@ export default createRule<
       },
 
       BlockStatement(statement) {
-        const blockType = getBlockType(statement, context.getScope());
+        const blockType = getBlockType(statement, context);
 
         if (blockType) {
           callStack.push(blockType);
@@ -131,8 +131,7 @@ export default createRule<
       },
       'BlockStatement:exit'(statement: TSESTree.BlockStatement) {
         if (
-          callStack[callStack.length - 1] ===
-          getBlockType(statement, context.getScope())
+          callStack[callStack.length - 1] === getBlockType(statement, context)
         ) {
           callStack.pop();
         }

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -20,8 +20,7 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        const scope = context.getScope();
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type !== 'describe' && jestFnCall?.type !== 'test') {
           return;

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -38,7 +38,7 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        if (!isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (!isTypeOfJestFnCall(node, context, ['test'])) {
           return;
         }
 
@@ -55,7 +55,7 @@ export default createRule({
         const declaredVariables = context.getDeclaredVariables(node);
         const testCallExpressions = getTestCallExpressionsFromDeclaredVariables(
           declaredVariables,
-          context.getScope(),
+          context,
         );
 
         if (testCallExpressions.length === 0) return;

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -157,7 +157,7 @@ export default createRule<[RuleOptions], MessageIds>({
       ForOfStatement: enterForLoop,
       'ForOfStatement:exit': exitForLoop,
       CallExpression(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           inTestCaseCall = true;
 
           return;
@@ -174,7 +174,7 @@ export default createRule<[RuleOptions], MessageIds>({
         }
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (!isTypeOfJestFnCall(node, context.getScope(), ['test'])) {
+        if (!isTypeOfJestFnCall(node, context, ['test'])) {
           return;
         }
 

--- a/src/rules/prefer-hooks-in-order.ts
+++ b/src/rules/prefer-hooks-in-order.ts
@@ -28,7 +28,7 @@ export default createRule({
           return;
         }
 
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type !== 'hook') {
           // Reset the previousHookIndex when encountering something different from a hook
@@ -57,7 +57,7 @@ export default createRule({
         previousHookIndex = currentHookIndex;
       },
       'CallExpression:exit'(node) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['hook'])) {
+        if (isTypeOfJestFnCall(node, context, ['hook'])) {
           inHook = false;
 
           return;

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -20,14 +20,12 @@ export default createRule({
 
     return {
       CallExpression(node) {
-        const scope = context.getScope();
-
-        if (isTypeOfJestFnCall(node, scope, ['test'])) {
+        if (isTypeOfJestFnCall(node, context, ['test'])) {
           hooksContext[hooksContext.length - 1] = true;
         }
         if (
           hooksContext[hooksContext.length - 1] &&
-          isTypeOfJestFnCall(node, scope, ['hook'])
+          isTypeOfJestFnCall(node, context, ['hook'])
         ) {
           context.report({
             messageId: 'noHookOnTop',

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -104,9 +104,7 @@ export default createRule<
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        const scope = context.getScope();
-
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (!jestFnCall || !hasStringAsFirstArgument(node)) {
           return;
@@ -162,7 +160,7 @@ export default createRule<
         });
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['describe'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe'])) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/prefer-snapshot-hint.ts
+++ b/src/rules/prefer-snapshot-hint.ts
@@ -106,17 +106,13 @@ export default createRule<[('always' | 'multi')?], keyof typeof messages>({
       ArrowFunctionExpression: enterExpression,
       'ArrowFunctionExpression:exit': exitExpression,
       'CallExpression:exit'(node) {
-        const scope = context.getScope();
-
-        if (isTypeOfJestFnCall(node, scope, ['describe', 'test'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe', 'test'])) {
           /* istanbul ignore next */
           expressionDepth = depths.pop() ?? 0;
         }
       },
       CallExpression(node) {
-        const scope = context.getScope();
-
-        if (isTypeOfJestFnCall(node, scope, ['describe', 'test'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe', 'test'])) {
           depths.push(expressionDepth);
           expressionDepth = 0;
         }

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -69,7 +69,7 @@ export default createRule({
       CallExpression(node) {
         const [title, callback] = node.arguments;
 
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (
           !title ||

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -10,9 +10,9 @@ import {
 
 const isJestFnCall = (
   node: TSESTree.CallExpression,
-  scope: TSESLint.Scope.Scope,
+  context: TSESLint.RuleContext<string, unknown[]>,
 ): boolean => {
-  if (parseJestFnCall(node, scope)) {
+  if (parseJestFnCall(node, context)) {
     return true;
   }
 
@@ -28,15 +28,15 @@ const isNullOrUndefined = (node: TSESTree.Expression): boolean => {
 
 const shouldBeInHook = (
   node: TSESTree.Node,
-  scope: TSESLint.Scope.Scope,
+  context: TSESLint.RuleContext<string, unknown[]>,
   allowedFunctionCalls: readonly string[] = [],
 ): boolean => {
   switch (node.type) {
     case AST_NODE_TYPES.ExpressionStatement:
-      return shouldBeInHook(node.expression, scope, allowedFunctionCalls);
+      return shouldBeInHook(node.expression, context, allowedFunctionCalls);
     case AST_NODE_TYPES.CallExpression:
       return !(
-        isJestFnCall(node, scope) ||
+        isJestFnCall(node, context) ||
         allowedFunctionCalls.includes(getNodeName(node) as string)
       );
     case AST_NODE_TYPES.VariableDeclaration: {
@@ -92,9 +92,7 @@ export default createRule<
 
     const checkBlockBody = (body: TSESTree.BlockStatement['body']) => {
       for (const statement of body) {
-        if (
-          shouldBeInHook(statement, context.getScope(), allowedFunctionCalls)
-        ) {
+        if (shouldBeInHook(statement, context, allowedFunctionCalls)) {
           context.report({
             node: statement,
             messageId: 'useHook',
@@ -109,7 +107,7 @@ export default createRule<
       },
       CallExpression(node) {
         if (
-          !isTypeOfJestFnCall(node, context.getScope(), ['describe']) ||
+          !isTypeOfJestFnCall(node, context, ['describe']) ||
           node.arguments.length < 2
         ) {
           return;

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -44,9 +44,7 @@ export default createRule<
 
     return {
       CallExpression(node) {
-        const scope = context.getScope();
-
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (!jestFnCall) {
           return;
@@ -87,7 +85,7 @@ export default createRule<
         }
       },
       'CallExpression:exit'(node: TSESTree.CallExpression) {
-        if (isTypeOfJestFnCall(node, context.getScope(), ['describe'])) {
+        if (isTypeOfJestFnCall(node, context, ['describe'])) {
           numberOfDescribeBlocks--;
         }
       },

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -121,7 +121,7 @@ export const isFunction = (node: TSESTree.Node): node is FunctionExpression =>
 
 export const getTestCallExpressionsFromDeclaredVariables = (
   declaredVariables: readonly TSESLint.Scope.Variable[],
-  scope: TSESLint.Scope.Scope,
+  context: TSESLint.RuleContext<string, unknown[]>,
 ): TSESTree.CallExpression[] => {
   return declaredVariables.reduce<TSESTree.CallExpression[]>(
     (acc, { references }) =>
@@ -131,7 +131,7 @@ export const getTestCallExpressionsFromDeclaredVariables = (
           .filter(
             (node): node is TSESTree.CallExpression =>
               node?.type === AST_NODE_TYPES.CallExpression &&
-              isTypeOfJestFnCall(node, scope, ['test']),
+              isTypeOfJestFnCall(node, context, ['test']),
           ),
       ),
     [],

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -41,7 +41,7 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node) {
-        const jestFnCall = parseJestFnCall(node, context.getScope());
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type !== 'describe') {
           return;

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -179,9 +179,7 @@ export default createRule<[Options], MessageIds>({
 
     return {
       CallExpression(node: TSESTree.CallExpression) {
-        const scope = context.getScope();
-
-        const jestFnCall = parseJestFnCall(node, scope);
+        const jestFnCall = parseJestFnCall(node, context);
 
         if (jestFnCall?.type !== 'describe' && jestFnCall?.type !== 'test') {
           return;


### PR DESCRIPTION
I'm a bit on the fence about this: it ended up being a pretty straightforward addition but I'm worried it's catering to a very small niche because: 
1. it requires you to set up the globaled aliases with a custom `setupTestFrameworkScriptFile`
2. you can get this already by importing the function you want to alias from `@jest/globals`
    * in addition to being a requirement if you're using ESM (since no globals), I think it's straight up easier than 1 as devs will already know how to import but would need to readup on jest configuration to know how to do 1

@SimenB do you think this is worth landing?

Resolves #83