### PR TITLE
fix: drop support for Node 19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 19.x, 20.x, 21.x]
+        node-version: [16.x, 18.x, 20.x, 21.x]
         eslint-version: [7, 8, 9]
         ts-eslint-plugin-version: [6, 7]
         exclude:
@@ -81,9 +81,6 @@ jobs:
           # eslint@9 doesn't support node@16
           - node-version: 16.x
             eslint-version: 9
-          # ts-eslint/plugin@7 doesn't support node@19
-          - node-version: 19.x
-            ts-eslint-plugin-version: 7
           # ts-eslint/plugin@7 doesn't support eslint@7
           - eslint-version: 7
             ts-eslint-plugin-version: 7

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
   },
   "packageManager": "yarn@3.8.1",
   "engines": {
-    "node": "^16.10.0 || >=18.0.0"
+    "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
BREAKING CHANGE: Node v19 is no longer supported