### PR TITLE
fix(no-disabled-tests): don't report on `it.todo` & `test.todo`

### DIFF
--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -23,6 +23,7 @@ ruleTester.run('no-disabled-tests', rule, {
     'test.only("foo", function () {})',
     'test.concurrent("foo", function () {})',
     'describe[`${"skip"}`]("foo", function () {})',
+    'it.todo("fill this later")',
     'var appliedSkip = describe.skip; appliedSkip.apply(describe)',
     'var calledSkip = it.skip; calledSkip.call(it)',
     '({ f: function () {} }).f()',

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -44,7 +44,10 @@ export default createRule({
         if (jestFnCall.type === 'test') {
           testDepth++;
 
-          if (node.arguments.length < 2) {
+          if (
+            node.arguments.length < 2 &&
+            jestFnCall.members.every(s => getAccessorValue(s) !== 'todo')
+          ) {
             context.report({ messageId: 'missingFunction', node });
           }
         }


### PR DESCRIPTION
Resolves #1136