### PR TITLE
refactor(valid-title): use `substring` instead of `substr`

### DIFF
--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -10,7 +10,7 @@ import {
 } from './utils';
 
 const trimFXprefix = (word: string) =>
-  ['f', 'x'].includes(word.charAt(0)) ? word.substr(1) : word;
+  ['f', 'x'].includes(word.charAt(0)) ? word.substring(1) : word;
 
 const doesBinaryExpressionContainStringNode = (
   binaryExp: TSESTree.BinaryExpression,


### PR DESCRIPTION
`substr` is actually non-spec - its very unlikely to ever go away, but we're using `substring` everywhere else and IDEs flag it as deprecated so might as well change our sole usage of it