### PR TITLE
docs: update removal details in `no-deprecated-functions`

### DIFF
--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -24,7 +24,8 @@ This function was renamed to `resetModules` in Jest 15 and removed in Jest 27.
 
 ### `jest.addMatchers`
 
-This function was replaced with `expect.extend` in Jest 17 and removed in Jest 27.
+This function was replaced with `expect.extend` in Jest 17 and removed in
+Jest 27.
 
 ### `require.requireActual` & `require.requireMock`
 
@@ -39,7 +40,8 @@ the release of Jest 26 saw them removed from the `require` function altogether.
 
 ### `jest.runTimersToTime`
 
-This function was renamed to `advanceTimersByTime` in Jest 22 and removed in Jest 27.
+This function was renamed to `advanceTimersByTime` in Jest 22 and removed in
+Jest 27.
 
 ### `jest.genMockFromModule`
 

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -20,13 +20,11 @@ This rule can also autofix a number of these deprecations for you.
 
 ### `jest.resetModuleRegistry`
 
-This function was renamed to `resetModules` in Jest 15, and is scheduled for
-removal in Jest 27.
+This function was renamed to `resetModules` in Jest 15 and removed in Jest 27.
 
 ### `jest.addMatchers`
 
-This function was replaced with `expect.extend` in Jest 17, and is scheduled for
-removal in Jest 27.
+This function was replaced with `expect.extend` in Jest 17 and removed in Jest 27.
 
 ### `require.requireActual` & `require.requireMock`
 
@@ -41,10 +39,9 @@ the release of Jest 26 saw them removed from the `require` function altogether.
 
 ### `jest.runTimersToTime`
 
-This function was renamed to `advanceTimersByTime` in Jest 22, and is scheduled
-for removal in Jest 27.
+This function was renamed to `advanceTimersByTime` in Jest 22 and removed in Jest 27.
 
 ### `jest.genMockFromModule`
 
 This function was renamed to `createMockFromModule` in Jest 26, and is scheduled
-for removal in a future version of Jest.
+for removal in Jest 30.


### PR DESCRIPTION
Some removal details could be update in `no-deprecated-functions` rule details.

Methods which were scheduled to be removed in Jest 27 are already gone. See #9853

And `jest.genMockFromModule` is now scheduled to be removed in Jest 30: https://github.com/facebook/jest/blob/0cfc2ad2991373324306c8daf962c41d0f37793c/packages/jest-environment/src/index.ts#L132-L142