### PR TITLE
perf: use `Set` instead of iterating, and deduplicate a function

### DIFF
--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -2,7 +2,7 @@ import {
   createRule,
   getAccessorValue,
   parseJestFnCall,
-  scopeHasLocalReference,
+  resolveScope,
 } from './utils';
 
 export default createRule({
@@ -80,7 +80,7 @@ export default createRule({
         }
       },
       'CallExpression[callee.name="pending"]'(node) {
-        if (scopeHasLocalReference(context.getScope(), 'pending')) {
+        if (resolveScope(context.getScope(), 'pending')) {
           return;
         }
 

--- a/src/rules/no-jasmine-globals.ts
+++ b/src/rules/no-jasmine-globals.ts
@@ -3,7 +3,7 @@ import {
   createRule,
   getNodeName,
   isSupportedAccessor,
-  scopeHasLocalReference,
+  resolveScope,
 } from './utils';
 
 export default createRule({
@@ -46,7 +46,7 @@ export default createRule({
           calleeName === 'fail' ||
           calleeName === 'pending'
         ) {
-          if (scopeHasLocalReference(context.getScope(), calleeName)) {
+          if (resolveScope(context.getScope(), calleeName)) {
             // It's a local variable, not a jasmine global.
             return;
           }

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -449,6 +449,15 @@ ruleTester.run('esm', rule, {
       `,
       parserOptions: { sourceType: 'module' },
     },
+    {
+      code: dedent`
+        async function doSomething() {
+          const build = await rollup(config);
+          build.generate();
+        }
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2017 },
+    },
   ],
   invalid: [],
 });

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -799,6 +799,14 @@ ruleTester.run('typescript', rule, {
       parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: { sourceType: 'module' },
     },
+    {
+      code: dedent`
+        import dedent = require('dedent');
+
+        dedent();
+      `,
+      parser: require.resolve('@typescript-eslint/parser'),
+    },
   ],
   invalid: [
     {

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -441,6 +441,14 @@ ruleTester.run('esm', rule, {
       `,
       parserOptions: { sourceType: 'module' },
     },
+    {
+      code: dedent`
+        import ByDefault from './myfile';
+
+        ByDefault.sayHello();
+      `,
+      parserOptions: { sourceType: 'module' },
+    },
   ],
   invalid: [],
 });

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -422,11 +422,8 @@ const describeImportDefAsImport = (
     );
   }
 
-  /* istanbul ignore if */
   if (def.node.type !== AST_NODE_TYPES.ImportSpecifier) {
-    throw new Error(
-      `Did not expect a ${def.node.type} here - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-    );
+    return null;
   }
 
   // we only care about value imports

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -415,11 +415,8 @@ interface ImportDetails {
 const describeImportDefAsImport = (
   def: TSESLint.Scope.Definitions.ImportBindingDefinition,
 ): ImportDetails | null => {
-  /* istanbul ignore if */
   if (def.parent.type === AST_NODE_TYPES.TSImportEqualsDeclaration) {
-    throw new Error(
-      `Did not expect a ${def.parent.type} here - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-    );
+    return null;
   }
 
   if (def.node.type !== AST_NODE_TYPES.ImportSpecifier) {

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -514,7 +514,10 @@ const describePossibleImportDef = (def: TSESLint.Scope.Definition) => {
   return null;
 };
 
-const resolveScope = (scope: TSESLint.Scope.Scope, identifier: string) => {
+export const resolveScope = (
+  scope: TSESLint.Scope.Scope,
+  identifier: string,
+): ImportDetails | 'local' | null => {
   let currentScope: TSESLint.Scope.Scope | null = scope;
 
   while (currentScope !== null) {
@@ -575,33 +578,4 @@ const resolveToJestFn = (
     local: identifier,
     type: 'global',
   };
-};
-
-export const scopeHasLocalReference = (
-  scope: TSESLint.Scope.Scope,
-  referenceName: string,
-) => {
-  let currentScope: TSESLint.Scope.Scope | null = scope;
-
-  while (currentScope !== null) {
-    const ref = currentScope.set.get(referenceName);
-
-    if (ref && ref.defs.length > 0) {
-      const def = ref.defs[ref.defs.length - 1];
-
-      const importDetails = describePossibleImportDef(def);
-
-      // referenceName was found as an imported identifier
-      if (importDetails?.local === referenceName) {
-        return true;
-      }
-
-      // referenceName was found as a local variable or function declaration.
-      return ref.name === referenceName;
-    }
-
-    currentScope = currentScope.upper;
-  }
-
-  return false;
 };

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -449,14 +449,11 @@ const findImportSourceNode = (
   node: TSESTree.Expression,
 ): TSESTree.Node | null => {
   if (node.type === AST_NODE_TYPES.AwaitExpression) {
-    /* istanbul ignore if */
-    if (node.argument.type !== AST_NODE_TYPES.ImportExpression) {
-      throw new Error(
-        `Did not expect a ${node.argument.type} here - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-      );
+    if (node.argument.type === AST_NODE_TYPES.ImportExpression) {
+      return node.argument.source;
     }
 
-    return node.argument.source;
+    return null;
   }
 
   if (


### PR DESCRIPTION
This greatly improves performance when running on _huge_ projects - I can't see any difference when running against the Jest codebase, but if I stick 3-4 copies of `typescript.js` (which is 10mb in size) then without this linting takes more than 3 minutes (I didn't let it finish) whereas afterwards it takes 30-60 seconds.

Weirdly this has also highlighted some test cases that apparently we didn't have yet somehow our coverage which has made me a little suspect that this could have changed behaviours, but all our tests are passing and there's no way to know for sure without having someone try this 🤷

Finally, I realised that `scopeHasLocalReference` is actually a complete duplication of `resolveScope` so have replaced that.
