### PR TITLE
feat: include plugin `meta` information for ESLint v9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
 import type { TSESLint } from '@typescript-eslint/utils';
+import {
+  name as packageName,
+  version as packageVersion,
+} from '../package.json';
 import globals from './globals.json';
 import * as snapshotProcessor from './processors/snapshot-processor';
 
@@ -56,6 +60,7 @@ const createConfig = (rules: Record<string, TSESLint.Linter.RuleLevel>) => ({
 });
 
 export = {
+  meta: { name: packageName, version: packageVersion },
   configs: {
     all: createConfig(allRules),
     recommended: createConfig(recommendedRules),


### PR DESCRIPTION
Relates to #1408

See https://eslint.org/docs/latest/extend/plugin-migration-flat-config#adding-plugin-meta-information

It seems like this is backwards compatible - I've at least done a quick test with an older version of ESLint and it didn't care 🤷 