### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ module.exports = [
     files: ['test/**'],
     ...jest.configs['flat/recommended'],
     rules: {
+      ...jest.configs['flat/recommended'].rules,
       'jest/prefer-expect-assertions': 'off',
     },
   },

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ module.exports = [
     files: ['test/**'],
     ...jest.configs['flat/recommended'],
     rules: {
-      ...jest.configs['flat/recommended'],
       'jest/prefer-expect-assertions': 'off',
     },
   },


### PR DESCRIPTION
Flat config: Add missing "rules" property of flat/recommended entry in "rules" object