### PR TITLE
fix(no-large-snapshots): avoid `instanceof RegExp` check for ESLint v9 compatibility

### DIFF
--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -54,11 +54,11 @@ const reportOnViolation = (
       const snapshotName = getAccessorValue(node.expression.left.property);
 
       isAllowed = allowedSnapshotsInFile.some(name => {
-        if (name instanceof RegExp) {
-          return name.test(snapshotName);
+        if (typeof name === 'string') {
+          return snapshotName === name;
         }
 
-        return snapshotName === name;
+        return name.test(snapshotName);
       });
     }
   }


### PR DESCRIPTION
Cherry picked from https://github.com/jest-community/eslint-plugin-jest/pull/1534 - it seems that globals are different in ESLint v9 resulting in the same issue with `instanceof` that Jest has (https://github.com/jestjs/jest/issues/2549); it should be fine to switch the check to checking for a string (in fact it's arguably better as it means people could provide their own custom object with a `test` function 🤷)