### PR TITLE
docs: use correct spelling of "grammar"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Bug Fixes
 
-* **valid-expect-in-promise:** adjust grammer in rule message ([#1264](https://github.com/jest-community/eslint-plugin-jest/issues/1264)) ([4494ed2](https://github.com/jest-community/eslint-plugin-jest/commit/4494ed21686edeb1bc4535cb2159989f87a7493e))
+* **valid-expect-in-promise:** adjust grammar in rule message ([#1264](https://github.com/jest-community/eslint-plugin-jest/issues/1264)) ([4494ed2](https://github.com/jest-community/eslint-plugin-jest/commit/4494ed21686edeb1bc4535cb2159989f87a7493e))
 
 ## [27.1.1](https://github.com/jest-community/eslint-plugin-jest/compare/v27.1.0...v27.1.1) (2022-10-05)
 


### PR DESCRIPTION
I can't fix it in the actual commit, but at least it'll be resolved here 🤷 