### PR TITLE
refactor(prefer-called-with): rename `name` data property to `matcherName`

### DIFF
--- a/src/rules/__tests__/prefer-called-with.test.ts
+++ b/src/rules/__tests__/prefer-called-with.test.ts
@@ -26,7 +26,7 @@ ruleTester.run('prefer-called-with', rule, {
       errors: [
         {
           messageId: 'preferCalledWith',
-          data: { name: 'toBeCalled' },
+          data: { matcherName: 'toBeCalled' },
           column: 12,
           line: 1,
         },
@@ -37,7 +37,7 @@ ruleTester.run('prefer-called-with', rule, {
       errors: [
         {
           messageId: 'preferCalledWith',
-          data: { name: 'toBeCalled' },
+          data: { matcherName: 'toBeCalled' },
           column: 21,
           line: 1,
         },
@@ -48,7 +48,7 @@ ruleTester.run('prefer-called-with', rule, {
       errors: [
         {
           messageId: 'preferCalledWith',
-          data: { name: 'toHaveBeenCalled' },
+          data: { matcherName: 'toHaveBeenCalled' },
           column: 12,
           line: 1,
         },

--- a/src/rules/prefer-called-with.ts
+++ b/src/rules/prefer-called-with.ts
@@ -15,7 +15,7 @@ export default createRule({
       recommended: false,
     },
     messages: {
-      preferCalledWith: 'Prefer {{name}}With(/* expected args */)',
+      preferCalledWith: 'Prefer {{ matcherName }}With(/* expected args */)',
     },
     type: 'suggestion',
     schema: [],
@@ -40,7 +40,7 @@ export default createRule({
 
         if (['toBeCalled', 'toHaveBeenCalled'].includes(matcher.name)) {
           context.report({
-            data: { name: matcher.name },
+            data: { matcherName: matcher.name },
             messageId: 'preferCalledWith',
             node: matcher.node.property,
           });


### PR DESCRIPTION
This reduces the diff in #1173 a little but it also technically an improvement on its own since it makes our message formatting consistent by adding spaces around the braces.