### PR TITLE
docs(prefer-hooks-in-order): update the url of the reference link to match the latest version

### DIFF
--- a/docs/rules/prefer-hooks-in-order.md
+++ b/docs/rules/prefer-hooks-in-order.md
@@ -131,4 +131,3 @@ describe('foo', () => {
 ## Further Reading
 
 - [Order of Execution](https://jestjs.io/docs/setup-teardown#order-of-execution)
-

--- a/docs/rules/prefer-hooks-in-order.md
+++ b/docs/rules/prefer-hooks-in-order.md
@@ -130,4 +130,5 @@ describe('foo', () => {
 
 ## Further Reading
 
-- [Order of execution of describe and test blocks](https://jestjs.io/docs/setup-teardown#order-of-execution-of-describe-and-test-blocks)
+- [Order of Execution](https://jestjs.io/docs/setup-teardown#order-of-execution)
+


### PR DESCRIPTION
It seems to specify a url that does not exist in the documentation for v27 and higher versions.
Perhaps it would be better to change the link to https://jestjs.io/docs/setup-teardown#order-of-execution.