### PR TITLE
ci: adjust caching to apply to all OSs

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,28 +11,21 @@ on:
       - next
 
 jobs:
-  prepare-yarn-cache:
-    name: Prepare yarn cache
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-          cache: yarn
-
-      - name: Validate cache
-        env:
-          # Use PnP and disable postinstall scripts as this just needs to
-          # populate the cache for the other jobs
-          YARN_NODE_LINKER: pnp
-          YARN_ENABLE_SCRIPTS: false
-        run: yarn --immutable
+  prepare-yarn-cache-ubuntu:
+    uses: ./.github/workflows/prepare-cache.yml
+    with:
+      os: ubuntu-latest
+  prepare-yarn-cache-macos:
+    uses: ./.github/workflows/prepare-cache.yml
+    with:
+      os: macos-latest
+  prepare-yarn-cache-windows:
+    uses: ./.github/workflows/prepare-cache.yml
+    with:
+      os: windows-latest
 
   prettier:
-    needs: prepare-yarn-cache
+    needs: prepare-yarn-cache-ubuntu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +39,7 @@ jobs:
         run: yarn prettier:check
 
   typecheck:
-    needs: prepare-yarn-cache
+    needs: prepare-yarn-cache-ubuntu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +56,7 @@ jobs:
     name:
       # prettier-ignore
       Test on Node.js v${{ matrix.node-version }}, eslint v${{ matrix.eslint-version }}
-    needs: prepare-yarn-cache
+    needs: prepare-yarn-cache-ubuntu
     strategy:
       fail-fast: false
       matrix:
@@ -91,34 +84,25 @@ jobs:
           CI: true
       - uses: codecov/codecov-action@v3
         if: ${{ matrix.eslint-version >= 8 }}
-  test-os:
-    name: Test on ${{ matrix.os }} using Node.js LTS
-    needs: prepare-yarn-cache
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: lts/*
-          cache: yarn
-      - name: install
-        run: yarn
-      - name: run tests
-        # only collect coverage on eslint versions that support dynamic import
-        run: yarn test --coverage ${{ matrix.eslint-version >= 8 }}
-        env:
-          CI: true
-      - uses: codecov/codecov-action@v3
-        if: ${{ matrix.eslint-version >= 8 }}
+  test-ubuntu:
+    uses: ./.github/workflows/test.yml
+    needs: prepare-yarn-cache-ubuntu
+    with:
+      os: ubuntu-latest
+  test-macos:
+    uses: ./.github/workflows/test.yml
+    needs: prepare-yarn-cache-macos
+    with:
+      os: macos-latest
+  test-windows:
+    uses: ./.github/workflows/test.yml
+    needs: prepare-yarn-cache-windows
+    with:
+      os: windows-latest
 
   docs:
     if: ${{ github.event_name == 'pull_request' }}
-    needs: prepare-yarn-cache
+    needs: prepare-yarn-cache-ubuntu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -141,7 +125,8 @@ jobs:
       # prettier-ignore
       ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/next') }}
     name: Release new version
-    needs: [prettier, typecheck, test-node, test-os]
+    needs:
+      [prettier, typecheck, test-node, test-ubuntu, test-macos, test-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/prepare-cache.yml
+++ b/.github/workflows/prepare-cache.yml
@@ -1,0 +1,29 @@
+name: Prepare CI cache
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  prepare-yarn-cache:
+    name: Prepare yarn cache for ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+
+      - name: Validate cache
+        env:
+          # Use PnP and disable postinstall scripts as this just needs to
+          # populate the cache for the other jobs
+          YARN_NODE_LINKER: pnp
+          YARN_ENABLE_SCRIPTS: false
+        run: yarn --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
+jobs:
+  test:
+    name: Test on ${{ inputs.os }} using Node.js LTS
+    runs-on: ${{ inputs.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: install
+        run: yarn
+      - name: run tests
+        run: yarn test
+        env:
+          CI: true


### PR DESCRIPTION
@SimenB the OS is included in the cache key, so currently we're only generating a cache for `ubuntu` even though we're running on MacOS & Windows too.