### PR TITLE
fix: include plugin `meta` information with snapshot processor for ESLint v9

### DIFF
--- a/src/processors/snapshot-processor.ts
+++ b/src/processors/snapshot-processor.ts
@@ -1,8 +1,13 @@
 // https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins
 // https://github.com/typescript-eslint/typescript-eslint/issues/808
+import {
+  name as packageName,
+  version as packageVersion,
+} from '../../package.json';
 
 type PostprocessMessage = { ruleId: string };
 
+export const meta = { name: packageName, version: packageVersion };
 export const preprocess = (source: string): string[] => [source];
 export const postprocess = (messages: PostprocessMessage[][]) =>
   // snapshot files should only be linted with snapshot specific rules


### PR DESCRIPTION
Related to #1454

 While not stated in eslint's (incomplete) migration guide, the meta object is explicitly required by the [flat config source](https://github.com/eslint/eslint/blob/2a8eea8e5847f4103d90d667a2b08edf9795545f/lib/config/flat-config-array.js#L223).