### PR TITLE
fix: produce valid code when when fixing properties accessed with square brackets

### DIFF
--- a/src/rules/__tests__/no-alias-methods.test.ts
+++ b/src/rules/__tests__/no-alias-methods.test.ts
@@ -231,5 +231,20 @@ ruleTester.run('no-alias-methods', rule, {
         },
       ],
     },
+    {
+      code: 'expect(a).not["toThrowError"]()',
+      output: "expect(a).not['toThrow']()",
+      errors: [
+        {
+          messageId: 'replaceAlias',
+          data: {
+            alias: 'toThrowError',
+            canonical: 'toThrow',
+          },
+          column: 15,
+          line: 1,
+        },
+      ],
+    },
   ],
 });

--- a/src/rules/__tests__/prefer-strict-equal.test.ts
+++ b/src/rules/__tests__/prefer-strict-equal.test.ts
@@ -26,5 +26,21 @@ ruleTester.run('prefer-strict-equal', rule, {
         },
       ],
     },
+    {
+      code: 'expect(something)["toEqual"](somethingElse);',
+      errors: [
+        {
+          messageId: 'useToStrictEqual',
+          column: 19,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWithStrictEqual',
+              output: "expect(something)['toStrictEqual'](somethingElse);",
+            },
+          ],
+        },
+      ],
+    },
   ],
 });

--- a/src/rules/__tests__/prefer-to-be.test.ts
+++ b/src/rules/__tests__/prefer-to-be.test.ts
@@ -46,6 +46,11 @@ ruleTester.run('prefer-to-be', rule, {
       errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
     },
     {
+      code: 'expect(value)["toEqual"](`my string`);',
+      output: "expect(value)['toBe'](`my string`);",
+      errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
+    },
+    {
       code: 'expect(value).toStrictEqual(`my ${string}`);',
       output: 'expect(value).toBe(`my ${string}`);',
       errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
@@ -54,6 +59,16 @@ ruleTester.run('prefer-to-be', rule, {
       code: 'expect(loadMessage()).resolves.toStrictEqual("hello world");',
       output: 'expect(loadMessage()).resolves.toBe("hello world");',
       errors: [{ messageId: 'useToBe', column: 32, line: 1 }],
+    },
+    {
+      code: 'expect(loadMessage()).resolves["toStrictEqual"]("hello world");',
+      output: 'expect(loadMessage()).resolves[\'toBe\']("hello world");',
+      errors: [{ messageId: 'useToBe', column: 32, line: 1 }],
+    },
+    {
+      code: 'expect(loadMessage())["resolves"].toStrictEqual("hello world");',
+      output: 'expect(loadMessage())["resolves"].toBe("hello world");',
+      errors: [{ messageId: 'useToBe', column: 35, line: 1 }],
     },
     {
       code: 'expect(loadMessage()).resolves.toStrictEqual(false);',
@@ -102,6 +117,16 @@ ruleTester.run('prefer-to-be: null', rule, {
       code: 'expect("a string").not.toBe(null);',
       output: 'expect("a string").not.toBeNull();',
       errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
+    },
+    {
+      code: 'expect("a string").not["toBe"](null);',
+      output: 'expect("a string").not[\'toBeNull\']();',
+      errors: [{ messageId: 'useToBeNull', column: 24, line: 1 }],
+    },
+    {
+      code: 'expect("a string")["not"]["toBe"](null);',
+      output: 'expect("a string")["not"][\'toBeNull\']();',
+      errors: [{ messageId: 'useToBeNull', column: 27, line: 1 }],
     },
     {
       code: 'expect("a string").not.toEqual(null);',
@@ -157,6 +182,11 @@ ruleTester.run('prefer-to-be: undefined', rule, {
       errors: [{ messageId: 'useToBeDefined', column: 32, line: 1 }],
     },
     {
+      code: 'expect("a string").rejects.not["toBe"](undefined);',
+      output: 'expect("a string").rejects[\'toBeDefined\']();',
+      errors: [{ messageId: 'useToBeDefined', column: 32, line: 1 }],
+    },
+    {
       code: 'expect("a string").not.toEqual(undefined);',
       output: 'expect("a string").toBeDefined();',
       errors: [{ messageId: 'useToBeDefined', column: 24, line: 1 }],
@@ -207,6 +237,11 @@ ruleTester.run('prefer-to-be: NaN', rule, {
       code: 'expect("a string").rejects.not.toBe(NaN);',
       output: 'expect("a string").rejects.not.toBeNaN();',
       errors: [{ messageId: 'useToBeNaN', column: 32, line: 1 }],
+    },
+    {
+      code: 'expect("a string")["rejects"].not.toBe(NaN);',
+      output: 'expect("a string")["rejects"].not.toBeNaN();',
+      errors: [{ messageId: 'useToBeNaN', column: 35, line: 1 }],
     },
     {
       code: 'expect("a string").not.toEqual(NaN);',

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -58,5 +58,15 @@ ruleTester.run('prefer-todo', rule, {
       output: 'test.todo("i need to write this test");',
       errors: [{ messageId: 'emptyTest' }],
     },
+    {
+      code: `test["skip"]("i need to write this test", function() {});`,
+      output: 'test[\'todo\']("i need to write this test");',
+      errors: [{ messageId: 'emptyTest' }],
+    },
+    {
+      code: `test[\`skip\`]("i need to write this test", function() {});`,
+      output: 'test[\'todo\']("i need to write this test");',
+      errors: [{ messageId: 'emptyTest' }],
+    },
   ],
 });

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -1,5 +1,9 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import { createRule, isExpectCall, parseExpectCall } from './utils';
+import {
+  createRule,
+  isExpectCall,
+  parseExpectCall,
+  replaceAccessorFixer,
+} from './utils';
 
 export default createRule({
   name: __filename,
@@ -58,12 +62,7 @@ export default createRule({
             },
             node: matcher.node.property,
             fix: fixer => [
-              fixer.replaceText(
-                matcher.node.property,
-                matcher.node.property.type === AST_NODE_TYPES.Identifier
-                  ? canonical
-                  : `'${canonical}'`,
-              ),
+              replaceAccessorFixer(fixer, matcher.node.property, canonical),
             ],
           });
         }

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -1,3 +1,4 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import { createRule, isExpectCall, parseExpectCall } from './utils';
 
 export default createRule({
@@ -56,7 +57,14 @@ export default createRule({
               canonical,
             },
             node: matcher.node.property,
-            fix: fixer => [fixer.replaceText(matcher.node.property, canonical)],
+            fix: fixer => [
+              fixer.replaceText(
+                matcher.node.property,
+                matcher.node.property.type === AST_NODE_TYPES.Identifier
+                  ? canonical
+                  : `'${canonical}'`,
+              ),
+            ],
           });
         }
       },

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -1,10 +1,10 @@
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   EqualityMatcher,
   createRule,
   isExpectCall,
   isParsedEqualityMatcherCall,
   parseExpectCall,
+  replaceAccessorFixer,
 } from './utils';
 
 export default createRule({
@@ -45,11 +45,10 @@ export default createRule({
               {
                 messageId: 'suggestReplaceWithStrictEqual',
                 fix: fixer => [
-                  fixer.replaceText(
+                  replaceAccessorFixer(
+                    fixer,
                     matcher.node.property,
-                    matcher.node.property.type === AST_NODE_TYPES.Identifier
-                      ? EqualityMatcher.toStrictEqual
-                      : `'${EqualityMatcher.toStrictEqual}'`,
+                    EqualityMatcher.toStrictEqual,
                   ),
                 ],
               },

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -1,3 +1,4 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import {
   EqualityMatcher,
   createRule,
@@ -46,7 +47,9 @@ export default createRule({
                 fix: fixer => [
                   fixer.replaceText(
                     matcher.node.property,
-                    EqualityMatcher.toStrictEqual,
+                    matcher.node.property.type === AST_NODE_TYPES.Identifier
+                      ? EqualityMatcher.toStrictEqual
+                      : `'${EqualityMatcher.toStrictEqual}'`,
                   ),
                 ],
               },

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -69,9 +69,11 @@ const reportPreferToBe = (
   context.report({
     messageId: `useToBe${whatToBe}`,
     fix(fixer) {
-      const fixes = [
-        fixer.replaceText(matcher.node.property, `toBe${whatToBe}`),
-      ];
+      const r = `toBe${whatToBe}`;
+      const text =
+        matcher.node.property.type === AST_NODE_TYPES.Identifier ? r : `'${r}'`;
+
+      const fixes = [fixer.replaceText(matcher.node.property, text)];
 
       if (matcher.arguments?.length && whatToBe !== '') {
         fixes.push(fixer.remove(matcher.arguments[0]));

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -12,6 +12,7 @@ import {
   isIdentifier,
   isParsedEqualityMatcherCall,
   parseExpectCall,
+  replaceAccessorFixer,
 } from './utils';
 
 const isNullLiteral = (node: TSESTree.Node): node is TSESTree.NullLiteral =>
@@ -69,11 +70,9 @@ const reportPreferToBe = (
   context.report({
     messageId: `useToBe${whatToBe}`,
     fix(fixer) {
-      const r = `toBe${whatToBe}`;
-      const text =
-        matcher.node.property.type === AST_NODE_TYPES.Identifier ? r : `'${r}'`;
-
-      const fixes = [fixer.replaceText(matcher.node.property, text)];
+      const fixes = [
+        replaceAccessorFixer(fixer, matcher.node.property, `toBe${whatToBe}`),
+      ];
 
       if (matcher.arguments?.length && whatToBe !== '') {
         fixes.push(fixer.remove(matcher.arguments[0]));

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -7,6 +7,7 @@ import {
   isFunction,
   isStringNode,
   parseJestFnCall,
+  replaceAccessorFixer,
 } from './utils';
 
 function isEmptyFunction(node: TSESTree.CallExpressionArgument) {
@@ -24,12 +25,7 @@ function createTodoFixer(
   fixer: TSESLint.RuleFixer,
 ) {
   if (jestFnCall.members.length) {
-    const text =
-      jestFnCall.members[0].type === AST_NODE_TYPES.Identifier
-        ? 'todo'
-        : "'todo'";
-
-    return [fixer.replaceText(jestFnCall.members[0], text)];
+    return [replaceAccessorFixer(fixer, jestFnCall.members[0], 'todo')];
   }
 
   return [

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -25,12 +25,13 @@ function createTodoFixer(
   fixer: TSESLint.RuleFixer,
 ) {
   if (jestFnCall.members.length) {
-    return [replaceAccessorFixer(fixer, jestFnCall.members[0], 'todo')];
+    return replaceAccessorFixer(fixer, jestFnCall.members[0], 'todo');
   }
 
-  return [
-    fixer.replaceText(jestFnCall.head.node, `${jestFnCall.head.local}.todo`),
-  ];
+  return fixer.replaceText(
+    jestFnCall.head.node,
+    `${jestFnCall.head.local}.todo`,
+  );
 }
 
 const isTargetedTestCase = (jestFnCall: ParsedJestFnCall): boolean => {
@@ -85,7 +86,7 @@ export default createRule({
             node,
             fix: fixer => [
               fixer.removeRange([title.range[1], callback.range[1]]),
-              ...createTodoFixer(jestFnCall, fixer),
+              createTodoFixer(jestFnCall, fixer),
             ],
           });
         }

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -23,20 +23,18 @@ function createTodoFixer(
   jestFnCall: ParsedJestFnCall,
   fixer: TSESLint.RuleFixer,
 ) {
-  const fixes = [
-    fixer.replaceText(jestFnCall.head.node, `${jestFnCall.head.local}.todo`),
-  ];
-
   if (jestFnCall.members.length) {
-    fixes.unshift(
-      fixer.removeRange([
-        jestFnCall.head.node.range[1],
-        jestFnCall.members[0].range[1],
-      ]),
-    );
+    const text =
+      jestFnCall.members[0].type === AST_NODE_TYPES.Identifier
+        ? 'todo'
+        : "'todo'";
+
+    return [fixer.replaceText(jestFnCall.members[0], text)];
   }
 
-  return fixes;
+  return [
+    fixer.replaceText(jestFnCall.head.node, `${jestFnCall.head.local}.todo`),
+  ];
 }
 
 const isTargetedTestCase = (jestFnCall: ParsedJestFnCall): boolean => {

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -137,3 +137,20 @@ export const getTestCallExpressionsFromDeclaredVariables = (
     [],
   );
 };
+
+/**
+ * Replaces an accessor node with the given `text`, surrounding it in quotes if required.
+ *
+ * This ensures that fixes produce valid code when replacing both dot-based and
+ * bracket-based property accessors.
+ */
+export const replaceAccessorFixer = (
+  fixer: TSESLint.RuleFixer,
+  node: AccessorNode,
+  text: string,
+) => {
+  return fixer.replaceText(
+    node,
+    node.type === AST_NODE_TYPES.Identifier ? text : `'${text}'`,
+  );
+};


### PR DESCRIPTION
Very minor (I really don't think anyone is accessing properties this way) but it's technically a bug - I realised afterwards that the alternative is to do:

```
fixer.replaceTextRange(
  [matcher.node.object.range[1], matcher.node.range[1]],
  `.${...}`,
),
```

which ensures the whole accessor is removed correctly making it safe to not use quotes - I'm not fussed which fix we actually do, but felt this helper was slightly better by way of being more readable 🤷 

We could be using it in `no-deprecated-functions` too except that technically isn't using a node of type `AccessorNode` so have left it as-is for now since it technically should be refactored anyway to use the new jest function parser.