### PR TITLE
chore: avoid TypeScript 5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,5 +160,8 @@
   },
   "publishConfig": {
     "provenance": true
+  },
+  "resolutions": {
+    "typescript": "~5.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10864,7 +10864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.4 || ^5.2.2, typescript@npm:^5.0.4":
+"typescript@npm:~5.2.2":
   version: 5.2.2
   resolution: "typescript@npm:5.2.2"
   bin:
@@ -10874,7 +10874,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.4 || ^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A~5.2.2#~builtin<compat/typescript>":
   version: 5.2.2
   resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
   bin:


### PR DESCRIPTION
Another one to unblock #1467 - it seems TS 5.3 is broken via `ts-node` somehow. Probably what made #1471 happen as well.

EDIT: yeah: https://github.com/TypeStrong/ts-node/pull/2091