### PR TITLE
fix: don't consider template tags in the middle of a possible jest function chain to be valid

### DIFF
--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -118,6 +118,9 @@ ruleTester.run('nonexistent methods', rule, {
     '"something".describe()',
     '[].describe()',
     'new describe().only()',
+    '``.test()',
+    'test.only``()',
+    'test``.only()',
   ],
   invalid: [],
 });


### PR DESCRIPTION
Found this while doing #1132