### PR TITLE
fix: ensure jest globals are enabled in `styles` config

### DIFF
--- a/src/__tests__/__snapshots__/rules.test.ts.snap
+++ b/src/__tests__/__snapshots__/rules.test.ts.snap
@@ -91,6 +91,9 @@ exports[`rules should export configs that refer to actual rules 1`] = `
     },
   },
   "style": {
+    "env": {
+      "jest/globals": true,
+    },
     "plugins": [
       "jest",
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,15 +68,12 @@ export = {
   configs: {
     all: createConfig(allRules),
     recommended: createConfig(recommendedRules),
-    style: {
-      plugins: ['jest'],
-      rules: {
-        'jest/no-alias-methods': 'warn',
-        'jest/prefer-to-be': 'error',
-        'jest/prefer-to-contain': 'error',
-        'jest/prefer-to-have-length': 'error',
-      },
-    },
+    style: createConfig({
+      'jest/no-alias-methods': 'warn',
+      'jest/prefer-to-be': 'error',
+      'jest/prefer-to-contain': 'error',
+      'jest/prefer-to-have-length': 'error',
+    }),
   },
   environments: {
     globals: {


### PR DESCRIPTION
This lets us avoid having to do ugly things in #1226 when accessing `configs[config].rules[rule]` (which currently we're `@ts-ignore`-ing) because it makes all configs of the same type.

I've labeled this as a fix because I think that is technically true given we're being inconsistent vs the other configs; this also could arguably be a breaking change and we have also spoken about removing the globals at some point once we had proper scope resolving.

@SimenB will wait for you to weight in on if you're happy to land this or if you think it should be in a major version (in which case I'll do something different)