### PR TITLE
fix(expect-expert): report on test function identifier rather than body

### DIFF
--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -93,7 +93,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -102,7 +102,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -111,7 +111,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -120,7 +120,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.MemberExpression,
         },
       ],
     },
@@ -130,7 +130,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -144,7 +144,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -153,7 +153,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -163,7 +163,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -173,7 +173,7 @@ ruleTester.run('expect-expect', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -235,7 +235,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -245,7 +245,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -255,7 +255,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -265,7 +265,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -275,7 +275,7 @@ ruleTester.run('wildcards', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -338,7 +338,7 @@ ruleTester.run('expect-expect (aliases)', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.Identifier,
         },
       ],
     },
@@ -354,7 +354,7 @@ ruleTester.run('expect-expect (aliases)', rule, {
       errors: [
         {
           messageId: 'noAssertions',
-          type: AST_NODE_TYPES.CallExpression,
+          type: AST_NODE_TYPES.MemberExpression,
         },
       ],
     },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -134,7 +134,7 @@ export default createRule<
       },
       'Program:exit'() {
         unchecked.forEach(node =>
-          context.report({ messageId: 'noAssertions', node }),
+          context.report({ messageId: 'noAssertions', node: node.callee }),
         );
       },
     };


### PR DESCRIPTION
Resolves #654
Resolves #641
Resolves #539