### PR TITLE
chore: update `moduleResolution` and `module` to `node16`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "node",
-    "module": "commonjs",
+    "moduleResolution": "node16",
+    "module": "node16",
     "noEmit": true,
     "stripInternal": true,
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
-    "moduleResolution": "node16",
-    "module": "node16",
     "noEmit": true,
     "stripInternal": true,
 


### PR DESCRIPTION
I'm honestly still trying to wrap my head around these new settings, but this is required for `@typescript-eslint/utils` v6 and doesn't seem to result in any different output (which makes sense since we're compiling with Babel) so I think this is safe to land.