### PR TITLE
fix(no-restricted-matchers): improve check to not be solely based on the start of the matcher chain

### DIFF
--- a/src/rules/__tests__/no-restricted-matchers.test.ts
+++ b/src/rules/__tests__/no-restricted-matchers.test.ts
@@ -34,6 +34,10 @@ ruleTester.run('no-restricted-matchers', rule, {
       options: [{ 'not.toBe': null }],
     },
     {
+      code: 'expect(a).toBeUndefined(b)',
+      options: [{ toBe: null }],
+    },
+    {
       code: 'expect(a)["toBe"](b)',
       options: [{ 'not.toBe': null }],
     },

--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -1,4 +1,20 @@
-import { createRule, getAccessorValue, parseJestFnCall } from './utils';
+import {
+  ModifierName,
+  createRule,
+  getAccessorValue,
+  parseJestFnCall,
+} from './utils';
+
+const isChainRestricted = (chain: string, restriction: string): boolean => {
+  if (
+    ModifierName.hasOwnProperty(restriction) ||
+    restriction.endsWith('.not')
+  ) {
+    return chain.startsWith(restriction);
+  }
+
+  return chain === restriction;
+};
 
 export default createRule<
   [Record<string, string | null>],
@@ -40,7 +56,7 @@ export default createRule<
           .join('.');
 
         for (const [restriction, message] of Object.entries(restrictedChains)) {
-          if (chain.startsWith(restriction)) {
+          if (isChainRestricted(chain, restriction)) {
             context.report({
               messageId: message
                 ? 'restrictedChainWithMessage'


### PR DESCRIPTION
Resolves #1235 