### PR TITLE
feat(valid-title): support ignoring leading and trailing whitespace

### DIFF
--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -125,8 +125,8 @@ describe('foo', () => {
 
 **accidentalSpace**
 
-A `describe` / `test` block should not contain accidentalSpace, but can be turned off via
-the `ignoreSpaces` option:
+A `describe` / `test` block should not contain accidentalSpace, but can be
+turned off via the `ignoreSpaces` option:
 
 Examples of **incorrect** code for this rule
 

--- a/docs/rules/valid-title.md
+++ b/docs/rules/valid-title.md
@@ -125,7 +125,8 @@ describe('foo', () => {
 
 **accidentalSpace**
 
-A `describe` / `test` block should not contain accidentalSpace
+A `describe` / `test` block should not contain accidentalSpace, but can be turned off via
+the `ignoreSpaces` option:
 
 Examples of **incorrect** code for this rule
 
@@ -161,12 +162,19 @@ describe('foo', () => {
 
 ```ts
 interface Options {
+  ignoreSpaces?: boolean;
   ignoreTypeOfDescribeName?: boolean;
   disallowedWords?: string[];
   mustNotMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
   mustMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
 }
 ```
+
+#### `ignoreSpaces`
+
+Default: `false`
+
+When enabled, the leading and trailing spaces won't be checked.
 
 #### `ignoreTypeOfDescribeName`
 

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -848,6 +848,10 @@ ruleTester.run('no-accidental-space', rule, {
         it('bar', () => {})
       })
     `,
+    {
+      code: 'it(`GIVEN... \n  `, () => {});',
+      options: [{ ignoreSpaces: true }],
+    },
   ],
   invalid: [
     {

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -85,6 +85,7 @@ const MatcherAndMessageSchema: JSONSchema.JSONSchema7 = {
 type MatcherGroups = 'describe' | 'test' | 'it';
 
 interface Options {
+  ignoreSpaces?: boolean;
   ignoreTypeOfDescribeName?: boolean;
   disallowedWords?: string[];
   mustNotMatch?:
@@ -132,6 +133,10 @@ export default createRule<[Options], MessageIds>({
       {
         type: 'object',
         properties: {
+          ignoreSpaces: {
+            type: 'boolean',
+            default: false,
+          },
           ignoreTypeOfDescribeName: {
             type: 'boolean',
             default: false,
@@ -161,11 +166,16 @@ export default createRule<[Options], MessageIds>({
     ],
     fixable: 'code',
   },
-  defaultOptions: [{ ignoreTypeOfDescribeName: false, disallowedWords: [] }],
+  defaultOptions: [{ 
+    ignoreSpaces: false,
+    ignoreTypeOfDescribeName: false,
+    disallowedWords: [],
+  }],
   create(
     context,
     [
       {
+        ignoreSpaces,
         ignoreTypeOfDescribeName,
         disallowedWords = [],
         mustNotMatch,
@@ -247,7 +257,7 @@ export default createRule<[Options], MessageIds>({
           }
         }
 
-        if (title.trim().length !== title.length) {
+        if (ignoreSpaces === false && title.trim().length !== title.length) {
           context.report({
             messageId: 'accidentalSpace',
             node: argument,

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -166,11 +166,13 @@ export default createRule<[Options], MessageIds>({
     ],
     fixable: 'code',
   },
-  defaultOptions: [{ 
-    ignoreSpaces: false,
-    ignoreTypeOfDescribeName: false,
-    disallowedWords: [],
-  }],
+  defaultOptions: [
+    {
+      ignoreSpaces: false,
+      ignoreTypeOfDescribeName: false,
+      disallowedWords: [],
+    },
+  ],
   create(
     context,
     [


### PR DESCRIPTION
We use BDD style test names and want some trailing space for formatting
```js
describe('Feature: ...', () => {
    it(`GIVEN ...
        WHEN ...
        THEN ...
    `, () => {
        // test body
    });
});
```