### PR TITLE
chore: remove obsolete `meta.docs.suggestion` property

### DIFF
--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -30,7 +30,6 @@ export default createRule({
       category: 'Best Practices',
       description: 'Avoid using a callback in asynchronous tests and hooks',
       recommended: 'error',
-      suggestion: true,
     },
     messages: {
       noDoneCallback:

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -8,7 +8,6 @@ export default createRule({
       category: 'Best Practices',
       description: 'Disallow focused tests',
       recommended: 'error',
-      suggestion: true,
     },
     messages: {
       focusedTest: 'Unexpected focused test.',

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -16,7 +16,6 @@ export default createRule({
       category: 'Best Practices',
       description: 'Suggest using the built-in equality matchers',
       recommended: false,
-      suggestion: true,
     },
     messages: {
       useEqualityMatcher: 'Prefer using one of the equality matchers instead',

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -65,7 +65,6 @@ export default createRule<[RuleOptions], MessageIds>({
       description:
         'Suggest using `expect.assertions()` OR `expect.hasAssertions()`',
       recommended: false,
-      suggestion: true,
     },
     messages: {
       hasAssertionsTakesNoArguments:

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -13,7 +13,6 @@ export default createRule({
       category: 'Best Practices',
       description: 'Suggest using `toStrictEqual()`',
       recommended: false,
-      suggestion: true,
     },
     messages: {
       useToStrictEqual: 'Use `toStrictEqual()` instead',


### PR DESCRIPTION
`meta.docs.suggestion` was replaced by `meta.hasSuggestions` as of ESLint v8: https://github.com/eslint/eslint/pull/14573

The old property was never used for anything, while the presence of the new property is [enforced](https://eslint.org/docs/latest/user-guide/migrating-to-8.0.0#suggestions) by ESLint when a rule provides suggestions.

It's confusing to leave the old, redundant property in place, so I have removed it here.