### PR TITLE
chore: upgrade to TS 5.4

### DIFF
--- a/.yarn/patches/@typescript-eslint-typescript-estree-npm-5.62.0-5d1ea132a9.patch
+++ b/.yarn/patches/@typescript-eslint-typescript-estree-npm-5.62.0-5d1ea132a9.patch
@@ -1,0 +1,30 @@
+diff --git a/_ts3.4/dist/ts-estree/ts-nodes.d.ts b/_ts3.4/dist/ts-estree/ts-nodes.d.ts
+index 2021725e0371bc028330cee33e90021f08e12275..5d19dfc6fc8272fa065edba11e1d6fb5f4ca3cf7 100644
+--- a/_ts3.4/dist/ts-estree/ts-nodes.d.ts
++++ b/_ts3.4/dist/ts-estree/ts-nodes.d.ts
+@@ -8,10 +8,6 @@ declare module 'typescript' {
+     }
+     interface ClassStaticBlockDeclaration extends ts.Node {
+     }
+-    interface AssertClause extends ts.Node {
+-    }
+-    interface AssertEntry extends ts.Node {
+-    }
+     interface SatisfiesExpression extends ts.Node {
+     }
+ }
+diff --git a/dist/ts-estree/ts-nodes.d.ts b/dist/ts-estree/ts-nodes.d.ts
+index 1a90a38bf617eedfb7d9c0dbd431429480dd83ca..1ef85da052c3715a492ead81e4ada50697a15d78 100644
+--- a/dist/ts-estree/ts-nodes.d.ts
++++ b/dist/ts-estree/ts-nodes.d.ts
+@@ -8,10 +8,6 @@ declare module 'typescript' {
+     }
+     interface ClassStaticBlockDeclaration extends ts.Node {
+     }
+-    interface AssertClause extends ts.Node {
+-    }
+-    interface AssertEntry extends ts.Node {
+-    }
+     interface SatisfiesExpression extends ts.Node {
+     }
+ }

--- a/package.json
+++ b/package.json
@@ -162,6 +162,6 @@
     "provenance": true
   },
   "resolutions": {
-    "typescript": "~5.2.2"
+    "@typescript-eslint/typescript-estree@5.62.0": "patch:@typescript-eslint/typescript-estree@npm:^5.62.0#./.yarn/patches/@typescript-eslint-typescript-estree-npm-5.62.0-5d1ea132a9.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,7 +3014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.62.0":
+"@typescript-eslint/typescript-estree@npm:^5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
   dependencies:
@@ -3029,6 +3029,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 3624520abb5807ed8f57b1197e61c7b1ed770c56dfcaca66372d584ff50175225798bccb701f7ef129d62c5989070e1ee3a0aa2d84e56d9524dcf011a2bb1a52
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@patch:@typescript-eslint/typescript-estree@npm:^5.62.0#./.yarn/patches/@typescript-eslint-typescript-estree-npm-5.62.0-5d1ea132a9.patch::locator=eslint-plugin-jest%40workspace%3A.":
+  version: 5.62.0
+  resolution: "@typescript-eslint/typescript-estree@patch:@typescript-eslint/typescript-estree@npm%3A5.62.0#./.yarn/patches/@typescript-eslint-typescript-estree-npm-5.62.0-5d1ea132a9.patch::version=5.62.0&hash=bbaf25&locator=eslint-plugin-jest%40workspace%3A."
+  dependencies:
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/visitor-keys": 5.62.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 166673643210b8786c3190b3261c22e1b67025489f579183e1cb6cb58a80ea0dd2e12c98aec86ad557b852fb9fd5ae1dc9c913bccdb96a57459228af7adb0c63
   languageName: node
   linkType: hard
 
@@ -11028,23 +11046,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.2.2":
-  version: 5.2.2
-  resolution: "typescript@npm:5.2.2"
+"typescript@npm:^4.6.4 || ^5.2.2, typescript@npm:^5.0.4":
+  version: 5.4.2
+  resolution: "typescript@npm:5.4.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7912821dac4d962d315c36800fe387cdc0a6298dba7ec171b350b4a6e988b51d7b8f051317786db1094bd7431d526b648aba7da8236607febb26cf5b871d2d3c
+  checksum: 96d80fde25a09bcb04d399082fb27a808a9e17c2111e43849d2aafbd642d835e4f4ef0de09b0ba795ec2a700be6c4c2c3f62bf4660c05404c948727b5bbfb32a
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.2.2#~builtin<compat/typescript>":
-  version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+"typescript@patch:typescript@^4.6.4 || ^5.2.2#~builtin<compat/typescript>, typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+  version: 5.4.2
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#~builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
+  checksum: 797ac213c03a19749181c745647b4cab03d13bf4b6b738b05a3426f46c6b540f908989e839d9b0c89d7a4ee2bdb50493b4d4898d4ef1c897c3e9d0b082e78a67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Using 5.3 or 5.4 breaks due to https://github.com/typescript-eslint/typescript-eslint/issues/8047

We need to upgrade to v6 (or v7) in order to get the fix.

For now I've just patched the library