### PR TITLE
fix(prefer-mock-promise-shorthand): ignore `mockImplementation` functions that have parameters

### DIFF
--- a/src/rules/__tests__/prefer-mock-promise-shorthand.test.ts
+++ b/src/rules/__tests__/prefer-mock-promise-shorthand.test.ts
@@ -39,6 +39,7 @@ ruleTester.run('prefer-mock-shorthand', rule, {
     'aVariable.mockReturnValue(Promise.reject().then(() => 1))',
     'aVariable.mockReturnValue(new Promise(resolve => resolve(1)))',
     'aVariable.mockReturnValue(new Promise((_, reject) => reject(1)))',
+    "jest.spyOn(Thingy, 'method').mockImplementation(param => Promise.resolve(param));",
     dedent`
       aVariable.mockImplementation(() => {
         const value = new Date();

--- a/src/rules/prefer-mock-promise-shorthand.ts
+++ b/src/rules/prefer-mock-promise-shorthand.ts
@@ -112,7 +112,7 @@ export default createRule({
         } else if (mockFnName === withOnce('mockImplementation', isOnce)) {
           const [arg] = node.arguments;
 
-          if (!isFunction(arg)) {
+          if (!isFunction(arg) || arg.params.length !== 0) {
             return;
           }
 


### PR DESCRIPTION
Resolves #1184