### PR TITLE
docs(require-hook): remove redundant section

### DIFF
--- a/docs/rules/require-hook.md
+++ b/docs/rules/require-hook.md
@@ -2,10 +2,6 @@
 
 <!-- end auto-generated rule header -->
 
-Often while writing tests you have some setup work that needs to happen before
-tests run, and you have some finishing work that needs to happen after tests
-run. Jest provides helper functions to handle this.
-
 It's common when writing tests to need to perform setup work that needs to
 happen before tests run, and finishing work after tests run.
 

--- a/docs/rules/require-hook.md
+++ b/docs/rules/require-hook.md
@@ -2,8 +2,8 @@
 
 <!-- end auto-generated rule header -->
 
-It's common when writing tests to need to perform setup work that needs to
-happen before tests run, and finishing work after tests run.
+It's common when writing tests to need to perform setup work that has to happen
+before tests run, and finishing work after tests run.
 
 Because Jest executes all `describe` handlers in a test file _before_ it
 executes any of the actual tests, it's important to ensure setup and teardown


### PR DESCRIPTION
The intro to [require-hook.md](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-hook.md) has repeated information, this PR removes the extra copy.