### PR TITLE
fix: make rule message punctuation consistent

### DIFF
--- a/src/rules/max-expects.ts
+++ b/src/rules/max-expects.ts
@@ -16,7 +16,7 @@ export default createRule({
     },
     messages: {
       exceededMaxAssertion:
-        'Too many assertion calls ({{ count }}). Maximum allowed is {{ max }}.',
+        'Too many assertion calls ({{ count }}) - maximum allowed is {{ max }}',
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -11,7 +11,7 @@ export default createRule({
     },
     messages: {
       exceededMaxDepth:
-        'Too many nested describe calls ({{ depth }}). Maximum allowed is {{ max }}.',
+        'Too many nested describe calls ({{ depth }}) - maximum allowed is {{ max }}',
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -10,7 +10,7 @@ export default createRule({
       recommended: 'error',
     },
     messages: {
-      unexpectedExport: `Do not export from a test file.`,
+      unexpectedExport: `Do not export from a test file`,
     },
     type: 'suggestion',
     schema: [],

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -10,8 +10,8 @@ export default createRule({
       recommended: 'error',
     },
     messages: {
-      focusedTest: 'Unexpected focused test.',
-      suggestRemoveFocus: 'Remove focus from test.',
+      focusedTest: 'Unexpected focused test',
+      suggestRemoveFocus: 'Remove focus from test',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -27,9 +27,9 @@ export default createRule({
     },
     messages: {
       multipleTestTitle:
-        'Test title is used multiple times in the same describe block.',
+        'Test title is used multiple times in the same describe block',
       multipleDescribeTitle:
-        'Describe block title is used multiple times in the same describe block.',
+        'Describe block title is used multiple times in the same describe block',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/no-if.ts
+++ b/src/rules/no-if.ts
@@ -43,7 +43,7 @@ export default createRule({
       recommended: false,
     },
     messages: {
-      conditionalInTest: 'Test should not contain {{ condition }} statements.',
+      conditionalInTest: 'Test should not contain {{ condition }} statements',
     },
     deprecated: true,
     replacedBy: ['no-conditional-in-test'],

--- a/src/rules/no-mocks-import.ts
+++ b/src/rules/no-mocks-import.ts
@@ -22,7 +22,7 @@ export default createRule({
       recommended: 'error',
     },
     messages: {
-      noManualImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use \`jest.mock\` and import from the original module path.`,
+      noManualImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use \`jest.mock\` and import from the original module path`,
     },
     schema: [],
   },

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -65,7 +65,7 @@ export default createRule<
       recommended: 'error',
     },
     messages: {
-      unexpectedExpect: 'Expect must be inside of a test block.',
+      unexpectedExpect: 'Expect must be inside of a test block',
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -29,7 +29,7 @@ export default createRule({
       recommended: false,
     },
     messages: {
-      noReturnValue: 'Jest tests should not return a value.',
+      noReturnValue: 'Jest tests should not return a value',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/prefer-expect-resolves.ts
+++ b/src/rules/prefer-expect-resolves.ts
@@ -12,7 +12,7 @@ export default createRule({
     },
     fixable: 'code',
     messages: {
-      expectResolves: 'Use `await expect(...).resolves instead.',
+      expectResolves: 'Use `await expect(...).resolves instead',
     },
     schema: [],
     type: 'suggestion',

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -73,7 +73,7 @@ export default createRule({
       recommended: false,
     },
     messages: {
-      useJestSpyOn: 'Use jest.spyOn() instead.',
+      useJestSpyOn: 'Use jest.spyOn() instead',
     },
     fixable: 'code',
     schema: [],

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -120,14 +120,14 @@ export default createRule<[Options], MessageIds>({
       recommended: 'error',
     },
     messages: {
-      tooManyArgs: 'Expect takes at most {{ amount }} argument{{ s }}.',
-      notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}.',
-      modifierUnknown: 'Expect has an unknown modifier.',
-      matcherNotFound: 'Expect must have a corresponding matcher call.',
-      matcherNotCalled: 'Matchers must be called to assert.',
-      asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}.',
+      tooManyArgs: 'Expect takes at most {{ amount }} argument{{ s }}',
+      notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
+      modifierUnknown: 'Expect has an unknown modifier',
+      matcherNotFound: 'Expect must have a corresponding matcher call',
+      matcherNotCalled: 'Matchers must be called to assert',
+      asyncMustBeAwaited: 'Async assertions must be awaited{{ orReturned }}',
       promisesWithAsyncAssertionsMustBeAwaited:
-        'Promises which return async assertions must be awaited{{ orReturned }}.',
+        'Promises which return async assertions must be awaited{{ orReturned }}',
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -122,7 +122,7 @@ export default createRule<[Options], MessageIds>({
       emptyTitle: '{{ jestFunctionName }} should not have an empty title',
       duplicatePrefix: 'should not have duplicate prefix',
       accidentalSpace: 'should not have leading or trailing spaces',
-      disallowedWord: '"{{ word }}" is not allowed in test titles.',
+      disallowedWord: '"{{ word }}" is not allowed in test titles',
       mustNotMatch: '{{ jestFunctionName }} should not match {{ pattern }}',
       mustMatch: '{{ jestFunctionName }} should match {{ pattern }}',
       mustNotMatchCustom: '{{ message }}',


### PR DESCRIPTION
As far as I know ESLint does not have an official stance on the punctuation of rule messages, but in my experience it makes more sense to not end with a full stop because tools either display the rule at the end of their message (e.g. "<message> (<rule>)") or have nothing (such as in GitHub Actions annotations, iirc) - either way this at least makes us consistent, and we can invert it later if I turn out to be wrong 🤷 