### PR TITLE
fix: make no-jest-import error message more accurate

### DIFF
--- a/docs/rules/no-jest-import.md
+++ b/docs/rules/no-jest-import.md
@@ -2,7 +2,7 @@
 
 The `jest` object is automatically in scope within every test file. The methods
 in the `jest` object help create mocks and let you control Jest's overall
-behavior. It is therefore completely unnecessary to import in `jest`, as Jest
+behavior. It is therefore usually unnecessary to import in `jest`, as Jest
 doesn't export anything in the first place.
 
 ### Rule details
@@ -12,8 +12,13 @@ This rule reports on any importing of Jest.
 To name a few: `var jest = require('jest');` `const jest = require('jest');`
 `import jest from 'jest';` `import {jest as test} from 'jest';`
 
-There is no correct usage of this code, other than to not import `jest` in the
-first place.
+Examples of correct code include running Jest programatically in non-CLI
+environments (note that this is [not officially supported](https://github.com/facebook/jest/issues/5048)):
+
+```js
+const jest = require('jest')
+jest.runCLI(...)
+```
 
 ## Further Reading
 

--- a/docs/rules/no-jest-import.md
+++ b/docs/rules/no-jest-import.md
@@ -2,8 +2,7 @@
 
 The `jest` object is automatically in scope within every test file. The methods
 in the `jest` object help create mocks and let you control Jest's overall
-behavior. It is therefore usually unnecessary to import in `jest`, as Jest
-doesn't export anything in the first place.
+behavior. It is therefore usually unnecessary to import in `jest`.
 
 ### Rule details
 

--- a/src/rules/no-jest-import.ts
+++ b/src/rules/no-jest-import.ts
@@ -11,7 +11,7 @@ export default createRule({
       recommended: 'error',
     },
     messages: {
-      unexpectedImport: `Jest is automatically in scope. Do not import "jest", as Jest doesn't export anything.`,
+      unexpectedImport: `Do not import "jest". Jest is automatically in scope within every test file.`,
     },
     schema: [],
   },


### PR DESCRIPTION
It isn't quite accurate to say that Jest doesn't export anything. It exports the `run` and `runCLI` functions, even though it isn't generally recommended to use them ([yet](https://github.com/facebook/jest/issues/5048#issuecomment-470693540)).

This updates the message to match the language in https://jestjs.io/docs/jest-object ("The `jest` object is automatically in scope within every test file").

There's also a similar update to the no-jest-import.md docs file.