### PR TITLE
chore: switch to using config file to configure `eslint-doc-generator`

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,0 +1,20 @@
+/** @type {import('eslint-doc-generator/dist/lib/options').GenerateOptions} */
+const config = {
+  ignoreConfig: ['all'],
+  ruleDocTitleFormat: 'desc-parens-name',
+  ruleDocSectionInclude: ['Rule details'],
+  ruleListColumns: [
+    'name',
+    'description',
+    'configsError',
+    'configsWarn',
+    'configsOff',
+    'fixable',
+    'hasSuggestions',
+    'deprecated',
+  ].join(),
+  splitBy: 'meta.docs.requiresTypeChecking',
+  urlConfigs: `https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#shareable-configurations`,
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prettier:write": "prettier --write 'docs/**/*.md' README.md '.github/**' package.json tsconfig.json src/globals.json .yarnrc.yml",
     "postpublish": "pinst --enable",
     "test": "jest",
-    "tools:regenerate-docs": "yarn prepack && eslint-doc-generator --ignore-config all --rule-doc-title-format desc-parens-name --rule-doc-section-include \"Rule details\" --rule-list-columns name,description,configsError,configsWarn,configsOff,fixable,hasSuggestions,deprecated --split-by meta.docs.requiresTypeChecking --url-configs \"https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#shareable-configurations\" && yarn prettier:write",
+    "tools:regenerate-docs": "yarn prepack && eslint-doc-generator && yarn prettier:write",
     "typecheck": "tsc -p ."
   },
   "commitlint": {


### PR DESCRIPTION
I've created https://github.com/bmish/eslint-doc-generator/issues/260 about supporting TypeScript for config, but for now JS will do.

Currently we don't actually check JS files with TS, but will do that in another PR since it affects a few other files.