### PR TITLE
fix(no-restricted-jest-methods): don't crash on `jest()`

### DIFF
--- a/src/rules/__tests__/no-restricted-jest-methods.test.ts
+++ b/src/rules/__tests__/no-restricted-jest-methods.test.ts
@@ -13,6 +13,7 @@ const ruleTester = new TSESLint.RuleTester({
 ruleTester.run('no-restricted-jest-methods', rule, {
   valid: [
     'jest',
+    'jest()',
     'jest.mock()',
     'expect(a).rejects;',
     'expect(a);',

--- a/src/rules/no-restricted-jest-methods.ts
+++ b/src/rules/no-restricted-jest-methods.ts
@@ -33,7 +33,7 @@ export default createRule<
       CallExpression(node) {
         const jestFnCall = parseJestFnCall(node, context);
 
-        if (jestFnCall?.type !== 'jest') {
+        if (jestFnCall?.type !== 'jest' || jestFnCall.members.length === 0) {
           return;
         }
 


### PR DESCRIPTION
Resolves #1266