### PR TITLE
feat: upgrade `@typescript-eslint/utils` to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^5.10.0"
+    "@typescript-eslint/utils": "^6.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
-import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint } from '@typescript-eslint/utils';
 import {
   name as packageName,
   version as packageVersion,
@@ -11,39 +11,6 @@ import * as snapshotProcessor from './processors/snapshot-processor';
 type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
   meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
 };
-
-// v5 of `@typescript-eslint/experimental-utils` removed this
-declare module '@typescript-eslint/utils/dist/ts-eslint/Rule' {
-  export interface RuleMetaDataDocs {
-    category: 'Best Practices' | 'Possible Errors';
-  }
-}
-
-declare module '@typescript-eslint/utils/dist/ts-eslint/SourceCode' {
-  export interface SourceCode {
-    /**
-     * Returns the scope of the given node.
-     * This information can be used track references to variables.
-     * @since 8.37.0
-     */
-    getScope(node: TSESTree.Node): TSESLint.Scope.Scope;
-    /**
-     * Returns an array of the ancestors of the given node, starting at
-     * the root of the AST and continuing through the direct parent of the current node.
-     * This array does not include the currently-traversed node itself.
-     * @since 8.38.0
-     */
-    getAncestors(node: TSESTree.Node): TSESTree.Node[];
-    /**
-     * Returns a list of variables declared by the given node.
-     * This information can be used to track references to variables.
-     * @since 8.38.0
-     */
-    getDeclaredVariables(
-      node: TSESTree.Node,
-    ): readonly TSESLint.Scope.Variable[];
-  }
-}
 
 // copied from https://github.com/babel/babel/blob/d8da63c929f2d28c401571e2a43166678c555bc4/packages/babel-helpers/src/helpers.js#L602-L606
 /* istanbul ignore next */

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { ESLintUtils, type TSESLint } from '@typescript-eslint/utils';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import type { MessageIds, Options } from '../unbound-method';
 
@@ -9,14 +9,24 @@ function getFixturesRootDir(): string {
 
 const rootPath = getFixturesRootDir();
 
-const ruleTester = new ESLintUtils.RuleTester({
-  parser: '@typescript-eslint/parser',
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: {
     sourceType: 'module',
     tsconfigRootDir: rootPath,
     project: './tsconfig.json',
   },
 });
+
+const fixtureFilename = path.join(rootPath, 'file.ts');
+
+const addFixtureFilename = (
+  code: TSESLint.ValidTestCase<unknown[]> | string,
+): TSESLint.ValidTestCase<unknown[]> => {
+  const test = typeof code === 'string' ? { code } : code;
+
+  return { filename: fixtureFilename, ...test };
+};
 
 const ConsoleClassAndVariableCode = dedent`
   class Console {
@@ -164,8 +174,8 @@ describe('error handling', () => {
   });
 
   describe('when @typescript-eslint/eslint-plugin is not available', () => {
-    const ruleTester = new ESLintUtils.RuleTester({
-      parser: '@typescript-eslint/parser',
+    const ruleTester = new TSESLint.RuleTester({
+      parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
         sourceType: 'module',
         tsconfigRootDir: rootPath,
@@ -185,7 +195,7 @@ describe('error handling', () => {
 });
 
 ruleTester.run('unbound-method jest edition', requireRule(false), {
-  valid: validTestCases,
+  valid: validTestCases.map(addFixtureFilename),
   invalid: invalidTestCases,
 });
 
@@ -456,7 +466,7 @@ class OtherClass extends BaseClass {
 const oc = new OtherClass();
 oc.superLogThis();
     `,
-  ],
+  ].map(addFixtureFilename),
   invalid: [
     {
       code: `

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -230,6 +230,7 @@ ruleTester.run('unbound-method', requireRule(false), {
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
     'const x = console.log;',
+    'const x = Object.defineProperty;',
     ...[
       'instance.bound();',
       'instance.unbound();',
@@ -758,6 +759,60 @@ class OtherClass extends BaseClass {
         {
           line: 9,
           column: 9,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  a() {},
+  b: () => {},
+};
+
+const { a, b } = values;
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 9,
+          endColumn: 10,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  a() {},
+  b: () => {},
+};
+
+const { a: c } = values;
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 9,
+          endColumn: 10,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    },
+    {
+      code: `
+const values = {
+  a() {},
+  b: () => {},
+};
+
+const { b, a } = values;
+      `,
+      errors: [
+        {
+          line: 7,
+          column: 12,
+          endColumn: 13,
           messageId: 'unboundWithoutThisAnnotation',
         },
       ],

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { version as rawTypeScriptESLintPluginVersion } from '@typescript-eslint/eslint-plugin/package.json';
 import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import type { MessageIds, Options } from '../unbound-method';
@@ -252,7 +253,9 @@ ruleTester.run('unbound-method', requireRule(false), {
     "['1', '2', '3'].map(Number.parseInt);",
     '[5.2, 7.1, 3.6].map(Math.floor);',
     'const x = console.log;',
-    'const x = Object.defineProperty;',
+    ...(parseInt(rawTypeScriptESLintPluginVersion.split('.')[0], 10) >= 6
+      ? ['const x = Object.defineProperty;']
+      : []),
     ...[
       'instance.bound();',
       'instance.unbound();',

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -35,9 +35,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce `test` and `it` usage conventions',
-      recommended: false,
     },
     fixable: 'code',
     messages: {

--- a/src/rules/consistent-test-it.ts
+++ b/src/rules/consistent-test-it.ts
@@ -49,9 +49,11 @@ export default createRule<
         type: 'object',
         properties: {
           fn: {
+            type: 'string',
             enum: [TestCaseName.it, TestCaseName.test],
           },
           withinDescribe: {
+            type: 'string',
             enum: [TestCaseName.it, TestCaseName.test],
           },
         },

--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -54,9 +54,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce assertion to be made in a test body',
-      recommended: 'warn',
     },
     messages: {
       noAssertions: 'Test has no assertions',

--- a/src/rules/max-expects.ts
+++ b/src/rules/max-expects.ts
@@ -10,9 +10,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforces a maximum number assertion calls in a test body',
-      recommended: false,
     },
     messages: {
       exceededMaxAssertion:

--- a/src/rules/max-nested-describe.ts
+++ b/src/rules/max-nested-describe.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforces a maximum depth to nested describe calls',
-      recommended: false,
     },
     messages: {
       exceededMaxDepth:

--- a/src/rules/no-alias-methods.ts
+++ b/src/rules/no-alias-methods.ts
@@ -9,9 +9,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow alias methods',
-      recommended: 'error',
     },
     messages: {
       replaceAlias: `Replace {{ alias }}() with its canonical name of {{ canonical }}()`,

--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -11,9 +11,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow commented out tests',
-      recommended: 'warn',
     },
     messages: {
       commentedTests: 'Some tests seem to be commented',

--- a/src/rules/no-conditional-expect.ts
+++ b/src/rules/no-conditional-expect.ts
@@ -20,8 +20,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallow calling `expect` conditionally',
-      category: 'Best Practices',
-      recommended: 'error',
     },
     messages: {
       conditionalExpect: 'Avoid calling `expect` conditionally`',

--- a/src/rules/no-conditional-in-test.ts
+++ b/src/rules/no-conditional-in-test.ts
@@ -6,8 +6,6 @@ export default createRule({
   meta: {
     docs: {
       description: 'Disallow conditional logic in tests',
-      category: 'Best Practices',
-      recommended: false,
     },
     messages: {
       conditionalInTest: 'Avoid having conditionals in tests',

--- a/src/rules/no-confusing-set-timeout.ts
+++ b/src/rules/no-confusing-set-timeout.ts
@@ -18,9 +18,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow confusing usages of jest.setTimeout',
-      recommended: false,
     },
     messages: {
       globalSetTimeout: '`jest.setTimeout` should be call in `global` scope',

--- a/src/rules/no-deprecated-functions.ts
+++ b/src/rules/no-deprecated-functions.ts
@@ -28,9 +28,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow use of deprecated functions',
-      recommended: 'error',
     },
     messages: {
       deprecatedFunction:

--- a/src/rules/no-disabled-tests.ts
+++ b/src/rules/no-disabled-tests.ts
@@ -10,9 +10,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow disabled tests',
-      recommended: 'warn',
     },
     messages: {
       missingFunction: 'Test is missing function argument',

--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -37,9 +37,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow using a callback in asynchronous tests and hooks',
-      recommended: 'error',
     },
     messages: {
       noDoneCallback:

--- a/src/rules/no-duplicate-hooks.ts
+++ b/src/rules/no-duplicate-hooks.ts
@@ -4,9 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow duplicate setup and teardown hooks',
-      recommended: false,
     },
     messages: {
       noDuplicateHook: 'Duplicate {{hook}} in describe block',

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow using `exports` in files containing tests',
-      recommended: 'error',
     },
     messages: {
       unexpectedExport: `Do not export from a test file`,

--- a/src/rules/no-focused-tests.ts
+++ b/src/rules/no-focused-tests.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow focused tests',
-      recommended: 'error',
     },
     messages: {
       focusedTest: 'Unexpected focused test',

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -7,9 +7,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow setup and teardown hooks',
-      recommended: false,
     },
     messages: {
       unexpectedHook: "Unexpected '{{ hookName }}' hook",

--- a/src/rules/no-hooks.ts
+++ b/src/rules/no-hooks.ts
@@ -18,6 +18,7 @@ export default createRule<
         properties: {
           allow: {
             type: 'array',
+            // @ts-expect-error https://github.com/eslint/eslint/discussions/17573
             contains: ['beforeAll', 'beforeEach', 'afterAll', 'afterEach'],
           },
         },

--- a/src/rules/no-identical-title.ts
+++ b/src/rules/no-identical-title.ts
@@ -21,9 +21,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow identical titles',
-      recommended: 'error',
     },
     messages: {
       multipleTestTitle:

--- a/src/rules/no-interpolation-in-snapshots.ts
+++ b/src/rules/no-interpolation-in-snapshots.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow string interpolation inside snapshots',
-      recommended: 'error',
     },
     messages: {
       noInterpolation: 'Do not use string interpolation inside of snapshots',

--- a/src/rules/no-jasmine-globals.ts
+++ b/src/rules/no-jasmine-globals.ts
@@ -11,9 +11,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow Jasmine globals',
-      recommended: 'error',
     },
     messages: {
       illegalGlobal:

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -76,9 +76,7 @@ export default createRule<[RuleOptions], MessageId>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow large snapshots',
-      recommended: false,
     },
     messages: {
       noSnapshot: '`{{ lineCount }}`s should begin with lowercase',

--- a/src/rules/no-mocks-import.ts
+++ b/src/rules/no-mocks-import.ts
@@ -17,9 +17,7 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      category: 'Best Practices',
       description: 'Disallow manually importing from `__mocks__`',
-      recommended: 'error',
     },
     messages: {
       noManualImport: `Mocks should not be manually imported from a ${mocksDirName} directory. Instead use \`jest.mock\` and import from the original module path`,

--- a/src/rules/no-restricted-jest-methods.ts
+++ b/src/rules/no-restricted-jest-methods.ts
@@ -12,9 +12,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow specific `jest.` methods',
-      recommended: false,
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/no-restricted-matchers.ts
+++ b/src/rules/no-restricted-matchers.ts
@@ -23,9 +23,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow specific matchers & modifiers',
-      recommended: false,
     },
     type: 'suggestion',
     schema: [

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -60,9 +60,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow using `expect` outside of `it` or `test` blocks',
-      recommended: 'error',
     },
     messages: {
       unexpectedExpect: 'Expect must be inside of a test block',

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -68,6 +68,7 @@ export default createRule<
     type: 'suggestion',
     schema: [
       {
+        type: 'object',
         properties: {
           additionalTestBlockFunctions: {
             type: 'array',

--- a/src/rules/no-test-prefixes.ts
+++ b/src/rules/no-test-prefixes.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Require using `.only` and `.skip` over `f` and `x`',
-      recommended: 'error',
     },
     messages: {
       usePreferredName: 'Use "{{ preferredNodeName }}" instead',

--- a/src/rules/no-test-return-statement.ts
+++ b/src/rules/no-test-return-statement.ts
@@ -25,9 +25,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Disallow explicitly returning from tests',
-      recommended: false,
     },
     messages: {
       noReturnValue: 'Jest tests should not return a value',

--- a/src/rules/no-untyped-mock-factory.ts
+++ b/src/rules/no-untyped-mock-factory.ts
@@ -21,10 +21,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Disallow using `jest.mock()` factories without an explicit type parameter',
-      recommended: false,
     },
     messages: {
       addTypeParameterToModuleMock:

--- a/src/rules/no-untyped-mock-factory.ts
+++ b/src/rules/no-untyped-mock-factory.ts
@@ -36,7 +36,12 @@ export default createRule({
   create(context) {
     return {
       CallExpression(node: TSESTree.CallExpression): void {
-        const { callee, typeParameters } = node;
+        let { callee, typeArguments } = node;
+
+        /* istanbul ignore next */
+        if (!('typeArguments' in node)) {
+          typeArguments = (node as TSESTree.CallExpression).typeParameters;
+        }
 
         if (callee.type !== AST_NODE_TYPES.MemberExpression) {
           return;
@@ -53,7 +58,7 @@ export default createRule({
           const [nameNode, factoryNode] = node.arguments;
 
           const hasTypeParameter =
-            typeParameters !== undefined && typeParameters.params.length > 0;
+            typeArguments !== undefined && typeArguments.params.length > 0;
           const hasReturnType =
             isFunction(factoryNode) && factoryNode.returnType !== undefined;
 

--- a/src/rules/prefer-called-with.ts
+++ b/src/rules/prefer-called-with.ts
@@ -4,10 +4,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`',
-      recommended: false,
     },
     messages: {
       preferCalledWith: 'Prefer {{ matcherName }}With(/* expected args */)',

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -57,9 +57,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using the built-in comparison matchers',
-      recommended: false,
     },
     messages: {
       useToBeComparison: 'Prefer using `{{ preferredMatcher }}` instead',

--- a/src/rules/prefer-each.ts
+++ b/src/rules/prefer-each.ts
@@ -5,9 +5,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer using `.each` rather than manual loops',
-      recommended: false,
     },
     messages: {
       preferEach: 'prefer using `{{ fn }}.each` rather than a manual loop',

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -14,9 +14,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using the built-in equality matchers',
-      recommended: false,
     },
     messages: {
       useEqualityMatcher: 'Prefer using one of the equality matchers instead',

--- a/src/rules/prefer-expect-assertions.ts
+++ b/src/rules/prefer-expect-assertions.ts
@@ -64,10 +64,8 @@ export default createRule<[RuleOptions], MessageIds>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Suggest using `expect.assertions()` OR `expect.hasAssertions()`',
-      recommended: false,
     },
     messages: {
       hasAssertionsTakesNoArguments:

--- a/src/rules/prefer-expect-resolves.ts
+++ b/src/rules/prefer-expect-resolves.ts
@@ -5,10 +5,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Prefer `await expect(...).resolves` over `expect(await ...)` syntax',
-      recommended: false,
     },
     fixable: 'code',
     messages: {

--- a/src/rules/prefer-hooks-in-order.ts
+++ b/src/rules/prefer-hooks-in-order.ts
@@ -6,9 +6,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer having hooks in a consistent order',
-      recommended: false,
     },
     messages: {
       reorderHooks: `\`{{ currentHook }}\` hooks should be before any \`{{ previousHook }}\` hooks`,

--- a/src/rules/prefer-hooks-on-top.ts
+++ b/src/rules/prefer-hooks-on-top.ts
@@ -4,9 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest having hooks before any test cases',
-      recommended: false,
     },
     messages: {
       noHookOnTop: 'Hooks should come before test cases',

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -56,8 +56,6 @@ export default createRule<
     type: 'suggestion',
     docs: {
       description: 'Enforce lowercase test names',
-      category: 'Best Practices',
-      recommended: false,
     },
     fixable: 'code',
     messages: {

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -68,11 +68,14 @@ export default createRule<
           ignore: {
             type: 'array',
             items: {
+              type: 'string',
+              // for some reason TypeScript thinks this _must_ be a read-only
+              // array, so we have to explicitly cast it as a mutable array
               enum: [
                 DescribeAlias.describe,
                 TestCaseName.test,
                 TestCaseName.it,
-              ],
+              ] as string[],
             },
             additionalItems: false,
           },

--- a/src/rules/prefer-mock-promise-shorthand.ts
+++ b/src/rules/prefer-mock-promise-shorthand.ts
@@ -32,9 +32,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer mock resolved/rejected shorthands for promises',
-      recommended: false,
     },
     messages: {
       useMockShorthand: 'Prefer {{ replacement }}',

--- a/src/rules/prefer-snapshot-hint.ts
+++ b/src/rules/prefer-snapshot-hint.ts
@@ -43,9 +43,7 @@ export default createRule<[('always' | 'multi')?], keyof typeof messages>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Prefer including a hint with external snapshots',
-      recommended: false,
     },
     messages,
     type: 'suggestion',

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -68,9 +68,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `jest.spyOn()`',
-      recommended: false,
     },
     messages: {
       useJestSpyOn: 'Use jest.spyOn() instead',

--- a/src/rules/prefer-strict-equal.ts
+++ b/src/rules/prefer-strict-equal.ts
@@ -10,9 +10,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toStrictEqual()`',
-      recommended: false,
     },
     messages: {
       useToStrictEqual: 'Use `toStrictEqual()` instead',

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -93,9 +93,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toBe()` for primitive literals',
-      recommended: false,
     },
     messages: {
       useToBe: 'Use `toBe` when expecting primitive literals',

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -39,9 +39,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toContain()`',
-      recommended: false,
     },
     messages: {
       useToContain: 'Use toContain() instead',

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -11,9 +11,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `toHaveLength()`',
-      recommended: false,
     },
     messages: {
       useToHaveLength: 'Use toHaveLength() instead',

--- a/src/rules/prefer-todo.ts
+++ b/src/rules/prefer-todo.ts
@@ -55,9 +55,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Suggest using `test.todo`',
-      recommended: false,
     },
     messages: {
       emptyTest: 'Prefer todo test case over empty test case',

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -65,9 +65,7 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Require setup and teardown code to be within a hook',
-      recommended: false,
     },
     messages: {
       useHook: 'This should be done within a hook',

--- a/src/rules/require-to-throw-message.ts
+++ b/src/rules/require-to-throw-message.ts
@@ -4,9 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Require a message for `toThrow()`',
-      recommended: false,
     },
     messages: {
       addErrorMessage: 'Add an error message to {{ matcherName }}()',

--- a/src/rules/require-top-level-describe.ts
+++ b/src/rules/require-top-level-describe.ts
@@ -15,10 +15,8 @@ export default createRule<
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Require test cases and hooks to be inside a `describe` block',
-      recommended: false,
     },
     messages,
     type: 'suggestion',

--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -60,12 +60,12 @@ export default createRule<Options, MessageIds>({
     type: 'problem',
     ...baseRule?.meta,
     docs: {
-      category: 'Best Practices',
       description:
         'Enforce unbound methods are called with their expected scope',
       requiresTypeChecking: true,
       ...baseRule?.meta.docs,
-      recommended: false,
+      // mark this as not recommended
+      recommended: undefined,
     },
   },
   create(context) {

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -48,9 +48,7 @@ const rule = createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Possible Errors',
       description: 'Fake rule for testing parseJestFnCall',
-      recommended: false,
     },
     messages: {
       details: '{{ data }}',

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -234,18 +234,14 @@ export const getFirstMatcherArg = (
 export const getFilename = (
   context: TSESLint.RuleContext<string, unknown[]>,
 ) => {
-  return 'filename' in context
-    ? (context.filename as string)
-    : context.getFilename();
+  return context.filename ?? context.getFilename();
 };
 
 /* istanbul ignore next */
 export const getSourceCode = (
   context: TSESLint.RuleContext<string, unknown[]>,
 ) => {
-  return 'sourceCode' in context
-    ? (context.sourceCode as TSESLint.SourceCode)
-    : context.getSourceCode();
+  return context.sourceCode ?? context.getSourceCode();
 };
 
 /* istanbul ignore next */
@@ -253,13 +249,7 @@ export const getScope = (
   context: TSESLint.RuleContext<string, unknown[]>,
   node: TSESTree.Node,
 ) => {
-  const sourceCode = getSourceCode(context);
-
-  if ('getScope' in sourceCode) {
-    return sourceCode.getScope(node);
-  }
-
-  return context.getScope();
+  return getSourceCode(context).getScope?.(node) ?? context.getScope();
 };
 
 /* istanbul ignore next */
@@ -267,13 +257,7 @@ export const getAncestors = (
   context: TSESLint.RuleContext<string, unknown[]>,
   node: TSESTree.Node,
 ) => {
-  const sourceCode = getSourceCode(context);
-
-  if ('getAncestors' in sourceCode) {
-    return sourceCode.getAncestors(node);
-  }
-
-  return context.getAncestors();
+  return getSourceCode(context).getAncestors?.(node) ?? context.getAncestors();
 };
 
 /* istanbul ignore next */
@@ -281,11 +265,8 @@ export const getDeclaredVariables = (
   context: TSESLint.RuleContext<string, unknown[]>,
   node: TSESTree.Node,
 ) => {
-  const sourceCode = getSourceCode(context);
-
-  if ('getDeclaredVariables' in sourceCode) {
-    return sourceCode.getDeclaredVariables(node);
-  }
-
-  return context.getDeclaredVariables(node);
+  return (
+    getSourceCode(context).getDeclaredVariables?.(node) ??
+    context.getDeclaredVariables(node)
+  );
 };

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -183,20 +183,21 @@ const ValidJestFnCallChains = [
   'xtest.failing.each',
 ];
 
-declare module '@typescript-eslint/utils/dist/ts-eslint' {
-  export interface SharedConfigurationSettings {
-    jest?: {
-      globalAliases?: Record<string, string[]>;
-      version?: number | string;
-    };
-  }
+// todo: switch back to using declaration merging once https://github.com/typescript-eslint/typescript-eslint/pull/8485
+//  is landed
+interface SharedConfigurationSettings {
+  jest?: {
+    globalAliases?: Record<string, string[]>;
+    version?: number | string;
+  };
 }
 
 const resolvePossibleAliasedGlobal = (
   global: string,
   context: TSESLint.RuleContext<string, unknown[]>,
 ) => {
-  const globalAliases = context.settings.jest?.globalAliases ?? {};
+  const globalAliases =
+    (context.settings as SharedConfigurationSettings).jest?.globalAliases ?? {};
 
   const alias = Object.entries(globalAliases).find(([, aliases]) =>
     aliases.includes(global),

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -23,9 +23,7 @@ export default createRule({
   meta: {
     type: 'problem',
     docs: {
-      category: 'Possible Errors',
       description: 'Enforce valid `describe()` callback',
-      recommended: 'error',
     },
     messages: {
       nameAndCallback: 'Describe requires name and callback arguments',

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -344,10 +344,8 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description:
         'Require promises that have expectations in their chain to be valid',
-      recommended: 'error',
     },
     messages: {
       expectInFloatingPromise:

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -115,9 +115,7 @@ export default createRule<[Options], MessageIds>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce valid `expect()` usage',
-      recommended: 'error',
     },
     messages: {
       tooManyArgs: 'Expect takes at most {{ amount }} argument{{ s }}',

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -114,9 +114,7 @@ export default createRule<[Options], MessageIds>({
   name: __filename,
   meta: {
     docs: {
-      category: 'Best Practices',
       description: 'Enforce valid titles',
-      recommended: 'error',
     },
     messages: {
       titleMustBeString: 'Title must be a string',

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -74,7 +74,7 @@ const compileMatcherPatterns = (
 type CompiledMatcherAndMessage = [matcher: RegExp, message?: string];
 type MatcherAndMessage = [matcher: string, message?: string];
 
-const MatcherAndMessageSchema: JSONSchema.JSONSchema7 = {
+const MatcherAndMessageSchema: JSONSchema.JSONSchema4 = {
   type: 'array',
   items: { type: 'string' },
   minItems: 1,
@@ -156,6 +156,7 @@ export default createRule<[Options], MessageIds>({
               MatcherAndMessageSchema,
               {
                 type: 'object',
+                // @ts-expect-error https://github.com/eslint/eslint/discussions/17573
                 propertyNames: { enum: ['describe', 'test', 'it'] },
                 additionalProperties: {
                   oneOf: [{ type: 'string' }, MatcherAndMessageSchema],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,7 +1650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.2.0":
+"@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -2844,7 +2844,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
@@ -2902,10 +2902,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.3.12":
-  version: 7.5.8
-  resolution: "@types/semver@npm:7.5.8"
-  checksum: ea6f5276f5b84c55921785a3a27a3cd37afee0111dfe2bcb3e03c31819c197c782598f17f0b150a69d453c9584cd14c4c4d7b9a55d2c5e6cacd4d66fdb3b3663
+"@types/semver@npm:^7.3.12, @types/semver@npm:^7.5.0":
+  version: 7.5.7
+  resolution: "@types/semver@npm:7.5.7"
+  checksum: 5af9b13e3d74d86d4b618f6506ccbded801fb35dbc28608cd5a7bfb8bcac0021dd35ef305a72a0c2a8def0cff60acd706bfee16a9ed1c39a893d2a175e778ea7
   languageName: node
   linkType: hard
 
@@ -2990,6 +2990,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/visitor-keys": 6.21.0
+  checksum: 71028b757da9694528c4c3294a96cc80bc7d396e383a405eab3bc224cda7341b88e0fc292120b35d3f31f47beac69f7083196c70616434072fbcd3d3e62d3376
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/type-utils@npm:5.62.0"
@@ -3011,6 +3021,32 @@ __metadata:
   version: 5.62.0
   resolution: "@typescript-eslint/types@npm:5.62.0"
   checksum: 48c87117383d1864766486f24de34086155532b070f6264e09d0e6139449270f8a9559cfef3c56d16e3bcfb52d83d42105d61b36743626399c7c2b5e0ac3b670
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/types@npm:6.21.0"
+  checksum: 9501b47d7403417af95fc1fb72b2038c5ac46feac0e1598a46bcb43e56a606c387e9dcd8a2a0abe174c91b509f2d2a8078b093786219eb9a01ab2fbf9ee7b684
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/visitor-keys": 6.21.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    minimatch: 9.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: dec02dc107c4a541e14fb0c96148f3764b92117c3b635db3a577b5a56fc48df7a556fa853fb82b07c0663b4bf2c484c9f245c28ba3e17e5cb0918ea4cab2ea21
   languageName: node
   linkType: hard
 
@@ -3050,7 +3086,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.62.0, @typescript-eslint/utils@npm:^5.10.0, @typescript-eslint/utils@npm:^5.38.1":
+"@typescript-eslint/utils@npm:5.62.0, @typescript-eslint/utils@npm:^5.38.1":
   version: 5.62.0
   resolution: "@typescript-eslint/utils@npm:5.62.0"
   dependencies:
@@ -3068,6 +3104,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^6.0.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/utils@npm:6.21.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.12
+    "@types/semver": ^7.5.0
+    "@typescript-eslint/scope-manager": 6.21.0
+    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/typescript-estree": 6.21.0
+    semver: ^7.5.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: b129b3a4aebec8468259f4589985cb59ea808afbfdb9c54f02fad11e17d185e2bf72bb332f7c36ec3c09b31f18fc41368678b076323e6e019d06f74ee93f7bf2
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -3075,6 +3128,16 @@ __metadata:
     "@typescript-eslint/types": 5.62.0
     eslint-visitor-keys: ^3.3.0
   checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": 6.21.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: 67c7e6003d5af042d8703d11538fca9d76899f0119130b373402819ae43f0bc90d18656aa7add25a24427ccf1a0efd0804157ba83b0d4e145f06107d7d1b7433
   languageName: node
   linkType: hard
 
@@ -5148,7 +5211,7 @@ __metadata:
     "@types/node": ^14.18.26
     "@typescript-eslint/eslint-plugin": ^5.0.0
     "@typescript-eslint/parser": ^5.0.0
-    "@typescript-eslint/utils": ^5.10.0
+    "@typescript-eslint/utils": ^6.0.0
     babel-jest: ^29.0.0
     babel-plugin-replace-ts-export-assignment: ^0.0.2
     dedent: ^1.5.0
@@ -8239,21 +8302,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:9.0.3, minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
     brace-expansion: ^1.1.7
   checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
   languageName: node
   linkType: hard
 
@@ -10819,6 +10882,15 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.2.1
+  resolution: "ts-api-utils@npm:1.2.1"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: 17a2a4454d65a6765b9351304cfd516fcda3098f49d72bba90cb7f22b6a09a573b4a1993fd7de7d6b8046c408960c5f21a25e64ccb969d484b32ea3b3e19d6e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Really the changes needed were just type and testing based, though I'm not sure if we can support v5 without a breaking change anyway because we'd have to switch to requiring it as a peer dependency which is arguably still breaking?

v6 dropped support for Node v14 which we still support.

Closes #1401

(this is meant to be the min. required for the upgrade - I'll do other stuff like updating the linting plugins in another PR)