### PR TITLE
refactor: use `flatMap` instead of `reduce`

### DIFF
--- a/src/__tests__/rules.test.ts
+++ b/src/__tests__/rules.test.ts
@@ -76,12 +76,9 @@ describe('rules', () => {
     expect(Object.keys(recommendedConfigs['flat/all'].rules)).toHaveLength(
       ruleNames.length - deprecatedRules.length,
     );
-    const allConfigRules = Object.values(recommendedConfigs)
-      .map(config => Object.keys(config.rules ?? {}))
-      .reduce((previousValue, currentValue) => [
-        ...previousValue,
-        ...currentValue,
-      ]);
+    const allConfigRules = Object.values(recommendedConfigs).flatMap(config =>
+      Object.keys(config.rules ?? {}),
+    );
 
     allConfigRules.forEach(rule => {
       const ruleNamePrefix = 'jest/';

--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -120,30 +120,26 @@ describe('the rule', () => {
       valid: [
         'jest',
         'require("fs")',
-        ...allowedFunctions
-          .map(func => generateValidCases(jestVersion, func))
-          .reduce((acc, arr) => acc.concat(arr), []),
+        ...allowedFunctions.flatMap(func =>
+          generateValidCases(jestVersion, func),
+        ),
       ],
-      invalid: deprecations
-        .map(([, deprecation, replacement]) =>
-          generateInvalidCases(jestVersion, deprecation, replacement),
-        )
-        .reduce((acc, arr) => acc.concat(arr), []),
+      invalid: deprecations.flatMap(([, deprecation, replacement]) =>
+        generateInvalidCases(jestVersion, deprecation, replacement),
+      ),
     });
 
     ruleTester.run('detected jest version', rule, {
       valid: [
         'jest',
         'require("fs")',
-        ...allowedFunctions
-          .map(func => generateValidCases(undefined, func))
-          .reduce((acc, arr) => acc.concat(arr), []),
+        ...allowedFunctions.flatMap(func =>
+          generateValidCases(undefined, func),
+        ),
       ],
-      invalid: deprecations
-        .map(([, deprecation, replacement]) =>
-          generateInvalidCases(undefined, deprecation, replacement),
-        )
-        .reduce((acc, arr) => acc.concat(arr), []),
+      invalid: deprecations.flatMap(([, deprecation, replacement]) =>
+        generateInvalidCases(undefined, deprecation, replacement),
+      ),
     });
   });
 

--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -205,30 +205,24 @@ const generateValidStringLiteralCases = (operator: string, matcher: string) => {
     ['x', "'y'"],
     ['x', '`y`'],
     ['x', '`y${z}`'],
-  ].reduce(
-    (cases, [a, b]) => [
-      ...cases,
-      ...[
-        `expect(${a} ${operator} ${b}).${matcher}(true)`,
-        `expect(${a} ${operator} ${b}).${matcher}(false)`,
-        `expect(${a} ${operator} ${b}).not.${matcher}(true)`,
-        `expect(${a} ${operator} ${b}).not.${matcher}(false)`,
-        `expect(${a} ${operator} ${b}).resolves.${matcher}(true)`,
-        `expect(${a} ${operator} ${b}).resolves.${matcher}(false)`,
-        `expect(${a} ${operator} ${b}).resolves.not.${matcher}(true)`,
-        `expect(${a} ${operator} ${b}).resolves.not.${matcher}(false)`,
-        `expect(${b} ${operator} ${a}).resolves.not.${matcher}(false)`,
-        `expect(${b} ${operator} ${a}).resolves.not.${matcher}(true)`,
-        `expect(${b} ${operator} ${a}).resolves.${matcher}(false)`,
-        `expect(${b} ${operator} ${a}).resolves.${matcher}(true)`,
-        `expect(${b} ${operator} ${a}).not.${matcher}(false)`,
-        `expect(${b} ${operator} ${a}).not.${matcher}(true)`,
-        `expect(${b} ${operator} ${a}).${matcher}(false)`,
-        `expect(${b} ${operator} ${a}).${matcher}(true)`,
-      ],
-    ],
-    [],
-  );
+  ].flatMap(([a, b]) => [
+    `expect(${a} ${operator} ${b}).${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).${matcher}(false)`,
+    `expect(${a} ${operator} ${b}).not.${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).not.${matcher}(false)`,
+    `expect(${a} ${operator} ${b}).resolves.${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).resolves.${matcher}(false)`,
+    `expect(${a} ${operator} ${b}).resolves.not.${matcher}(true)`,
+    `expect(${a} ${operator} ${b}).resolves.not.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).resolves.not.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).resolves.not.${matcher}(true)`,
+    `expect(${b} ${operator} ${a}).resolves.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).resolves.${matcher}(true)`,
+    `expect(${b} ${operator} ${a}).not.${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).not.${matcher}(true)`,
+    `expect(${b} ${operator} ${a}).${matcher}(false)`,
+    `expect(${b} ${operator} ${a}).${matcher}(true)`,
+  ]);
 };
 
 const testComparisonOperator = (
@@ -244,27 +238,17 @@ const testComparisonOperator = (
       `expect(value).${preferredMatcherWhenNegated}(1);`,
       `expect(value).not.${preferredMatcher}(1);`,
       `expect(value).not.${preferredMatcherWhenNegated}(1);`,
-      ...['toBe', 'toEqual', 'toStrictEqual'].reduce<string[]>(
-        (cases, equalityMatcher) => [
-          ...cases,
-          ...generateValidStringLiteralCases(operator, equalityMatcher),
-        ],
-        [],
+      ...['toBe', 'toEqual', 'toStrictEqual'].flatMap(equalityMatcher =>
+        generateValidStringLiteralCases(operator, equalityMatcher),
       ),
     ],
-    invalid: ['toBe', 'toEqual', 'toStrictEqual'].reduce<
-      Array<TSESLint.InvalidTestCase<'useToBeComparison', never>>
-    >(
-      (cases, equalityMatcher) => [
-        ...cases,
-        ...generateInvalidCases(
-          operator,
-          equalityMatcher,
-          preferredMatcher,
-          preferredMatcherWhenNegated,
-        ),
-      ],
-      [],
+    invalid: ['toBe', 'toEqual', 'toStrictEqual'].flatMap(equalityMatcher =>
+      generateInvalidCases(
+        operator,
+        equalityMatcher,
+        preferredMatcher,
+        preferredMatcherWhenNegated,
+      ),
     ),
   });
 };

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -137,18 +137,14 @@ export const getTestCallExpressionsFromDeclaredVariables = (
   declaredVariables: readonly TSESLint.Scope.Variable[],
   context: TSESLint.RuleContext<string, unknown[]>,
 ): TSESTree.CallExpression[] => {
-  return declaredVariables.reduce<TSESTree.CallExpression[]>(
-    (acc, { references }) =>
-      acc.concat(
-        references
-          .map(({ identifier }) => identifier.parent)
-          .filter(
-            (node): node is TSESTree.CallExpression =>
-              node?.type === AST_NODE_TYPES.CallExpression &&
-              isTypeOfJestFnCall(node, context, ['test']),
-          ),
+  return declaredVariables.flatMap(({ references }) =>
+    references
+      .map(({ identifier }) => identifier.parent)
+      .filter(
+        (node): node is TSESTree.CallExpression =>
+          node?.type === AST_NODE_TYPES.CallExpression &&
+          isTypeOfJestFnCall(node, context, ['test']),
       ),
-    [],
   );
 };
 


### PR DESCRIPTION
I realised this while doing #1540 - shaves off a few lines which is nice