### PR TITLE
chore: remove unneeded types for prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@types/eslint": "^8.4.6",
     "@types/jest": "^29.0.0",
     "@types/node": "^14.18.26",
-    "@types/prettier": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "babel-jest": "^29.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2848,7 +2848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prettier@npm:^2.0.0, @types/prettier@npm:^2.1.5":
+"@types/prettier@npm:^2.1.5":
   version: 2.7.3
   resolution: "@types/prettier@npm:2.7.3"
   checksum: 705384209cea6d1433ff6c187c80dcc0b95d99d5c5ce21a46a9a58060c527973506822e428789d842761e0280d25e3359300f017fbe77b9755bc772ab3dc2f83
@@ -4996,7 +4996,6 @@ __metadata:
     "@types/eslint": ^8.4.6
     "@types/jest": ^29.0.0
     "@types/node": ^14.18.26
-    "@types/prettier": ^2.0.0
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
     "@typescript-eslint/utils": ^5.10.0


### PR DESCRIPTION
We're no longer actually using `prettier` programmatically so don't need the types for it.