### PR TITLE
refactor: use types from `@typescript-eslint/utils` for snapshot processor

### DIFF
--- a/src/processors/__tests__/snapshot-processor.test.ts
+++ b/src/processors/__tests__/snapshot-processor.test.ts
@@ -12,7 +12,7 @@ describe('snapshot-processor', () => {
     it('should pass on untouched source code to source array', () => {
       const { preprocess } = snapshotProcessor;
       const sourceCode = "const name = 'johnny bravo';";
-      const result = preprocess(sourceCode);
+      const result = preprocess(sourceCode, 'my-file.snap');
 
       expect(result).toEqual([sourceCode]);
     });
@@ -21,13 +21,35 @@ describe('snapshot-processor', () => {
   describe('postprocess function', () => {
     it('should only return messages about snapshot specific rules', () => {
       const { postprocess } = snapshotProcessor;
-      const result = postprocess([
-        ['no-console', 'global-require', 'jest/no-large-snapshots'].map(
-          ruleId => ({ ruleId }),
-        ),
-      ]);
 
-      expect(result).toEqual([{ ruleId: 'jest/no-large-snapshots' }]);
+      const result = postprocess(
+        [
+          ['no-console', 'global-require', 'jest/no-large-snapshots'].map(
+            ruleId => ({
+              ruleId,
+              column: 1,
+              line: 1,
+              source: null,
+              nodeType: 'Program',
+              message: 'something is not right about this...',
+              severity: 1,
+            }),
+          ),
+        ],
+        'my-file.snap',
+      );
+
+      expect(result).toEqual([
+        {
+          ruleId: 'jest/no-large-snapshots',
+          column: 1,
+          line: 1,
+          source: null,
+          nodeType: 'Program',
+          message: 'something is not right about this...',
+          severity: 1,
+        },
+      ]);
     });
   });
 });

--- a/src/processors/snapshot-processor.ts
+++ b/src/processors/snapshot-processor.ts
@@ -1,14 +1,15 @@
 // https://eslint.org/docs/developer-guide/working-with-plugins#processors-in-plugins
 // https://github.com/typescript-eslint/typescript-eslint/issues/808
+import type { TSESLint } from '@typescript-eslint/utils';
 import {
   name as packageName,
   version as packageVersion,
 } from '../../package.json';
 
-type PostprocessMessage = { ruleId: string };
+type SnapshotProcessor = Required<TSESLint.Linter.Processor>;
 
 export const meta = { name: packageName, version: packageVersion };
-export const preprocess = (source: string): string[] => [source];
-export const postprocess = (messages: PostprocessMessage[][]) =>
+export const preprocess: SnapshotProcessor['preprocess'] = source => [source];
+export const postprocess: SnapshotProcessor['postprocess'] = messages =>
   // snapshot files should only be linted with snapshot specific rules
   messages[0].filter(message => message.ruleId === 'jest/no-large-snapshots');


### PR DESCRIPTION
Mostly useful because it means we're more compatible with the `Plugin` type which I'm using in another branch