### PR TITLE
ci: don't test `@typescript-eslint` v7 against Node v19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -84,6 +84,9 @@ jobs:
           # ts-eslint/plugin@7 doesn't support node@16
           - node-version: 16.x
             ts-eslint-plugin-version: 7
+          # ts-eslint/plugin@7 doesn't support node@19
+          - node-version: 19.x
+            ts-eslint-plugin-version: 7
           # ts-eslint/plugin@7 doesn't support eslint@7
           - eslint-version: 7
             ts-eslint-plugin-version: 7


### PR DESCRIPTION
While the tests are passing, it's not officially supported for v7 and excluding it saves us a few CI jobs in the matrix.