### PR TITLE
Fix typo: possessive it's should be its

### DIFF
--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -347,7 +347,7 @@ export default createRule({
     },
     messages: {
       expectInFloatingPromise:
-        "This promise should either be returned or awaited to ensure the expects in it's chain are called",
+        'This promise should either be returned or awaited to ensure the expects in its chain are called',
     },
     type: 'suggestion',
     schema: [],


### PR DESCRIPTION
Fix a typo in `valid-expect-in-promise` that uses [`it's` as a possessive instead of the correct `its`](https://www.merriam-webster.com/words-at-play/when-to-use-its-vs-its):

```
   17:5  error  This promise should either be returned or awaited to ensure the expects in it's chain are called  jest/valid-expect-in-promise
```