### PR TITLE
fix: ensure rule fixes produce valid code when function params and args have trailing commas

### DIFF
--- a/src/rules/__tests__/no-done-callback.test.ts
+++ b/src/rules/__tests__/no-done-callback.test.ts
@@ -60,6 +60,24 @@ ruleTester.run('no-done-callback', rule, {
       ],
     },
     {
+      code: 'test("something", (done,) => {done();})',
+      errors: [
+        {
+          messageId: 'noDoneCallback',
+          line: 1,
+          column: 20,
+          suggestions: [
+            {
+              messageId: 'suggestWrappingInPromise',
+              data: { callback: 'done' },
+              output:
+                'test("something", () => {return new Promise(done => {done();})})',
+            },
+          ],
+        },
+      ],
+    },
+    {
       code: 'test("something", finished => {finished();})',
       errors: [
         {
@@ -89,7 +107,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output:
-                'test("something", () => {return new Promise((done) => {done();})})',
+                'test("something", () => {return new Promise(done => {done();})})',
             },
           ],
         },
@@ -123,7 +141,7 @@ ruleTester.run('no-done-callback', rule, {
             {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
-              output: 'test("something", () => new Promise((done) => done()))',
+              output: 'test("something", () => new Promise(done => done()))',
             },
           ],
         },
@@ -141,7 +159,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output:
-                'test("something", function() {return new Promise((done) => {done();})})',
+                'test("something", function() {return new Promise(done => {done();})})',
             },
           ],
         },
@@ -159,7 +177,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output:
-                'test("something", function () {return new Promise((done) => {done();})})',
+                'test("something", function () {return new Promise(done => {done();})})',
             },
           ],
         },
@@ -203,7 +221,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output: dedent`
-                test('something', () => {return new Promise((done) => {
+                test('something', () => {return new Promise(done => {
                   done();
                 })});
               `,
@@ -270,7 +288,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output:
-                'beforeEach(() => {return new Promise((done) => {done();})})',
+                'beforeEach(() => {return new Promise(done => {done();})})',
             },
           ],
         },
@@ -304,7 +322,7 @@ ruleTester.run('no-done-callback', rule, {
             {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
-              output: 'afterEach(() => new Promise((done) => done()))',
+              output: 'afterEach(() => new Promise(done => done()))',
             },
           ],
         },
@@ -322,7 +340,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output:
-                'beforeAll(function() {return new Promise((done) => {done();})})',
+                'beforeAll(function() {return new Promise(done => {done();})})',
             },
           ],
         },
@@ -340,7 +358,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output:
-                'afterEach(function () {return new Promise((done) => {done();})})',
+                'afterEach(function () {return new Promise(done => {done();})})',
             },
           ],
         },
@@ -383,7 +401,7 @@ ruleTester.run('no-done-callback', rule, {
               messageId: 'suggestWrappingInPromise',
               data: { callback: 'done' },
               output: dedent`
-                beforeEach(() => {return new Promise((done) => {
+                beforeEach(() => {return new Promise(done => {
                   done();
                 })});
               `,
@@ -413,7 +431,7 @@ ruleTester.run('no-done-callback', rule, {
               output: dedent`
                 import { beforeEach } from '@jest/globals';
 
-                beforeEach(() => {return new Promise((done) => {
+                beforeEach(() => {return new Promise(done => {
                   done();
                 })});
               `,
@@ -443,7 +461,7 @@ ruleTester.run('no-done-callback', rule, {
               output: dedent`
                 import { beforeEach as atTheStartOfEachTest } from '@jest/globals';
 
-                atTheStartOfEachTest(() => {return new Promise((done) => {
+                atTheStartOfEachTest(() => {return new Promise(done => {
                   done();
                 })});
               `,

--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -29,6 +29,19 @@ const generateInvalidCases = (
       ],
     },
     {
+      code: `expect(value ${operator} 1,).${equalityMatcher}(true,);`,
+      output: `expect(value,).${preferredMatcher}(1,);`,
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [
+        {
+          messageId: 'useToBeComparison',
+          data: { preferredMatcher },
+          column: 19 + operator.length,
+          line: 1,
+        },
+      ],
+    },
+    {
       code: `expect(value ${operator} 1)['${equalityMatcher}'](true);`,
       output: `expect(value).${preferredMatcher}(1);`,
       errors: [

--- a/src/rules/__tests__/prefer-equality-matcher.test.ts
+++ b/src/rules/__tests__/prefer-equality-matcher.test.ts
@@ -55,6 +55,20 @@ ruleTester.run('prefer-equality-matcher: ===', rule, {
       ],
     },
     {
+      code: 'expect(a === b,).toBe(true,);',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [
+        {
+          messageId: 'useEqualityMatcher',
+          suggestions: expectSuggestions(
+            equalityMatcher => `expect(a,).${equalityMatcher}(b,);`,
+          ),
+          column: 18,
+          line: 1,
+        },
+      ],
+    },
+    {
       code: 'expect(a === b).toBe(false);',
       errors: [
         {

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -254,7 +254,23 @@ ruleTester.run('prefer-expect-assertions', rule, {
           suggestions: [
             {
               messageId: 'suggestRemovingExtraArguments',
-              output: 'it("it1", function() {expect.assertions(1);})',
+              output: 'it("it1", function() {expect.assertions(1,);})',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'it("it1", function() {expect.assertions(1,2,);})',
+      errors: [
+        {
+          messageId: 'assertionsRequiresOneArgument',
+          column: 43,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestRemovingExtraArguments',
+              output: 'it("it1", function() {expect.assertions(1,);})',
             },
           ],
         },
@@ -273,6 +289,22 @@ ruleTester.run('prefer-expect-assertions', rule, {
     },
     {
       code: 'it("it1", function() {expect.hasAssertions("1");})',
+      errors: [
+        {
+          messageId: 'hasAssertionsTakesNoArguments',
+          column: 30,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestRemovingExtraArguments',
+              output: 'it("it1", function() {expect.hasAssertions();})',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      code: 'it("it1", function() {expect.hasAssertions("1",);})',
       errors: [
         {
           messageId: 'hasAssertionsTakesNoArguments',

--- a/src/rules/__tests__/prefer-expect-resolves.test.ts
+++ b/src/rules/__tests__/prefer-expect-resolves.test.ts
@@ -37,12 +37,12 @@ ruleTester.run('prefer-expect-resolves', rule, {
     {
       code: dedent`
         it('passes', async () => {
-          expect(await someValue()).toBe(true);
+          expect(await someValue(),).toBe(true);
         });
       `,
       output: dedent`
         it('passes', async () => {
-          await expect(someValue()).resolves.toBe(true);
+          await expect(someValue(),).resolves.toBe(true);
         });
       `,
       errors: [{ endColumn: 27, column: 10, messageId: 'expectResolves' }],

--- a/src/rules/__tests__/prefer-mock-promise-shorthand.test.ts
+++ b/src/rules/__tests__/prefer-mock-promise-shorthand.test.ts
@@ -128,6 +128,19 @@ ruleTester.run('prefer-mock-shorthand', rule, {
       ],
     },
     {
+      code: 'aVariable.mockImplementation(() => Promise.reject(42),)',
+      output: 'aVariable.mockRejectedValue(42,)',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [
+        {
+          messageId: 'useMockShorthand',
+          data: { replacement: 'mockRejectedValue' },
+          column: 11,
+          line: 1,
+        },
+      ],
+    },
+    {
       code: 'aVariable.mockImplementationOnce(() => Promise.resolve(42))',
       output: 'aVariable.mockResolvedValueOnce(42)',
       errors: [

--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -74,8 +74,9 @@ ruleTester.run('prefer-spy-on', rule, {
       ],
     },
     {
-      code: 'obj.a = jest.fn(() => 10)',
+      code: 'obj.a = jest.fn(() => 10,)',
       output: "jest.spyOn(obj, 'a').mockImplementation(() => 10)",
+      parserOptions: { ecmaVersion: 2017 },
       errors: [
         {
           messageId: 'useJestSpyOn',

--- a/src/rules/__tests__/prefer-strict-equal.test.ts
+++ b/src/rules/__tests__/prefer-strict-equal.test.ts
@@ -27,6 +27,23 @@ ruleTester.run('prefer-strict-equal', rule, {
       ],
     },
     {
+      code: 'expect(something).toEqual(somethingElse,);',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [
+        {
+          messageId: 'useToStrictEqual',
+          column: 19,
+          line: 1,
+          suggestions: [
+            {
+              messageId: 'suggestReplaceWithStrictEqual',
+              output: 'expect(something).toStrictEqual(somethingElse,);',
+            },
+          ],
+        },
+      ],
+    },
+    {
       code: 'expect(something)["toEqual"](somethingElse);',
       errors: [
         {

--- a/src/rules/__tests__/prefer-to-be.test.ts
+++ b/src/rules/__tests__/prefer-to-be.test.ts
@@ -43,6 +43,12 @@ ruleTester.run('prefer-to-be', rule, {
       errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
     },
     {
+      code: 'expect(value).toStrictEqual(1,);',
+      output: 'expect(value).toBe(1,);',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
+    },
+    {
       code: 'expect(value).toStrictEqual(-1);',
       output: 'expect(value).toBe(-1);',
       errors: [{ messageId: 'useToBe', column: 15, line: 1 }],
@@ -113,6 +119,12 @@ ruleTester.run('prefer-to-be: null', rule, {
     {
       code: 'expect(null).toEqual(null);',
       output: 'expect(null).toBeNull();',
+      errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
+    },
+    {
+      code: 'expect(null).toEqual(null,);',
+      output: 'expect(null).toBeNull();',
+      parserOptions: { ecmaVersion: 2017 },
       errors: [{ messageId: 'useToBeNull', column: 14, line: 1 }],
     },
     {

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -45,6 +45,12 @@ ruleTester.run('prefer-to-contain', rule, {
       errors: [{ messageId: 'useToContain', column: 23, line: 1 }],
     },
     {
+      code: 'expect(a.includes(b,),).toEqual(true,);',
+      output: 'expect(a,).toContain(b,);',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [{ messageId: 'useToContain', column: 25, line: 1 }],
+    },
+    {
       code: "expect(a['includes'](b)).toEqual(true);",
       output: 'expect(a).toContain(b);',
       errors: [{ messageId: 'useToContain', column: 26, line: 1 }],

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -29,6 +29,12 @@ ruleTester.run('prefer-to-have-length', rule, {
       errors: [{ messageId: 'useToHaveLength', column: 25, line: 1 }],
     },
     {
+      code: 'expect(files["length"]).toBe(1,);',
+      output: 'expect(files).toHaveLength(1,);',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [{ messageId: 'useToHaveLength', column: 25, line: 1 }],
+    },
+    {
       code: 'expect(files["length"])["not"].toBe(1);',
       output: 'expect(files)["not"].toHaveLength(1);',
       errors: [{ messageId: 'useToHaveLength', column: 32, line: 1 }],

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -34,6 +34,12 @@ ruleTester.run('prefer-todo', rule, {
       errors: [{ messageId: 'unimplementedTest' }],
     },
     {
+      code: `test("i need to write this test",);`,
+      output: 'test.todo("i need to write this test",);',
+      parserOptions: { ecmaVersion: 2017 },
+      errors: [{ messageId: 'unimplementedTest' }],
+    },
+    {
       code: 'test(`i need to write this test`);',
       output: 'test.todo(`i need to write this test`);',
       errors: [{ messageId: 'unimplementedTest' }],

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -8,6 +8,7 @@ import {
   getFirstMatcherArg,
   isIdentifier,
   parseJestFnCall,
+  removeExtraArgumentsFixer,
   replaceAccessorFixer,
 } from './utils';
 
@@ -58,6 +59,7 @@ const reportPreferToBe = (
   context: TSESLint.RuleContext<MessageId, unknown[]>,
   whatToBe: ToBeWhat,
   expectFnCall: ParsedExpectFnCall,
+  func: TSESTree.CallExpression,
   modifierNode?: AccessorNode,
 ) => {
   context.report({
@@ -68,7 +70,7 @@ const reportPreferToBe = (
       ];
 
       if (expectFnCall.args?.length && whatToBe !== '') {
-        fixes.push(fixer.remove(expectFnCall.args[0]));
+        fixes.push(removeExtraArgumentsFixer(fixer, context, func, 0));
       }
 
       if (modifierNode) {
@@ -125,6 +127,7 @@ export default createRule({
             context,
             matcherName === 'toBeDefined' ? 'Undefined' : 'Defined',
             jestFnCall,
+            node,
             notModifier,
           );
 
@@ -139,7 +142,7 @@ export default createRule({
         }
 
         if (isNullEqualityMatcher(jestFnCall)) {
-          reportPreferToBe(context, 'Null', jestFnCall);
+          reportPreferToBe(context, 'Null', jestFnCall, node);
 
           return;
         }
@@ -147,19 +150,19 @@ export default createRule({
         if (isFirstArgumentIdentifier(jestFnCall, 'undefined')) {
           const name = notModifier ? 'Defined' : 'Undefined';
 
-          reportPreferToBe(context, name, jestFnCall, notModifier);
+          reportPreferToBe(context, name, jestFnCall, node, notModifier);
 
           return;
         }
 
         if (isFirstArgumentIdentifier(jestFnCall, 'NaN')) {
-          reportPreferToBe(context, 'NaN', jestFnCall);
+          reportPreferToBe(context, 'NaN', jestFnCall, node);
 
           return;
         }
 
         if (shouldUseToBe(jestFnCall) && matcherName !== EqualityMatcher.toBe) {
-          reportPreferToBe(context, '', jestFnCall);
+          reportPreferToBe(context, '', jestFnCall, node);
         }
       },
     };

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -168,6 +168,25 @@ export const replaceAccessorFixer = (
   );
 };
 
+export const removeExtraArgumentsFixer = (
+  fixer: TSESLint.RuleFixer,
+  context: TSESLint.RuleContext<string, unknown[]>,
+  func: TSESTree.CallExpression,
+  from: number,
+): TSESLint.RuleFix => {
+  const firstArg = func.arguments[from];
+  const lastArg = func.arguments[func.arguments.length - 1];
+
+  const sourceCode = context.getSourceCode();
+  let tokenAfterLastParam = sourceCode.getTokenAfter(lastArg)!;
+
+  if (tokenAfterLastParam.value === ',') {
+    tokenAfterLastParam = sourceCode.getTokenAfter(tokenAfterLastParam)!;
+  }
+
+  return fixer.removeRange([firstArg.range[0], tokenAfterLastParam.range[0]]);
+};
+
 export const findTopMostCallExpression = (
   node: TSESTree.CallExpression,
 ): TSESTree.CallExpression => {


### PR DESCRIPTION
The fix that no one asked for 😄 props to @berkinanik for bring this to my attention over in `eslint-plugin-jest-dom`.

Weirdly ESLint doesn't seem to think some of the result syntax before this is invalid (namely in `no-done-callback` which'd give `((), ) => {}`), but didn't feel like digging into that further right now.