### PR TITLE
chore: use `@tsconfig/node14` and stricter TS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "@schemastore/package": "^0.0.6",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
+    "@tsconfig/node14": "^1.0.3",
     "@types/dedent": "^0.7.0",
     "@types/jest": "^29.0.0",
     "@types/node": "^14.18.26",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 import globals from './globals.json';
 import * as snapshotProcessor from './processors/snapshot-processor';
 

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 import { createRule } from './utils';
 
 function hasTests(node: TSESTree.Comment) {

--- a/src/rules/no-conditional-in-test.ts
+++ b/src/rules/no-conditional-in-test.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 import { createRule, isTypeOfJestFnCall } from './utils';
 
 export default createRule({

--- a/src/rules/no-mocks-import.ts
+++ b/src/rules/no-mocks-import.ts
@@ -1,5 +1,5 @@
 import { posix } from 'path';
-import { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 import { createRule, getStringValue, isStringNode } from './utils';
 
 const mocksDirName = '__mocks__';

--- a/src/rules/prefer-each.ts
+++ b/src/rules/prefer-each.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 import { JestFnType, createRule, parseJestFnCall } from './utils';
 
 export default createRule({

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -1,4 +1,4 @@
-import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   CallExpressionWithSingleArgument,
   DescribeAlias,

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -1,4 +1,4 @@
-import { TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 import { createRule, isTypeOfJestFnCall, parseJestFnCall } from './utils';
 
 const messages = {

--- a/src/rules/utils/__tests__/detectJestVersion.test.ts
+++ b/src/rules/utils/__tests__/detectJestVersion.test.ts
@@ -2,7 +2,7 @@ import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
+import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import { create } from 'ts-node';
 import { detectJestVersion } from '../detectJestVersion';
 

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -1,4 +1,4 @@
-import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
+import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import { espreeParser } from '../../__tests__/test-utils';
@@ -76,7 +76,7 @@ const rule = createRule({
           messageId: 'details',
           node,
           data: {
-            data: JSON.stringify(sorted, (key, value) => {
+            data: JSON.stringify(sorted, (_key, value) => {
               if (isNode(value)) {
                 if (isSupportedAccessor(value)) {
                   return getAccessorValue(value);

--- a/src/rules/utils/detectJestVersion.ts
+++ b/src/rules/utils/detectJestVersion.ts
@@ -1,4 +1,4 @@
-import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
+import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 
 export type JestVersion =
   | 14

--- a/tools/regenerate-docs.ts
+++ b/tools/regenerate-docs.ts
@@ -2,7 +2,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { TSESLint } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 import prettier, { Options } from 'prettier';
 import { prettier as prettierRC } from '../package.json';
 import config from '../src/index';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,25 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "target": "es2015",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "lib": ["es2018"],
     "noEmit": true,
+    "importsNotUsedAsValues": "error",
+    "stripInternal": true,
+
+    /* Additional Checks */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": false,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*", "tools/**/*"]
+  "include": ["src/**/*", "tools/**/*"],
+  "exclude": ["src/rules/__tests__/fixtures/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
+    "moduleResolution": "node",
     "noEmit": true,
     "importsNotUsedAsValues": "error",
     "stripInternal": true,
@@ -12,7 +13,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
 
-    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,7 +2506,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node14@npm:^1.0.0":
+"@tsconfig/node14@npm:^1.0.0, @tsconfig/node14@npm:^1.0.3":
   version: 1.0.3
   resolution: "@tsconfig/node14@npm:1.0.3"
   checksum: 19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
@@ -4570,6 +4570,7 @@ __metadata:
     "@schemastore/package": ^0.0.6
     "@semantic-release/changelog": ^6.0.0
     "@semantic-release/git": ^10.0.0
+    "@tsconfig/node14": ^1.0.3
     "@types/dedent": ^0.7.0
     "@types/jest": ^29.0.0
     "@types/node": ^14.18.26


### PR DESCRIPTION
#1226 fails CI due to "missing" `flatMap` - instead of manually defining `lib` etc., extending `@tsconfig/node14` seems cleaner