### PR TITLE
docs: update rule name in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Features
 
-* create `require-typed-module-mocks` rule ([#1314](https://github.com/jest-community/eslint-plugin-jest/issues/1314)) ([ee43c3f](https://github.com/jest-community/eslint-plugin-jest/commit/ee43c3f4d5de5e6935d0242cc846f1dec43af20d))
+* create `no-untyped-mock-factory` rule ([#1314](https://github.com/jest-community/eslint-plugin-jest/issues/1314)) ([ee43c3f](https://github.com/jest-community/eslint-plugin-jest/commit/ee43c3f4d5de5e6935d0242cc846f1dec43af20d))
 
 ## [27.1.7](https://github.com/jest-community/eslint-plugin-jest/compare/v27.1.6...v27.1.7) (2022-12-15)
 


### PR DESCRIPTION
I forgot to update the title of #1314 before merging, so it had the old rule name