### PR TITLE
fix(prefer-to-be): support negative numbers

### DIFF
--- a/src/rules/__tests__/prefer-to-be.test.ts
+++ b/src/rules/__tests__/prefer-to-be.test.ts
@@ -14,6 +14,7 @@ ruleTester.run('prefer-to-be', rule, {
     'expect(null).toBeNull();',
     'expect(null).not.toBeNull();',
     'expect(null).toBe(1);',
+    'expect(null).toBe(-1);',
     'expect(null).toBe(...1);',
     'expect(obj).toStrictEqual([ x, 1 ]);',
     'expect(obj).toStrictEqual({ x: 1 });',
@@ -39,6 +40,11 @@ ruleTester.run('prefer-to-be', rule, {
     {
       code: 'expect(value).toStrictEqual(1);',
       output: 'expect(value).toBe(1);',
+      errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
+    },
+    {
+      code: 'expect(value).toStrictEqual(-1);',
+      output: 'expect(value).toBe(-1);',
       errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
     },
     {
@@ -309,6 +315,11 @@ new TSESLint.RuleTester({
     {
       code: 'expect(null).toEqual(1 as unknown as string as unknown as any);',
       output: 'expect(null).toBe(1 as unknown as string as unknown as any);',
+      errors: [{ messageId: 'useToBe', column: 14, line: 1 }],
+    },
+    {
+      code: 'expect(null).toEqual(-1 as unknown as string as unknown as any);',
+      output: 'expect(null).toBe(-1 as unknown as string as unknown as any);',
       errors: [{ messageId: 'useToBe', column: 14, line: 1 }],
     },
     {

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -27,7 +27,14 @@ const isFirstArgumentIdentifier = (
 ) => isIdentifier(getFirstMatcherArg(expectFnCall), name);
 
 const shouldUseToBe = (expectFnCall: ParsedExpectFnCall): boolean => {
-  const firstArg = getFirstMatcherArg(expectFnCall);
+  let firstArg = getFirstMatcherArg(expectFnCall);
+
+  if (
+    firstArg.type === AST_NODE_TYPES.UnaryExpression &&
+    firstArg.operator === '-'
+  ) {
+    firstArg = firstArg.argument;
+  }
 
   if (firstArg.type === AST_NODE_TYPES.Literal) {
     // regex literals are classed as literals, but they're actually objects


### PR DESCRIPTION
Hello,

I felt like `prefer-to-be` rule should support also negative numbers so I **tried** to implement it. I will be glad for feedback and improvement suggestions. I'm also not sure if it's feature or bug.