### PR TITLE
chore(.husky): shell path and arg updates

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
 yarn commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged


### PR DESCRIPTION
v8.0.0 of Husky fixed shell path and args for newly created git hooks, but doesn't update existing ones, so have done that here.

See https://github.com/typicode/husky/pull/1051 and https://github.com/typicode/husky/pull/1132