### PR TITLE
fix(prefer-expect-assertions): report on concise arrow functions with `expect` call

### DIFF
--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -116,6 +116,28 @@ ruleTester.run('prefer-expect-assertions', rule, {
       ],
     },
     {
+      code: "it('resolves', () => expect(staged()).toBe(true));",
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+          suggestions: null,
+        },
+      ],
+    },
+    {
+      code: "it('resolves', async () => expect(await staged()).toBe(true));",
+      errors: [
+        {
+          messageId: 'haveExpectAssertions',
+          column: 1,
+          line: 1,
+          suggestions: null,
+        },
+      ],
+    },
+    {
       code: 'it("it1", () => {})',
       errors: [
         {

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -16,6 +16,12 @@ const isFirstStatement = (node: TSESTree.CallExpression): boolean => {
       return parent.parent.body[0] === parent;
     }
 
+    // if we've hit an arrow function, then it must have a single expression
+    // as its body, as otherwise we would have hit the block statement already
+    if (parent.parent?.type === AST_NODE_TYPES.ArrowFunctionExpression) {
+      return true;
+    }
+
     parent = parent.parent;
   }
 
@@ -51,11 +57,6 @@ type MessageIds =
   | 'suggestAddingHasAssertions'
   | 'suggestAddingAssertions'
   | 'suggestRemovingExtraArguments';
-
-// const suggestions: Array<[MessageIds, string]> = [
-//   ['suggestAddingHasAssertions', 'expect.hasAssertions();'],
-//   ['suggestAddingAssertions', 'expect.assertions();'],
-// ];
 
 export default createRule<[RuleOptions], MessageIds>({
   name: __filename,


### PR DESCRIPTION
Resolves #1223