### PR TITLE
test(detectJestVersion): strip ansi before comparing

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "rimraf": "^5.0.0",
     "semantic-release": "^22.0.0",
     "semver": "^7.3.5",
+    "strip-ansi": "^6.0.0",
     "ts-node": "^10.2.1",
     "typescript": "^5.0.4"
   },

--- a/src/rules/utils/__tests__/detectJestVersion.test.ts
+++ b/src/rules/utils/__tests__/detectJestVersion.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
+import stripAnsi from 'strip-ansi';
 import { create } from 'ts-node';
 import { detectJestVersion } from '../detectJestVersion';
 
@@ -18,10 +19,13 @@ const compiledFn = compileFnCode(require.resolve('../detectJestVersion.ts'));
 const relativePathToFn = 'eslint-plugin-jest/lib/rules/detectJestVersion.js';
 
 const runNodeScript = (cwd: string, script: string) => {
-  return spawnSync('node', ['-e', script.split('\n').join(' ')], {
-    cwd,
-    encoding: 'utf-8',
-  });
+  const { stdout, stderr } = spawnSync(
+    'node',
+    ['-e', script.split('\n').join(' ')],
+    { cwd, encoding: 'utf-8' },
+  );
+
+  return { stdout: stripAnsi(stdout.trim()), stderr: stripAnsi(stderr.trim()) };
 };
 
 const runDetectJestVersion = (cwd: string) => {
@@ -120,8 +124,8 @@ describe('detectJestVersion', () => {
 
       const { stdout, stderr } = runDetectJestVersion(projectDir);
 
-      expect(stdout.trim()).toBe('21');
-      expect(stderr.trim()).toBe('');
+      expect(stdout).toBe('21');
+      expect(stderr).toBe('');
     });
   });
 
@@ -140,8 +144,8 @@ describe('detectJestVersion', () => {
 
       const { stdout, stderr } = runDetectJestVersion(projectDir);
 
-      expect(stdout.trim()).toBe('19');
-      expect(stderr.trim()).toBe('');
+      expect(stdout).toBe('19');
+      expect(stderr).toBe('');
     });
   });
 
@@ -165,14 +169,14 @@ describe('detectJestVersion', () => {
       const { stdout: stdoutBackend, stderr: stderrBackend } =
         runDetectJestVersion(path.join(projectDir, 'backend'));
 
-      expect(stdoutBackend.trim()).toBe('24');
-      expect(stderrBackend.trim()).toBe('');
+      expect(stdoutBackend).toBe('24');
+      expect(stderrBackend).toBe('');
 
       const { stdout: stdoutFrontend, stderr: stderrFrontend } =
         runDetectJestVersion(path.join(projectDir, 'frontend'));
 
-      expect(stdoutFrontend.trim()).toBe('15');
-      expect(stderrFrontend.trim()).toBe('');
+      expect(stdoutFrontend).toBe('15');
+      expect(stderrFrontend).toBe('');
     });
   });
 
@@ -186,8 +190,8 @@ describe('detectJestVersion', () => {
 
       const { stdout, stderr } = runDetectJestVersion(projectDir);
 
-      expect(stdout.trim()).toBe('');
-      expect(stderr.trim()).toContain('Unable to detect Jest version');
+      expect(stdout).toBe('');
+      expect(stderr).toContain('Unable to detect Jest version');
     });
   });
 
@@ -221,7 +225,7 @@ describe('detectJestVersion', () => {
 
       expect(firstCall).toBe('26');
       expect(secondCall).toBe('26');
-      expect(stderr.trim()).toBe('');
+      expect(stderr).toBe('');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5095,6 +5095,7 @@ __metadata:
     rimraf: ^5.0.0
     semantic-release: ^22.0.0
     semver: ^7.3.5
+    strip-ansi: ^6.0.0
     ts-node: ^10.2.1
     typescript: ^5.0.4
   peerDependencies:


### PR DESCRIPTION
For some reason when running these tests on Jest v29.2.1 and Node v20.6.0 they fail because of coloring - this doesn't cause problems in CI as color output is disabled nor does it happen if we use `toStrictEqual` but that felt wrong since we have a rule called `prefer-to-be`...