### PR TITLE
perf: cache jest fn call parsing results

### DIFF
--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -181,6 +181,8 @@ const resolvePossibleAliasedGlobal = (
   return null;
 };
 
+const parseJestFnCallCache = new WeakMap();
+
 export const parseJestFnCall = (
   node: TSESTree.CallExpression,
   context: TSESLint.RuleContext<string, unknown[]>,
@@ -195,6 +197,21 @@ export const parseJestFnCall = (
 };
 
 export const parseJestFnCallWithReason = (
+  node: TSESTree.CallExpression,
+  context: TSESLint.RuleContext<string, unknown[]>,
+): ParsedJestFnCall | string | null => {
+  if (parseJestFnCallCache.has(node)) {
+    return parseJestFnCallCache.get(node);
+  }
+
+  const parsedJestFnCall = parseJestFnCallWithReasonInner(node, context);
+
+  parseJestFnCallCache.set(node, parsedJestFnCall);
+
+  return parsedJestFnCall;
+};
+
+const parseJestFnCallWithReasonInner = (
   node: TSESTree.CallExpression,
   context: TSESLint.RuleContext<string, unknown[]>,
 ): ParsedJestFnCall | string | null => {

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -181,7 +181,10 @@ const resolvePossibleAliasedGlobal = (
   return null;
 };
 
-const parseJestFnCallCache = new WeakMap();
+const parseJestFnCallCache = new WeakMap<
+  TSESTree.CallExpression,
+  ParsedJestFnCall | string | null
+>();
 
 export const parseJestFnCall = (
   node: TSESTree.CallExpression,
@@ -200,11 +203,13 @@ export const parseJestFnCallWithReason = (
   node: TSESTree.CallExpression,
   context: TSESLint.RuleContext<string, unknown[]>,
 ): ParsedJestFnCall | string | null => {
-  if (parseJestFnCallCache.has(node)) {
-    return parseJestFnCallCache.get(node);
+  let parsedJestFnCall = parseJestFnCallCache.get(node);
+
+  if (parsedJestFnCall) {
+    return parsedJestFnCall;
   }
 
-  const parsedJestFnCall = parseJestFnCallWithReasonInner(node, context);
+  parsedJestFnCall = parseJestFnCallWithReasonInner(node, context);
 
   parseJestFnCallCache.set(node, parsedJestFnCall);
 


### PR DESCRIPTION
This adds caching to _greatly_ reduce the cost of `parseJestFnCall` - currently most rules now sit around the 300-700ms mark, and this takes them down to about ~30ms (after the initial hit).

Running with `all` against the `jest` codebase:

```
TIMING=1 npx eslint --no-eslintrc --config my-eslint-config.cjs . --ext js,ts,tsx,jsx
```

before:

```
Rule                          | Time (ms) | Relative
:-----------------------------|----------:|--------:
jest/consistent-test-it       |   959.762 |     4.5%
jest/no-standalone-expect     |   866.172 |     4.0%
jest/prefer-expect-assertions |   854.663 |     4.0%
jest/no-conditional-expect    |   798.178 |     3.7%
jest/no-conditional-in-test   |   770.365 |     3.6%
jest/no-duplicate-hooks       |   767.634 |     3.6%
jest/no-identical-title       |   760.904 |     3.5%
jest/no-disabled-tests        |   751.041 |     3.5%
jest/prefer-snapshot-hint     |   749.891 |     3.5%
jest/prefer-hooks-in-order    |   747.734 |     3.5%
```

after:

```
Rule                          | Time (ms) | Relative
:-----------------------------|----------:|--------:
jest/consistent-test-it       |   189.048 |    23.6%
jest/expect-expect            |    53.102 |     6.6%
jest/require-hook             |    50.167 |     6.3%
jest/prefer-expect-assertions |    46.285 |     5.8%
jest/no-standalone-expect     |    32.031 |     4.0%
jest/unbound-method           |    28.302 |     3.5%
jest/no-deprecated-functions  |    25.051 |     3.1%
jest/valid-title              |    24.635 |     3.1%
jest/no-conditional-expect    |    21.598 |     2.7%
jest/no-jasmine-globals       |    16.126 |     2.0%
```

(@SimenB we should make sure that `pref` actually triggers a release before merging this 😅)