### PR TITLE
fix: allow `@typescript-eslint/eslint-plugin` v6 as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.0.0 || ^6.0.0",
     "eslint": "^7.0.0 || ^8.0.0",
     "jest": "*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4961,7 +4961,7 @@ __metadata:
     ts-node: ^10.2.1
     typescript: ^5.0.4
   peerDependencies:
-    "@typescript-eslint/eslint-plugin": ^5.0.0
+    "@typescript-eslint/eslint-plugin": ^5.0.0 || ^6.0.0
     eslint: ^7.0.0 || ^8.0.0
     jest: "*"
   peerDependenciesMeta:


### PR DESCRIPTION
Closes #1398.

Note that we cannot verify that it works on CI as they've removed `types` from `package.json`. We have to use `node16` module resolution, which brings its own errors.