### PR TITLE
docs(prefer-expect-resolves): adjust incorrect example snippet

### DIFF
--- a/docs/rules/prefer-expect-resolves.md
+++ b/docs/rules/prefer-expect-resolves.md
@@ -58,6 +58,8 @@ it('is true', async () => {
 });
 
 it('errors', async () => {
-  await expect(Promise.rejects('oh noes!')).rejects.toThrow('oh noes!');
+  await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
+    'oh noes!',
+  );
 });
 ```

--- a/src/rules/__tests__/prefer-expect-resolves.test.ts
+++ b/src/rules/__tests__/prefer-expect-resolves.test.ts
@@ -27,7 +27,9 @@ ruleTester.run('prefer-expect-resolves', rule, {
     `,
     dedent`
       it('errors', async () => {
-        await expect(Promise.rejects('oh noes!')).rejects.toThrow('oh noes!');
+        await expect(Promise.reject(new Error('oh noes!'))).rejects.toThrowError(
+          'oh noes!',
+        );
       });
     `,
   ],


### PR DESCRIPTION
Credit goes to @fauxbytes for noticing this 😅 