### PR TITLE
chore: format `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "skipLibCheck": false,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": true
   },
   "files": ["eslint-remote-tester.config.ts"],
   "include": ["src/**/*", "tools/**/*"],
-  "exclude": ["src/rules/__tests__/fixtures/**/*"],
+  "exclude": ["src/rules/__tests__/fixtures/**/*"]
 }


### PR DESCRIPTION
This was because of a change in `prettier` that has then been reverted