### PR TITLE
docs: update ESLint logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <a href="https://eslint.org/">
-    <img width="150" height="150" src="https://eslint.org/assets/img/logo.svg">
+    <img width="150" height="150" src="https://eslint.org/assets/images/logo/eslint-logo-color.svg">
   </a>
   <a href="https://facebook.github.io/jest/">
     <img width="150" height="150" vspace="" hspace="25" src="https://jestjs.io/img/jest.png">


### PR DESCRIPTION
The current logo path returns a 404, this PR updates to use the new ESLint logo location.

Current:

![image](https://user-images.githubusercontent.com/28659384/180603487-b9aa85ff-90e3-4b0f-8c50-8a51ea30f8c4.png)

Updated:

![image](https://user-images.githubusercontent.com/28659384/180603506-bcedec12-e5bb-4af4-8e55-b2ce3c2347f5.png)

