### PR TITLE
feat: upgrade `@typescript-eslint/utils` to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.10.0"
+    "@typescript-eslint/utils": "6"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -111,8 +111,9 @@
     "@types/eslint": "^8.4.6",
     "@types/jest": "^29.0.0",
     "@types/node": "^14.18.26",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "6",
+    "@typescript-eslint/parser": "6",
+    "@typescript-eslint/rule-tester": "^6.0.0",
     "babel-jest": "^29.0.0",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
     "dedent": "^1.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,6 @@ type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
   meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
 };
 
-// v5 of `@typescript-eslint/experimental-utils` removed this
-declare module '@typescript-eslint/utils/dist/ts-eslint/Rule' {
-  export interface RuleMetaDataDocs {
-    category: 'Best Practices' | 'Possible Errors';
-  }
-}
-
 // copied from https://github.com/babel/babel/blob/d8da63c929f2d28c401571e2a43166678c555bc4/packages/babel-helpers/src/helpers.js#L602-L606
 /* istanbul ignore next */
 const interopRequireDefault = (obj: any): { default: any } =>

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -9,7 +9,12 @@ function getFixturesRootDir(): string {
 
 const rootPath = getFixturesRootDir();
 
-const ruleTester = new ESLintUtils.RuleTester({
+const RuleTester =
+  ESLintUtils.RuleTester ??
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('@typescript-eslint/rule-tester').RuleTester;
+
+const ruleTester = new RuleTester({
   parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',
@@ -164,7 +169,7 @@ describe('error handling', () => {
   });
 
   describe('when @typescript-eslint/eslint-plugin is not available', () => {
-    const ruleTester = new ESLintUtils.RuleTester({
+    const ruleTester = new RuleTester({
       parser: '@typescript-eslint/parser',
       parserOptions: {
         sourceType: 'module',

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -35,9 +35,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce `test` and `it` usage conventions',
-      recommended: false,
     },
     fixable: 'code',
     messages: {
@@ -51,9 +49,11 @@ export default createRule<
         type: 'object',
         properties: {
           fn: {
+            type: 'string',
             enum: [TestCaseName.it, TestCaseName.test],
           },
           withinDescribe: {
+            type: 'string',
             enum: [TestCaseName.it, TestCaseName.test],
           },
         },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -52,9 +52,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce assertion to be made in a test body',
-      recommended: 'warn',
     },
     messages: {
       noAssertions: 'Test has no assertions',

--- a/src/rules/max-expects.ts
+++ b/src/rules/max-expects.ts
@@ -10,9 +10,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforces a maximum number assertion calls in a test body',
-      recommended: false,
     },
     messages: {
       exceededMaxAssertion:

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforces a maximum depth to nested describe calls',
-      recommended: false,
     },
     messages: {
       exceededMaxDepth:

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -9,9 +9,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow alias methods',
-      recommended: 'error',
     },
     messages: {
       replaceAlias: `Replace {{ alias }}() with its canonical name of {{ canonical }}()`,

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -11,9 +11,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow commented out tests',
-      recommended: 'warn',
     },
     messages: {
       commentedTests: 'Some tests seem to be commented',

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -19,8 +19,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallow calling `expect` conditionally',
-      category: 'Best Practices',
-      recommended: 'error',
     },
     messages: {
       conditionalExpect: 'Avoid calling `expect` conditionally`',

--- a/src/rules/no-conditional-in-test.ts
+++ b/src/rules/no-conditional-in-test.ts
@@ -6,8 +6,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallow conditional logic in tests',
-      category: 'Best Practices',
-      recommended: false,
     },
     messages: {
       conditionalInTest: 'Avoid having conditionals in tests',

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -28,9 +28,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow use of deprecated functions',
-      recommended: 'error',
     },
     messages: {
       deprecatedFunction:

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -9,9 +9,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow disabled tests',
-      recommended: 'warn',
     },
     messages: {
       missingFunction: 'Test is missing function argument',

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -31,9 +31,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow using a callback in asynchronous tests and hooks',
-      recommended: 'error',
     },
     messages: {
       noDoneCallback:

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -4,9 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow duplicate setup and teardown hooks',
-      recommended: false,
     },
     messages: {
       noDuplicateHook: 'Duplicate {{hook}} in describe block',

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow using `exports` in files containing tests',
-      recommended: 'error',
     },
     messages: {
       unexpectedExport: `Do not export from a test file`,

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow focused tests',
-      recommended: 'error',
     },
     messages: {
       focusedTest: 'Unexpected focused test',

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -7,9 +7,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow setup and teardown hooks',
-      recommended: false,
     },
     messages: {
       unexpectedHook: "Unexpected '{{ hookName }}' hook",

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -21,9 +21,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow identical titles',
-      recommended: 'error',
     },
     messages: {
       multipleTestTitle:

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -39,8 +39,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallow conditional logic',
-      category: 'Best Practices',
-      recommended: false,
     },
     messages: {
       conditionalInTest: 'Test should not contain {{ condition }} statements',

--- a/src/rules/no-interpolation-in-snapshots.ts
+++ b/src/rules/no-interpolation-in-snapshots.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow string interpolation inside snapshots',
-      recommended: 'error',
     },
     messages: {
       noInterpolation: 'Do not use string interpolation inside of snapshots',

--- a/src/rules/no-jasmine-globals.ts
+++ b/src/rules/no-jasmine-globals.ts
@@ -10,9 +10,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow Jasmine globals',
-      recommended: 'error',
     },
     messages: {
       illegalGlobal:

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -75,9 +75,7 @@ export default createRule<[RuleOptions], MessageId>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow large snapshots',
-      recommended: false,
     },
     messages: {
       noSnapshot: '`{{ lineCount }}`s should begin with lowercase',

--- a/src/rules/no-mocks-import.ts
+++ b/src/rules/no-mocks-import.ts
@@ -17,9 +17,7 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      category: 'Best Practices',
       description: 'Disallow manually importing from `__mocks__`',
-      recommended: 'error',
     },
     messages: {
       noManualImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use \`jest.mock\` and import from the original module path`,

--- a/src/rules/no-restricted-jest-methods.ts
+++ b/src/rules/no-restricted-jest-methods.ts
@@ -12,9 +12,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow specific `jest.` methods',
-      recommended: false,
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -23,9 +23,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow specific matchers & modifiers',
-      recommended: false,
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -60,9 +60,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow using `expect` outside of `it` or `test` blocks',
-      recommended: 'error',
     },
     messages: {
       unexpectedExpect: 'Expect must be inside of a test block',

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Require using `.only` and `.skip` over `f` and `x`',
-      recommended: 'error',
     },
     messages: {
       usePreferredName: 'Use "{{ preferredNodeName }}" instead',

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -24,9 +24,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow explicitly returning from tests',
-      recommended: false,
     },
     messages: {
       noReturnValue: 'Jest tests should not return a value',

--- a/src/rules/no-untyped-mock-factory.ts
+++ b/src/rules/no-untyped-mock-factory.ts
@@ -21,10 +21,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Disallow using `jest.mock()` factories without an explicit type parameter',
-      recommended: false,
     },
     messages: {
       addTypeParameterToModuleMock:
@@ -38,7 +36,7 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node: TSESTree.CallExpression): void {
-        const { callee, typeParameters } = node;
+        const { callee } = node;
 
         if (callee.type !== AST_NODE_TYPES.MemberExpression) {
           return;
@@ -53,6 +51,9 @@ export default createRule({
           ['mock', 'doMock'].includes(getAccessorValue(property))
         ) {
           const [nameNode, factoryNode] = node.arguments;
+
+          // this will still emit a deprecation warning as `typeArguments` might be nullish on v6
+          const typeParameters = node.typeArguments ?? node.typeParameters;
 
           const hasTypeParameter =
             typeParameters !== undefined && typeParameters.params.length > 0;

--- a/src/rules/prefer-called-with.ts
+++ b/src/rules/prefer-called-with.ts
@@ -4,10 +4,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`',
-      recommended: false,
     },
     messages: {
       preferCalledWith: 'Prefer {{ matcherName }}With(/* expected args */)',

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -56,9 +56,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using the built-in comparison matchers',
-      recommended: false,
     },
     messages: {
       useToBeComparison: 'Prefer using `{{ preferredMatcher }}` instead',

--- a/src/rules/prefer-each.ts
+++ b/src/rules/prefer-each.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer using `.each` rather than manual loops',
-      recommended: false,
     },
     messages: {
       preferEach: 'prefer using `{{ fn }}.each` rather than a manual loop',

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -13,9 +13,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using the built-in equality matchers',
-      recommended: false,
     },
     messages: {
       useEqualityMatcher: 'Prefer using one of the equality matchers instead',

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -64,10 +64,8 @@ export default createRule<[RuleOptions], MessageIds>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Suggest using `expect.assertions()` OR `expect.hasAssertions()`',
-      recommended: false,
     },
     messages: {
       hasAssertionsTakesNoArguments:

--- a/src/rules/prefer-expect-resolves.ts
+++ b/src/rules/prefer-expect-resolves.ts
@@ -5,10 +5,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Prefer `await expect(...).resolves` over `expect(await ...)` syntax',
-      recommended: false,
     },
     fixable: 'code',
     messages: {

--- a/src/rules/prefer-hooks-in-order.ts
+++ b/src/rules/prefer-hooks-in-order.ts
@@ -6,9 +6,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer having hooks in a consistent order',
-      recommended: false,
     },
     messages: {
       reorderHooks: `\`{{ currentHook }}\` hooks should be before any \`{{ previousHook }}\` hooks`,

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -4,9 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest having hooks before any test cases',
-      recommended: false,
     },
     messages: {
       noHookOnTop: 'Hooks should come before test cases',

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -56,8 +56,6 @@ export default createRule<
     type: 'suggestion',
     docs: {
       description: 'Enforce lowercase test names',
-      category: 'Best Practices',
-      recommended: false,
     },
     fixable: 'code',
     messages: {

--- a/src/rules/prefer-mock-promise-shorthand.ts
+++ b/src/rules/prefer-mock-promise-shorthand.ts
@@ -31,9 +31,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer mock resolved/rejected shorthands for promises',
-      recommended: false,
     },
     messages: {
       useMockShorthand: 'Prefer {{ replacement }}',

--- a/src/rules/prefer-snapshot-hint.ts
+++ b/src/rules/prefer-snapshot-hint.ts
@@ -43,9 +43,7 @@ export default createRule<[('always' | 'multi')?], keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer including a hint with external snapshots',
-      recommended: false,
     },
     messages,
     type: 'suggestion',

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -68,9 +68,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `jest.spyOn()`',
-      recommended: false,
     },
     messages: {
       useJestSpyOn: 'Use jest.spyOn() instead',

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -10,9 +10,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toStrictEqual()`',
-      recommended: false,
     },
     messages: {
       useToStrictEqual: 'Use `toStrictEqual()` instead',

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -93,9 +93,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toBe()` for primitive literals',
-      recommended: false,
     },
     messages: {
       useToBe: 'Use `toBe` when expecting primitive literals',

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -38,9 +38,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toContain()`',
-      recommended: false,
     },
     messages: {
       useToContain: 'Use toContain() instead',

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -11,9 +11,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toHaveLength()`',
-      recommended: false,
     },
     messages: {
       useToHaveLength: 'Use toHaveLength() instead',

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -55,9 +55,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `test.todo`',
-      recommended: false,
     },
     messages: {
       emptyTest: 'Prefer todo test case over empty test case',

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -65,9 +65,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Require setup and teardown code to be within a hook',
-      recommended: false,
     },
     messages: {
       useHook: 'This should be done within a hook',

--- a/src/rules/require-to-throw-message.ts
+++ b/src/rules/require-to-throw-message.ts
@@ -4,9 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Require a message for `toThrow()`',
-      recommended: false,
     },
     messages: {
       addErrorMessage: 'Add an error message to {{ matcherName }}()',

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -15,10 +15,8 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Require test cases and hooks to be inside a `describe` block',
-      recommended: false,
     },
     messages,
     type: 'suggestion',

--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -60,12 +60,10 @@ export default createRule<Options, MessageIds>({
     type: 'problem',
     ...baseRule?.meta,
     docs: {
-      category: 'Best Practices',
       description:
         'Enforce unbound methods are called with their expected scope',
       requiresTypeChecking: true,
       ...baseRule?.meta.docs,
-      recommended: false,
     },
   },
   create(context) {

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -48,9 +48,7 @@ const rule = createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Possible Errors',
       description: 'Fake rule for testing parseJestFnCall',
-      recommended: false,
     },
     messages: {
       details: '{{ data }}',

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -23,9 +23,7 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      category: 'Possible Errors',
       description: 'Enforce valid `describe()` callback',
-      recommended: 'error',
     },
     messages: {
       nameAndCallback: 'Describe requires name and callback arguments',

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -344,10 +344,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Require promises that have expectations in their chain to be valid',
-      recommended: 'error',
     },
     messages: {
       expectInFloatingPromise:

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -115,9 +115,7 @@ export default createRule<[Options], MessageIds>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce valid `expect()` usage',
-      recommended: 'error',
     },
     messages: {
       tooManyArgs: 'Expect takes at most {{ amount }} argument{{ s }}',

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -74,7 +74,7 @@ const compileMatcherPatterns = (
 type CompiledMatcherAndMessage = [matcher: RegExp, message?: string];
 type MatcherAndMessage = [matcher: string, message?: string];
 
-const MatcherAndMessageSchema: JSONSchema.JSONSchema7 = {
+const MatcherAndMessageSchema: JSONSchema.JSONSchema4 = {
   type: 'array',
   items: { type: 'string' },
   minItems: 1,
@@ -113,9 +113,7 @@ export default createRule<[Options], MessageIds>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce valid titles',
-      recommended: 'error',
     },
     messages: {
       titleMustBeString: 'Title must be a string',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "module": "commonjs",
     "noEmit": true,
     "stripInternal": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,7 +1623,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -1634,10 +1634,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.4.0, @eslint-community/regexpp@npm:^4.6.1":
-  version: 4.8.1
-  resolution: "@eslint-community/regexpp@npm:4.8.1"
-  checksum: 82d62c845ef42b810f268cfdc84d803a2da01735fb52e902fd34bdc09f92464a094fd8e4802839874b000b2f73f67c972859e813ba705233515d3e954f234bf2
+"@eslint-community/regexpp@npm:^4.5.1, @eslint-community/regexpp@npm:^4.6.1":
+  version: 4.9.1
+  resolution: "@eslint-community/regexpp@npm:4.9.1"
+  checksum: 06fb839e9c756f6375cc545c2f2e05a0a64576bd6370e8e3c07983fd29a3d6e164ef4aa48a361f7d27e6713ab79c83053ff6a2ccb78748bc955e344279c4a3b6
   languageName: node
   linkType: hard
 
@@ -2801,7 +2801,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.9":
   version: 7.0.13
   resolution: "@types/json-schema@npm:7.0.13"
   checksum: 345df21a678fa72fb389f35f33de77833d09d4a142bb2bcb27c18690efa4cf70fc2876e43843cefb3fbdb9fcb12cd3e970a90936df30f53bbee899865ff605ab
@@ -2857,10 +2857,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.12":
-  version: 7.5.2
-  resolution: "@types/semver@npm:7.5.2"
-  checksum: 743aa8a2b58e20b329c19bd2459152cb049d12fafab7279b90ac11e0f268c97efbcb606ea0c681cca03f79015381b40d9b1244349b354270bec3f939ed49f6e9
+"@types/semver@npm:^7.3.12, @types/semver@npm:^7.5.0":
+  version: 7.5.3
+  resolution: "@types/semver@npm:7.5.3"
+  checksum: 349fdd1ab6c213bac5c991bac766bd07b8b12e63762462bb058740dcd2eb09c8193d068bb226f134661275f2022976214c0e727a4e5eb83ec1b131127c980d3e
   languageName: node
   linkType: hard
 
@@ -2894,44 +2894,62 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^5.0.0":
-  version: 5.62.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.62.0"
+"@typescript-eslint/eslint-plugin@npm:6":
+  version: 6.7.4
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.7.4"
   dependencies:
-    "@eslint-community/regexpp": ^4.4.0
-    "@typescript-eslint/scope-manager": 5.62.0
-    "@typescript-eslint/type-utils": 5.62.0
-    "@typescript-eslint/utils": 5.62.0
+    "@eslint-community/regexpp": ^4.5.1
+    "@typescript-eslint/scope-manager": 6.7.4
+    "@typescript-eslint/type-utils": 6.7.4
+    "@typescript-eslint/utils": 6.7.4
+    "@typescript-eslint/visitor-keys": 6.7.4
     debug: ^4.3.4
     graphemer: ^1.4.0
-    ignore: ^5.2.0
-    natural-compare-lite: ^1.4.0
-    semver: ^7.3.7
-    tsutils: ^3.21.0
+    ignore: ^5.2.4
+    natural-compare: ^1.4.0
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
   peerDependencies:
-    "@typescript-eslint/parser": ^5.0.0
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    "@typescript-eslint/parser": ^6.0.0 || ^6.0.0-alpha
+    eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: fc104b389c768f9fa7d45a48c86d5c1ad522c1d0512943e782a56b1e3096b2cbcc1eea3fcc590647bf0658eef61aac35120a9c6daf979bf629ad2956deb516a1
+  checksum: 91d5051ae935d8bb61091665ee1e5c456992a0c29b58c86c1bb2b72c935dd831c0d3c7726a8d609455ae4a8b4ba8786ebeeef4bc7eff388b5f77475e7a634dc0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.0.0":
-  version: 5.62.0
-  resolution: "@typescript-eslint/parser@npm:5.62.0"
+"@typescript-eslint/parser@npm:6":
+  version: 6.7.4
+  resolution: "@typescript-eslint/parser@npm:6.7.4"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.62.0
-    "@typescript-eslint/types": 5.62.0
-    "@typescript-eslint/typescript-estree": 5.62.0
+    "@typescript-eslint/scope-manager": 6.7.4
+    "@typescript-eslint/types": 6.7.4
+    "@typescript-eslint/typescript-estree": 6.7.4
+    "@typescript-eslint/visitor-keys": 6.7.4
     debug: ^4.3.4
   peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: d168f4c7f21a7a63f47002e2d319bcbb6173597af5c60c1cf2de046b46c76b4930a093619e69faf2d30214c29ab27b54dcf1efc7046a6a6bd6f37f59a990e752
+  checksum: 60e7c01a69c1a67577f031cd6ef3c7980a9aedf2045b9950e339836acb2fe9d7bf0c8909fa95d713a8270f19dead43d82beb27dcf8705f81fe35b14b737e8fe0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/rule-tester@npm:^6.0.0":
+  version: 6.7.4
+  resolution: "@typescript-eslint/rule-tester@npm:6.7.4"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 6.7.4
+    "@typescript-eslint/utils": 6.7.4
+    ajv: ^6.10.0
+    lodash.merge: 4.6.2
+    semver: ^7.5.4
+  peerDependencies:
+    "@eslint/eslintrc": ">=2"
+    eslint: ">=8"
+  checksum: 51fcd52cd6b63c6df6bb76630cb1424658ecdb698690b8159dfbce0a01ec0341d8540fe4ef839b26346bb8e134c67175cfb1e51aa41fddc1710f4b6d8b34d143
   languageName: node
   linkType: hard
 
@@ -2945,20 +2963,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.62.0":
-  version: 5.62.0
-  resolution: "@typescript-eslint/type-utils@npm:5.62.0"
+"@typescript-eslint/scope-manager@npm:6.7.4":
+  version: 6.7.4
+  resolution: "@typescript-eslint/scope-manager@npm:6.7.4"
   dependencies:
-    "@typescript-eslint/typescript-estree": 5.62.0
-    "@typescript-eslint/utils": 5.62.0
+    "@typescript-eslint/types": 6.7.4
+    "@typescript-eslint/visitor-keys": 6.7.4
+  checksum: 8475d28f6408c204fb6bf25df45c1f16cad950190e31346c4b1ae15461a96f30b31b6fd1d3d635b41db6aa9a3fd3de25f04823632c74eeea478f34ebd134a1b0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/type-utils@npm:6.7.4":
+  version: 6.7.4
+  resolution: "@typescript-eslint/type-utils@npm:6.7.4"
+  dependencies:
+    "@typescript-eslint/typescript-estree": 6.7.4
+    "@typescript-eslint/utils": 6.7.4
     debug: ^4.3.4
-    tsutils: ^3.21.0
+    ts-api-utils: ^1.0.1
   peerDependencies:
-    eslint: "*"
+    eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: fc41eece5f315dfda14320be0da78d3a971d650ea41300be7196934b9715f3fe1120a80207551eb71d39568275dbbcf359bde540d1ca1439d8be15e9885d2739
+  checksum: 231240a1aa1008a1b1facdd40b931433606947254f6e04705d154791a8b2c15d5ce3355b7d8a29cf7bb53c2e2eca1340c7860dd395389858d442af06c586d1fd
   languageName: node
   linkType: hard
 
@@ -2966,6 +2994,13 @@ __metadata:
   version: 5.62.0
   resolution: "@typescript-eslint/types@npm:5.62.0"
   checksum: 48c87117383d1864766486f24de34086155532b070f6264e09d0e6139449270f8a9559cfef3c56d16e3bcfb52d83d42105d61b36743626399c7c2b5e0ac3b670
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.7.4":
+  version: 6.7.4
+  resolution: "@typescript-eslint/types@npm:6.7.4"
+  checksum: 287ae48a2bb722b866460bcb2ba4ff908348145b3fc0af4ea75679d474e9ba3632bf64689044f181fe8ca3cb5f41238bb31ea428d5e78f1c3982f6dac6b7b149
   languageName: node
   linkType: hard
 
@@ -2987,7 +3022,42 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.62.0, @typescript-eslint/utils@npm:^5.10.0, @typescript-eslint/utils@npm:^5.38.1":
+"@typescript-eslint/typescript-estree@npm:6.7.4":
+  version: 6.7.4
+  resolution: "@typescript-eslint/typescript-estree@npm:6.7.4"
+  dependencies:
+    "@typescript-eslint/types": 6.7.4
+    "@typescript-eslint/visitor-keys": 6.7.4
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 2e8f5e972403233522eff09cfe7a0a23549cfd462e82b434aa32ddbdba5b329be5a549514a157f6b79e2d0159c9348d23b202e5d915d4f2c7cbfe72e1a48a429
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:6, @typescript-eslint/utils@npm:6.7.4":
+  version: 6.7.4
+  resolution: "@typescript-eslint/utils@npm:6.7.4"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.12
+    "@types/semver": ^7.5.0
+    "@typescript-eslint/scope-manager": 6.7.4
+    "@typescript-eslint/types": 6.7.4
+    "@typescript-eslint/typescript-estree": 6.7.4
+    semver: ^7.5.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: 75e197dd58b230436ceb51f2050bb3af8796b05a197eaf741251f8e9c4d9ba1a99d654d090da0c49d31b20da79d9cc3746cbb663ffd5ea614d7a960d64676d65
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^5.38.1":
   version: 5.62.0
   resolution: "@typescript-eslint/utils@npm:5.62.0"
   dependencies:
@@ -3012,6 +3082,16 @@ __metadata:
     "@typescript-eslint/types": 5.62.0
     eslint-visitor-keys: ^3.3.0
   checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.7.4":
+  version: 6.7.4
+  resolution: "@typescript-eslint/visitor-keys@npm:6.7.4"
+  dependencies:
+    "@typescript-eslint/types": 6.7.4
+    eslint-visitor-keys: ^3.4.1
+  checksum: 34d09798b6c48dc059e88c6cb3df5f96e859bd65d1dd05d907b8a3c7a5708a737d50607081fb14a4b974b90cfe4169a93db974bf53af8b282420187f73b0afac
   languageName: node
   linkType: hard
 
@@ -3132,7 +3212,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^6.12.4":
+"ajv@npm:^6.10.0, ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
   dependencies:
@@ -5072,9 +5152,10 @@ __metadata:
     "@types/eslint": ^8.4.6
     "@types/jest": ^29.0.0
     "@types/node": ^14.18.26
-    "@typescript-eslint/eslint-plugin": ^5.0.0
-    "@typescript-eslint/parser": ^5.0.0
-    "@typescript-eslint/utils": ^5.10.0
+    "@typescript-eslint/eslint-plugin": 6
+    "@typescript-eslint/parser": 6
+    "@typescript-eslint/rule-tester": ^6.0.0
+    "@typescript-eslint/utils": 6
     babel-jest: ^29.0.0
     babel-plugin-replace-ts-export-assignment: ^0.0.2
     dedent: ^1.5.0
@@ -7904,7 +7985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.6.2":
+"lodash.merge@npm:4.6.2, lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
@@ -8422,13 +8503,6 @@ __metadata:
   version: 1.0.0
   resolution: "mute-stream@npm:1.0.0"
   checksum: 36fc968b0e9c9c63029d4f9dc63911950a3bdf55c9a87f58d3a266289b67180201cade911e7699f8b2fa596b34c9db43dad37649e3f7fdd13c3bb9edb0017ee7
-  languageName: node
-  linkType: hard
-
-"natural-compare-lite@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "natural-compare-lite@npm:1.4.0"
-  checksum: 5222ac3986a2b78dd6069ac62cbb52a7bf8ffc90d972ab76dfe7b01892485d229530ed20d0c62e79a6b363a663b273db3bde195a1358ce9e5f779d4453887225
   languageName: node
   linkType: hard
 
@@ -10793,6 +10867,15 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.0.3
+  resolution: "ts-api-utils@npm:1.0.3"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 441cc4489d65fd515ae6b0f4eb8690057add6f3b6a63a36073753547fb6ce0c9ea0e0530220a0b282b0eec535f52c4dfc315d35f8a4c9a91c0def0707a714ca6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There are so many breaking changes in v6 I don't think we'll be able to properly support v5 and v6 at the same time...

I started here and just ended up frustrated 😛 @G-Rath I dunno if you wanna give it a whack?