### PR TITLE
fix(expect-expect): include numbers when matching assert function names with wildcards

### DIFF
--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -188,6 +188,14 @@ ruleTester.run('expect-expect', rule, {
 ruleTester.run('wildcards', rule, {
   valid: [
     {
+      code: "test('should pass *', () => expect404ToBeLoaded());",
+      options: [{ assertFunctionNames: ['expect*'] }],
+    },
+    {
+      code: "test('should pass *', () => expect.toHaveStatus404());",
+      options: [{ assertFunctionNames: ['expect.**'] }],
+    },
+    {
       code: "test('should pass', () => tester.foo().expect(123));",
       options: [{ assertFunctionNames: ['tester.*.expect'] }],
     },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -28,9 +28,9 @@ function matchesAssertFunctionName(
       `^${p
         .split('.')
         .map(x => {
-          if (x === '**') return '[a-z\\.]*';
+          if (x === '**') return '[a-z\\d\\.]*';
 
-          return x.replace(/\*/gu, '[a-z]*');
+          return x.replace(/\*/gu, '[a-z\\d]*');
         })
         .join('\\.')}(\\.|$)`,
       'ui',


### PR DESCRIPTION
Resolves #1103