### PR TITLE
fix: add missing (optional) peer dependency on Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,8 @@
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "eslint": "^7.0.0 || ^8.0.0"
+    "eslint": "^7.0.0 || ^8.0.0",
+    "jest": "*"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,6 +4934,7 @@ __metadata:
   peerDependencies:
     "@typescript-eslint/eslint-plugin": ^5.0.0
     eslint: ^7.0.0 || ^8.0.0
+    jest: "*"
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":
       optional: true


### PR DESCRIPTION
It's already declared as optional.

We load it here: https://github.com/jest-community/eslint-plugin-jest/blob/197e986e2290530fd8a807d3de2f9298de74e8e5/src/rules/utils/detectJestVersion.ts#L30