### PR TITLE
test(no-done-callback): add missing `suggestions` to `each` cases

### DIFF
--- a/src/rules/__tests__/no-done-callback.test.ts
+++ b/src/rules/__tests__/no-done-callback.test.ts
@@ -477,6 +477,14 @@ ruleTester.run('no-done-callback', rule, {
           messageId: 'noDoneCallback',
           line: 1,
           column: 37,
+          suggestions: [
+            {
+              messageId: 'suggestWrappingInPromise',
+              data: { callback: 'done' },
+              output:
+                'test.each``("something", () => {return new Promise(done => { done(); })})',
+            },
+          ],
         },
       ],
     },
@@ -487,6 +495,14 @@ ruleTester.run('no-done-callback', rule, {
           messageId: 'noDoneCallback',
           line: 1,
           column: 35,
+          suggestions: [
+            {
+              messageId: 'suggestWrappingInPromise',
+              data: { callback: 'done' },
+              output:
+                'it.each``("something", () => {return new Promise(done => { done(); })})',
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
ESLint v9 cares about these, and it's not wrong - relates to #1534