### PR TITLE
docs: correct typo in description

### DIFF
--- a/docs/rules/no-restricted-jest-methods.md
+++ b/docs/rules/no-restricted-jest-methods.md
@@ -11,7 +11,7 @@ You may wish to restrict the use of specific `jest` methods.
 ## Rule details
 
 This rule checks for the usage of specific methods on the `jest` object, which
-can be used to disallow curtain patterns such as spies and mocks.
+can be used to disallow certain patterns such as spies and mocks.
 
 ## Options
 


### PR DESCRIPTION
There was a minor typo in the description

`curtain` vs. `certain` 😉 

see https://github.com/jest-community/eslint-plugin-jest/pull/1257#pullrequestreview-1129892834