### PR TITLE
feat: make `no-alias-methods` recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ installations requiring long-term consistency.
 | [expect-expect](docs/rules/expect-expect.md)                                 | Enforce assertion to be made in a test body                         | ![recommended][] |              |
 | [max-expects](docs/rules/max-expects.md)                                     | Enforces a maximum number assertion calls in a test body            |                  |              |
 | [max-nested-describe](docs/rules/max-nested-describe.md)                     | Enforces a maximum depth to nested describe calls                   |                  |              |
-| [no-alias-methods](docs/rules/no-alias-methods.md)                           | Disallow alias methods                                              | ![style][]       | ![fixable][] |
+| [no-alias-methods](docs/rules/no-alias-methods.md)                           | Disallow alias methods                                              | ![recommended][] | ![fixable][] |
 | [no-commented-out-tests](docs/rules/no-commented-out-tests.md)               | Disallow commented out tests                                        | ![recommended][] |              |
 | [no-conditional-expect](docs/rules/no-conditional-expect.md)                 | Prevent calling `expect` conditionally                              | ![recommended][] |              |
 | [no-conditional-in-test](docs/rules/no-conditional-in-test.md)               | Disallow conditional logic in tests                                 |                  |              |

--- a/docs/rules/no-alias-methods.md
+++ b/docs/rules/no-alias-methods.md
@@ -1,5 +1,8 @@
 # Disallow alias methods (`no-alias-methods`)
 
+> These aliases are going to be removed in the next major version of Jest - see
+> https://github.com/facebook/jest/issues/13164 for more
+
 Several Jest methods have alias names, such as `toThrow` having the alias of
 `toThrowError`. This rule ensures that only the canonical name as used in the
 Jest documentation is used in the code. This makes it easier to search for all

--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -70,6 +70,7 @@ exports[`rules should export configs that refer to actual rules 1`] = `
     ],
     "rules": {
       "jest/expect-expect": "warn",
+      "jest/no-alias-methods": "error",
       "jest/no-commented-out-tests": "warn",
       "jest/no-conditional-expect": "error",
       "jest/no-deprecated-functions": "error",

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -11,7 +11,7 @@ export default createRule({
     docs: {
       category: 'Best Practices',
       description: 'Disallow alias methods',
-      recommended: false,
+      recommended: 'error',
     },
     messages: {
       replaceAlias: `Replace {{ alias }}() with its canonical name of {{ canonical }}()`,


### PR DESCRIPTION
BREAKING CHANGE: `no-alias-methods` is now recommended as the methods themselves will be removed in
the next major version of Jest

Per https://github.com/facebook/jest/issues/13164

I'm the fence about if we fold this into `no-deprecated-methods` as it would be mostly a copy & paste, but on the other hand I don't like the fact that this uses "methods" when really its "matchers" - still, I've stuck with the current rule for now because its the smaller change. (tbh it wouldn't be wrong to have both rules checking this for a while either 🤷 )