### PR TITLE
feat(no-restricted-matchers): match based on start of chain, requiring each permutation to be set

### DIFF
--- a/docs/rules/no-restricted-matchers.md
+++ b/docs/rules/no-restricted-matchers.md
@@ -8,8 +8,9 @@ alternatives.
 Bans are expressed in the form of a map, with the value being either a string
 message to be shown, or `null` if the default rule message should be used.
 
-Both matchers, modifiers, and chains of the two are checked, allowing for
-specific variations of a matcher to be banned if desired.
+Bans are checked against the start of the `expect` chain - this means that to
+ban a specific matcher entirely you must specify all six permutations, but
+allows you to ban modifiers as well.
 
 By default, this map is empty, meaning no matchers or modifiers are banned.
 
@@ -22,7 +23,12 @@ For example:
     {
       "toBeFalsy": null,
       "resolves": "Use `expect(await promise)` instead.",
-      "not.toHaveBeenCalledWith": null
+      "toHaveBeenCalledWith": null,
+      "not.toHaveBeenCalledWith": null,
+      "resolves.toHaveBeenCalledWith": null,
+      "rejects.toHaveBeenCalledWith": null,
+      "resolves.not.toHaveBeenCalledWith": null,
+      "rejects.not.toHaveBeenCalledWith": null
     }
   ]
 }
@@ -32,15 +38,18 @@ Examples of **incorrect** code for this rule with the above configuration
 
 ```js
 it('is false', () => {
+  // if this has a modifer (i.e. `not.toBeFalsy`), it would be considered fine
   expect(a).toBeFalsy();
 });
 
 it('resolves', async () => {
+  // all uses of this modifier are disallowed, regardless of matcher
   await expect(myPromise()).resolves.toBe(true);
 });
 
 describe('when an error happens', () => {
   it('does not upload the file', async () => {
+    // all uses of this matcher are disallowed
     expect(uploadFileMock).not.toHaveBeenCalledWith('file.name');
   });
 });

--- a/src/rules/__tests__/no-restricted-matchers.test.ts
+++ b/src/rules/__tests__/no-restricted-matchers.test.ts
@@ -37,6 +37,26 @@ ruleTester.run('no-restricted-matchers', rule, {
       code: 'expect(a)["toBe"](b)',
       options: [{ 'not.toBe': null }],
     },
+    {
+      code: 'expect(a).resolves.not.toBe(b)',
+      options: [{ not: null }],
+    },
+    {
+      code: 'expect(a).resolves.not.toBe(b)',
+      options: [{ 'not.toBe': null }],
+    },
+    {
+      code: "expect(uploadFileMock).resolves.toHaveBeenCalledWith('file.name')",
+      options: [
+        { 'not.toHaveBeenCalledWith': 'Use not.toHaveBeenCalled instead' },
+      ],
+    },
+    {
+      code: "expect(uploadFileMock).resolves.not.toHaveBeenCalledWith('file.name')",
+      options: [
+        { 'not.toHaveBeenCalledWith': 'Use not.toHaveBeenCalled instead' },
+      ],
+    },
   ],
   invalid: [
     {
@@ -47,7 +67,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'toBe',
+            restriction: 'toBe',
           },
           column: 11,
           line: 1,
@@ -62,7 +82,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'toBe',
+            restriction: 'toBe',
           },
           column: 11,
           line: 1,
@@ -77,7 +97,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'not',
+            restriction: 'not',
           },
           column: 11,
           line: 1,
@@ -92,7 +112,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'not',
+            restriction: 'not',
           },
           column: 11,
           line: 1,
@@ -107,24 +127,9 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'resolves',
+            restriction: 'resolves',
           },
           column: 11,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'expect(a).resolves.not.toBe(b)',
-      options: [{ not: null }],
-      errors: [
-        {
-          messageId: 'restrictedChain',
-          data: {
-            message: null,
-            chain: 'not',
-          },
-          column: 20,
           line: 1,
         },
       ],
@@ -137,7 +142,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'resolves',
+            restriction: 'resolves',
           },
           column: 11,
           line: 1,
@@ -152,25 +157,9 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'resolves.not',
+            restriction: 'resolves.not',
           },
           column: 11,
-          line: 1,
-        },
-      ],
-    },
-    {
-      code: 'expect(a).resolves.not.toBe(b)',
-      options: [{ 'not.toBe': null }],
-      errors: [
-        {
-          messageId: 'restrictedChain',
-          data: {
-            message: null,
-            chain: 'not.toBe',
-          },
-          endColumn: 28,
-          column: 20,
           line: 1,
         },
       ],
@@ -183,7 +172,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'not.toBe',
+            restriction: 'not.toBe',
           },
           endColumn: 19,
           column: 11,
@@ -199,7 +188,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'resolves.not.toBe',
+            restriction: 'resolves.not.toBe',
           },
           endColumn: 28,
           column: 11,
@@ -215,7 +204,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChainWithMessage',
           data: {
             message: 'Prefer `toStrictEqual` instead',
-            chain: 'toBe',
+            restriction: 'toBe',
           },
           column: 11,
           line: 1,
@@ -234,25 +223,25 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChainWithMessage',
           data: {
             message: 'Use `expect(await promise)` instead.',
-            chain: 'resolves',
+            restriction: 'resolves',
           },
-          endColumn: 52,
+          endColumn: 57,
           column: 44,
         },
       ],
     },
     {
       code: 'expect(Promise.resolve({})).rejects.toBeFalsy()',
-      options: [{ toBeFalsy: null }],
+      options: [{ 'rejects.toBeFalsy': null }],
       errors: [
         {
           messageId: 'restrictedChain',
           data: {
             message: null,
-            chain: 'toBeFalsy',
+            restriction: 'rejects.toBeFalsy',
           },
           endColumn: 46,
-          column: 37,
+          column: 29,
         },
       ],
     },
@@ -266,7 +255,7 @@ ruleTester.run('no-restricted-matchers', rule, {
           messageId: 'restrictedChainWithMessage',
           data: {
             message: 'Use not.toHaveBeenCalled instead',
-            chain: 'not.toHaveBeenCalledWith',
+            restriction: 'not.toHaveBeenCalledWith',
           },
           endColumn: 48,
           column: 24,


### PR DESCRIPTION
BREAKING CHANGE

Resolves #1156

This messed my head up a little trying to come up with an intuitive interface that let you shortcut the config a bit i.e. by allowing `*` * `**`, but it always came out feeling brittle and hard to explain or dropping support for restricting modifiers; in the end I realised changing the check to just be `startsWith`  gets us what we want while being easy to understand.