### PR TITLE
chore: change rules to always report on matcher even when modifier is present

### DIFF
--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -95,7 +95,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher: preferredMatcherWhenNegated },
-          column: 18 + operator.length,
+          column: 22 + operator.length,
           line: 1,
         },
       ],
@@ -107,7 +107,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher: preferredMatcherWhenNegated },
-          column: 18 + operator.length,
+          column: 25 + operator.length,
           line: 1,
         },
       ],
@@ -119,7 +119,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher: preferredMatcherWhenNegated },
-          column: 27 + operator.length,
+          column: 31 + operator.length,
           line: 1,
         },
       ],
@@ -131,7 +131,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher },
-          column: 18 + operator.length,
+          column: 22 + operator.length,
           line: 1,
         },
       ],
@@ -143,7 +143,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher },
-          column: 27 + operator.length,
+          column: 31 + operator.length,
           line: 1,
         },
       ],
@@ -155,7 +155,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher },
-          column: 30 + operator.length,
+          column: 34 + operator.length,
           line: 1,
         },
       ],
@@ -167,7 +167,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher },
-          column: 30 + operator.length,
+          column: 37 + operator.length,
           line: 1,
         },
       ],
@@ -179,7 +179,7 @@ const generateInvalidCases = (
         {
           messageId: 'useToBeComparison',
           data: { preferredMatcher },
-          column: 30 + operator.length,
+          column: 37 + operator.length,
           line: 1,
         },
       ],

--- a/src/rules/__tests__/prefer-equality-matcher.test.ts
+++ b/src/rules/__tests__/prefer-equality-matcher.test.ts
@@ -97,7 +97,7 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).not.${equalityMatcher}(b);`,
           ),
-          column: 17,
+          column: 21,
           line: 1,
         },
       ],
@@ -110,7 +110,7 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).${equalityMatcher}(b);`,
           ),
-          column: 17,
+          column: 21,
           line: 1,
         },
       ],
@@ -123,7 +123,7 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).resolves.not.${equalityMatcher}(b);`,
           ),
-          column: 26,
+          column: 30,
           line: 1,
         },
       ],
@@ -136,7 +136,7 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).resolves.${equalityMatcher}(b);`,
           ),
-          column: 26,
+          column: 30,
           line: 1,
         },
       ],
@@ -149,7 +149,7 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).resolves.${equalityMatcher}(b);`,
           ),
-          column: 29,
+          column: 33,
           line: 1,
         },
       ],
@@ -162,7 +162,7 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).resolves.${equalityMatcher}(b);`,
           ),
-          column: 29,
+          column: 36,
           line: 1,
         },
       ],
@@ -237,7 +237,7 @@ ruleTester.run('prefer-equality-matcher: !==', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).${equalityMatcher}(b);`,
           ),
-          column: 17,
+          column: 21,
           line: 1,
         },
       ],
@@ -250,7 +250,7 @@ ruleTester.run('prefer-equality-matcher: !==', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).not.${equalityMatcher}(b);`,
           ),
-          column: 17,
+          column: 21,
           line: 1,
         },
       ],
@@ -263,7 +263,7 @@ ruleTester.run('prefer-equality-matcher: !==', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).resolves.${equalityMatcher}(b);`,
           ),
-          column: 26,
+          column: 30,
           line: 1,
         },
       ],
@@ -276,7 +276,7 @@ ruleTester.run('prefer-equality-matcher: !==', rule, {
           suggestions: expectSuggestions(
             equalityMatcher => `expect(a).resolves.not.${equalityMatcher}(b);`,
           ),
-          column: 26,
+          column: 30,
           line: 1,
         },
       ],

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -50,17 +50,17 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: "expect(a['includes'](b)).not.toEqual(false);",
       output: 'expect(a).toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 30, line: 1 }],
     },
     {
       code: "expect(a['includes'](b))['not'].toEqual(false);",
       output: 'expect(a).toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: "expect(a['includes'](b))['not']['toEqual'](false);",
       output: 'expect(a).toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 26, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toEqual(false);',
@@ -70,12 +70,12 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: 'expect(a.includes(b)).not.toEqual(false);',
       output: 'expect(a).toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toEqual(true);',
       output: 'expect(a).not.toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toBe(true);',
@@ -90,12 +90,12 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: 'expect(a.includes(b)).not.toBe(false);',
       output: 'expect(a).toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toBe(true);',
       output: 'expect(a).not.toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).toStrictEqual(true);',
@@ -110,12 +110,12 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: 'expect(a.includes(b)).not.toStrictEqual(false);',
       output: 'expect(a).toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
     },
     {
       code: 'expect(a.includes(b)).not.toStrictEqual(true);',
       output: 'expect(a).not.toContain(b);',
-      errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 27, line: 1 }],
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).toEqual(true);',
@@ -130,12 +130,12 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(true);',
       output: 'expect(a.test(t)).not.toContain(b.test(p));',
-      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 43, line: 1 }],
     },
     {
       code: 'expect(a.test(t).includes(b.test(p))).not.toEqual(false);',
       output: 'expect(a.test(t)).toContain(b.test(p));',
-      errors: [{ messageId: 'useToContain', column: 39, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 43, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toBe(true);',
@@ -150,12 +150,12 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(true);',
       output: 'expect([{a:1}]).not.toContain({a:1});',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 37, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toBe(false);',
       output: 'expect([{a:1}]).toContain({a:1});',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 37, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).toStrictEqual(true);',
@@ -170,12 +170,12 @@ ruleTester.run('prefer-to-contain', rule, {
     {
       code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(true);',
       output: 'expect([{a:1}]).not.toContain({a:1});',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 37, line: 1 }],
     },
     {
       code: 'expect([{a:1}].includes({a:1})).not.toStrictEqual(false);',
       output: 'expect([{a:1}]).toContain({a:1});',
-      errors: [{ messageId: 'useToContain', column: 33, line: 1 }],
+      errors: [{ messageId: 'useToContain', column: 37, line: 1 }],
     },
   ],
 });

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -168,7 +168,7 @@ export default createRule({
           },
           messageId: 'useToBeComparison',
           data: { preferredMatcher },
-          node: (negation || matcher).node.property,
+          node: matcher.node.property,
         });
       },
     };

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -140,7 +140,7 @@ export default createRule({
               fix: buildFixer(equalityMatcher),
             }),
           ),
-          node: (negation || matcher).node.property,
+          node: matcher.node.property,
         });
       },
     };

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -135,7 +135,7 @@ export default createRule({
             ];
           },
           messageId: 'useToContain',
-          node: (modifier || matcher).node.property,
+          node: matcher.node.property,
         });
       },
     };


### PR DESCRIPTION
This is the tiniest of "fixes" but it reduces the diff of #1173 a little - I don't think the matcher node is actually the best location to be reporting it, but it's still better than the modifier/negation node in all cases...