### PR TITLE
ci: test against v5 and v6 of `@typescript-eslint/eslint-plugin`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -66,13 +66,18 @@ jobs:
   test-node:
     name:
       # prettier-ignore
-      Test on Node.js v${{ matrix.node-version }}, eslint v${{ matrix.eslint-version }}
+      Test on Node.js v${{ matrix.node-version }}, eslint v${{ matrix.eslint-version }}, and ts-eslint/plugin v${{ matrix.ts-eslint-plugin-version }}
     needs: prepare-yarn-cache-ubuntu
     strategy:
       fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
         eslint-version: [7, 8]
+        ts-eslint-plugin-version: [5, 6]
+        exclude:
+          # ts-eslint/plugin@6 doesn't support node@14
+          - node-version: 14.x
+            ts-eslint-plugin-version: 6
     runs-on: ubuntu-latest
 
     steps:
@@ -86,10 +91,10 @@ jobs:
           cache: yarn
       - name:
           # prettier-ignore
-          install with eslint v${{ matrix.eslint-version }}
+          install with eslint v${{ matrix.eslint-version }} and ts-eslint/plugin v${{ matrix.ts-eslint-plugin-version }}
         run: |
           yarn
-          yarn add --dev eslint@${{ matrix.eslint-version }}
+          yarn add --dev eslint@${{ matrix.eslint-version }} @typescript-eslint/eslint-plugin@${{ matrix.ts-eslint-plugin-version }} @typescript-eslint/parser@${{ matrix.ts-eslint-plugin-version }}
       - name: run tests
         # only collect coverage on eslint versions that support dynamic import
         run: yarn test --coverage ${{ matrix.eslint-version >= 8 }}


### PR DESCRIPTION
Pulled across from #1401