### PR TITLE
`no-focused-tests` now highlights only the `fit` and `fdescribe` part of the node

### DIFF
--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -31,6 +31,7 @@ export default createRule({
           context.report({
             messageId: 'focusedTest',
             node,
+            loc: jestFnCall.head.node.loc,
             suggest: [
               {
                 messageId: 'suggestRemoveFocus',
@@ -63,6 +64,7 @@ export default createRule({
         context.report({
           messageId: 'focusedTest',
           node: onlyNode,
+          loc: onlyNode.loc,
           suggest: [
             {
               messageId: 'suggestRemoveFocus',


### PR DESCRIPTION
Fixes #1439.

<table>
<tr>
 <td>
Before
 <td>
After
<tr>
 <td>
<img width="382" alt="Screenshot 2023-09-29 at 20 05 25" src="https://github.com/jest-community/eslint-plugin-jest/assets/100233/d65dea34-d2ac-4351-b5d8-b79c50d01252">

 <td>
<img width="362" alt="Screenshot 2023-09-29 at 20 05 45" src="https://github.com/jest-community/eslint-plugin-jest/assets/100233/042a98a8-e670-4f58-9c38-c6ac7747fcc9">

</table>


We have control over what is highlighter by eslint. The `report` gives us the power to do that. You can see before that the editor just guesses, and sometimes it works, some it doesnt. You also see that after, things all are highlighted correctly.