### PR TITLE
refactor: inline `collectReferences` utility into `scopeHasLocalReference`

### DIFF
--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -514,42 +514,6 @@ const describePossibleImportDef = (def: TSESLint.Scope.Definition) => {
   return null;
 };
 
-const collectReferences = (scope: TSESLint.Scope.Scope) => {
-  const locals = new Set();
-  const imports = new Map<string, ImportDetails>();
-  const unresolved = new Set();
-
-  let currentScope: TSESLint.Scope.Scope | null = scope;
-
-  while (currentScope !== null) {
-    for (const ref of currentScope.variables) {
-      if (ref.defs.length === 0) {
-        continue;
-      }
-
-      const def = ref.defs[ref.defs.length - 1];
-
-      const importDetails = describePossibleImportDef(def);
-
-      if (importDetails) {
-        imports.set(importDetails.local, importDetails);
-
-        continue;
-      }
-
-      locals.add(ref.name);
-    }
-
-    for (const ref of currentScope.through) {
-      unresolved.add(ref.identifier.name);
-    }
-
-    currentScope = currentScope.upper;
-  }
-
-  return { locals, imports, unresolved };
-};
-
 const resolveScope = (scope: TSESLint.Scope.Scope, identifier: string) => {
   let currentScope: TSESLint.Scope.Scope | null = scope;
 
@@ -621,15 +585,38 @@ export const scopeHasLocalReference = (
   scope: TSESLint.Scope.Scope,
   referenceName: string,
 ) => {
-  const references = collectReferences(scope);
+  let unresolved = false;
+  let currentScope: TSESLint.Scope.Scope | null = scope;
 
-  return (
-    // referenceName was found as a local variable or function declaration.
-    references.locals.has(referenceName) ||
-    // referenceName was found as an imported identifier
-    references.imports.has(referenceName) ||
-    // referenceName was not found as an unresolved reference,
-    // meaning it is likely not an implicit global reference.
-    !references.unresolved.has(referenceName)
-  );
+  while (currentScope !== null) {
+    for (const ref of currentScope.variables) {
+      if (ref.defs.length === 0) {
+        continue;
+      }
+
+      const def = ref.defs[ref.defs.length - 1];
+
+      const importDetails = describePossibleImportDef(def);
+
+      // referenceName was found as an imported identifier
+      if (importDetails?.local === referenceName) {
+        return true;
+      }
+
+      // referenceName was found as a local variable or function declaration.
+      if (ref.name === referenceName) {
+        return true;
+      }
+    }
+
+    if (!unresolved) {
+      for (const ref of currentScope.through) {
+        unresolved = ref.identifier.name !== referenceName;
+      }
+    }
+
+    currentScope = currentScope.upper;
+  }
+
+  return unresolved;
 };

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -603,15 +603,7 @@ export const scopeHasLocalReference = (
       }
 
       // referenceName was found as a local variable or function declaration.
-      if (ref.name === referenceName) {
-        return true;
-      }
-    }
-
-    if (
-      currentScope.through.every(ref => ref.identifier.name !== referenceName)
-    ) {
-      return true;
+      return ref.name === referenceName;
     }
 
     currentScope = currentScope.upper;

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -585,7 +585,6 @@ export const scopeHasLocalReference = (
   scope: TSESLint.Scope.Scope,
   referenceName: string,
 ) => {
-  let unresolved = false;
   let currentScope: TSESLint.Scope.Scope | null = scope;
 
   while (currentScope !== null) {
@@ -609,14 +608,14 @@ export const scopeHasLocalReference = (
       }
     }
 
-    if (!unresolved) {
-      for (const ref of currentScope.through) {
-        unresolved = ref.identifier.name !== referenceName;
-      }
+    if (
+      currentScope.through.every(ref => ref.identifier.name !== referenceName)
+    ) {
+      return true;
     }
 
     currentScope = currentScope.upper;
   }
 
-  return unresolved;
+  return false;
 };


### PR DESCRIPTION
Follow on to #1274 & #1275 - in theory this is faster but it has no noticeable impact on performance so I'm marking this as a refactor rather than `perf`.

The actual reason I'm doing it in the first place is because it makes the codebase a little smaller and we don't really need the two functions anymore.