### PR TITLE
refactor: address missed usage of deprecated `context.getFilename` in rules

### DIFF
--- a/src/rules/no-done-callback.ts
+++ b/src/rules/no-done-callback.ts
@@ -5,6 +5,7 @@ import {
 } from '@typescript-eslint/utils';
 import {
   createRule,
+  getFilename,
   getNodeName,
   getSourceCode,
   isFunction,
@@ -132,7 +133,7 @@ export default createRule({
                   !tokenAfterLastParam
                 ) {
                   throw new Error(
-                    `Unexpected null when attempting to fix ${context.getFilename()} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
+                    `Unexpected null when attempting to fix ${getFilename(context)} - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
                   );
                 }
 

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -105,7 +105,7 @@ export default createRule<[RuleOptions], MessageId>({
   },
   defaultOptions: [{}],
   create(context, [options]) {
-    if (context.getFilename().endsWith('.snap')) {
+    if (getFilename(context).endsWith('.snap')) {
       return {
         ExpressionStatement(node) {
           reportOnViolation(context, node, options);


### PR DESCRIPTION
I missed these in #1453