### PR TITLE
fix: don't consider method calls on literals or `new` to be jest functions

### DIFF
--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -114,6 +114,10 @@ ruleTester.run('nonexistent methods', rule, {
     'describe.concurrent()()',
     'describe.concurrent``()',
     'describe.every``()',
+    '/regex/.test()',
+    '"something".describe()',
+    '[].describe()',
+    'new describe().only()',
   ],
   invalid: [],
 });


### PR DESCRIPTION
I was trying to be a little clever, but there's a reason why `getNodeName` does this...

I've also included removing allowing `NewExpression` because that's also not correct.

Resolves #1128
Resolves #1130