### PR TITLE
test: alias `RuleTester` so that linting still works

### DIFF
--- a/src/rules/__tests__/consistent-test-it.test.ts
+++ b/src/rules/__tests__/consistent-test-it.test.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import rule from '../consistent-test-it';
 import { TestCaseName } from '../utils';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/expect-expect.test.ts
+++ b/src/rules/__tests__/expect-expect.test.ts
@@ -1,9 +1,9 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../expect-expect';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/max-expects.test.ts
+++ b/src/rules/__tests__/max-expects.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../max-expects';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/max-nested-describe.test.ts
+++ b/src/rules/__tests__/max-nested-describe.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../max-nested-describe';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/no-commented-out-tests.test.ts
+++ b/src/rules/__tests__/no-commented-out-tests.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-commented-out-tests';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-conditional-expect.test.ts
+++ b/src/rules/__tests__/no-conditional-expect.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-conditional-expect';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2019,

--- a/src/rules/__tests__/no-conditional-in-test.test.ts
+++ b/src/rules/__tests__/no-conditional-in-test.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-conditional-in-test';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-confusing-set-timeout.test.ts
+++ b/src/rules/__tests__/no-confusing-set-timeout.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-confusing-set-timeout';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2020,

--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -4,7 +4,10 @@ import {
   type JestVersion,
   detectJestVersion,
 } from '../utils/detectJestVersion';
-import { FlatCompatRuleTester, usingFlatConfig } from './test-utils';
+import {
+  FlatCompatRuleTester as RuleTester,
+  usingFlatConfig,
+} from './test-utils';
 
 jest.mock('../utils/detectJestVersion');
 
@@ -12,7 +15,7 @@ const detectJestVersionMock = detectJestVersion as jest.MockedFunction<
   typeof detectJestVersion
 >;
 
-const ruleTester = new FlatCompatRuleTester();
+const ruleTester = new RuleTester();
 
 const generateValidCases = (
   jestVersion: JestVersion | string | undefined,

--- a/src/rules/__tests__/no-disabled-tests.test.ts
+++ b/src/rules/__tests__/no-disabled-tests.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-disabled-tests';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-done-callback.test.ts
+++ b/src/rules/__tests__/no-done-callback.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-done-callback';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/no-duplicate-hooks.test.ts
+++ b/src/rules/__tests__/no-duplicate-hooks.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-duplicate-hooks';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-export';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-focused-tests.test.ts
+++ b/src/rules/__tests__/no-focused-tests.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-focused-tests';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 6,

--- a/src/rules/__tests__/no-hooks.test.ts
+++ b/src/rules/__tests__/no-hooks.test.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import rule from '../no-hooks';
 import { HookName } from '../utils';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-identical-title.test.ts
+++ b/src/rules/__tests__/no-identical-title.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-identical-title';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-interpolation-in-snapshots.test.ts
+++ b/src/rules/__tests__/no-interpolation-in-snapshots.test.ts
@@ -1,7 +1,7 @@
 import rule from '../no-interpolation-in-snapshots';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/no-large-snapshots.test.ts
+++ b/src/rules/__tests__/no-large-snapshots.test.ts
@@ -2,12 +2,12 @@ import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../no-large-snapshots';
 import {
-  FlatCompatRuleTester,
+  FlatCompatRuleTester as RuleTester,
   espreeParser,
   usingFlatConfig,
 } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-mocks-import.test.ts
+++ b/src/rules/__tests__/no-mocks-import.test.ts
@@ -1,7 +1,7 @@
 import rule from '../no-mocks-import';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-restricted-jest-methods.test.ts
+++ b/src/rules/__tests__/no-restricted-jest-methods.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-restricted-jest-methods';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/no-restricted-matchers.test.ts
+++ b/src/rules/__tests__/no-restricted-matchers.test.ts
@@ -1,7 +1,7 @@
 import rule from '../no-restricted-matchers';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/no-standalone-expect.test.ts
+++ b/src/rules/__tests__/no-standalone-expect.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-standalone-expect';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/no-test-return-statement.test.ts
+++ b/src/rules/__tests__/no-test-return-statement.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-test-return-statement';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: { ecmaVersion: 2015 },
 });

--- a/src/rules/__tests__/no-untyped-mock-factory.test.ts
+++ b/src/rules/__tests__/no-untyped-mock-factory.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../no-untyped-mock-factory';
-import { FlatCompatRuleTester } from './test-utils';
+import { FlatCompatRuleTester as RuleTester } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
 });
 

--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -1,8 +1,8 @@
 import type { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-comparison-matcher';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-each.test.ts
+++ b/src/rules/__tests__/prefer-each.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-each';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-equality-matcher.test.ts
+++ b/src/rules/__tests__/prefer-equality-matcher.test.ts
@@ -1,8 +1,8 @@
 import type { TSESLint } from '@typescript-eslint/utils';
 import rule from '../prefer-equality-matcher';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-expect-assertions.test.ts
+++ b/src/rules/__tests__/prefer-expect-assertions.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-expect-assertions';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/prefer-expect-resolves.test.ts
+++ b/src/rules/__tests__/prefer-expect-resolves.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-expect-resolves';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/prefer-hooks-in-order.test.ts
+++ b/src/rules/__tests__/prefer-hooks-in-order.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-hooks-in-order';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-hooks-on-top.test.ts
+++ b/src/rules/__tests__/prefer-hooks-on-top.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-hooks-on-top';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-importing-jest-globals';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-lowercase-title.test.ts
+++ b/src/rules/__tests__/prefer-lowercase-title.test.ts
@@ -1,9 +1,9 @@
 import dedent from 'dedent';
 import rule from '../prefer-lowercase-title';
 import { DescribeAlias, TestCaseName } from '../utils';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-mock-promise-shorthand.test.ts
+++ b/src/rules/__tests__/prefer-mock-promise-shorthand.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-mock-promise-shorthand';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 6,

--- a/src/rules/__tests__/prefer-snapshot-hint.test.ts
+++ b/src/rules/__tests__/prefer-snapshot-hint.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-snapshot-hint';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-spy-on.test.ts
+++ b/src/rules/__tests__/prefer-spy-on.test.ts
@@ -1,8 +1,8 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import rule from '../prefer-spy-on';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/prefer-to-be.test.ts
+++ b/src/rules/__tests__/prefer-to-be.test.ts
@@ -1,7 +1,7 @@
 import rule from '../prefer-to-be';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
@@ -316,7 +316,7 @@ ruleTester.run('prefer-to-be: undefined vs defined', rule, {
   ],
 });
 
-new FlatCompatRuleTester({
+new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
 }).run('prefer-to-be: typescript edition', rule, {
   valid: [

--- a/src/rules/__tests__/prefer-to-contain.test.ts
+++ b/src/rules/__tests__/prefer-to-contain.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-to-contain';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,
@@ -211,7 +211,7 @@ ruleTester.run('prefer-to-contain', rule, {
   ],
 });
 
-new FlatCompatRuleTester({
+new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
 }).run('prefer-to-be-null: typescript edition', rule, {
   valid: [

--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -1,7 +1,7 @@
 import rule from '../prefer-to-have-length';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2020,

--- a/src/rules/__tests__/prefer-todo.test.ts
+++ b/src/rules/__tests__/prefer-todo.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../prefer-todo';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: { ecmaVersion: 2015 },
 });

--- a/src/rules/__tests__/require-hook.test.ts
+++ b/src/rules/__tests__/require-hook.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../require-hook';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,
@@ -407,7 +407,7 @@ ruleTester.run('require-hook', rule, {
   ],
 });
 
-new FlatCompatRuleTester({
+new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
 }).run('require-hook: typescript edition', rule, {
   valid: [

--- a/src/rules/__tests__/require-to-throw-message.test.ts
+++ b/src/rules/__tests__/require-to-throw-message.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../require-to-throw-message';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/require-top-level-describe.test.ts
+++ b/src/rules/__tests__/require-top-level-describe.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../require-top-level-describe';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import type { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import type { MessageIds, Options } from '../unbound-method';
-import { FlatCompatRuleTester } from './test-utils';
+import { FlatCompatRuleTester as RuleTester } from './test-utils';
 
 function getFixturesRootDir(): string {
   return path.join(__dirname, 'fixtures');
@@ -10,7 +10,7 @@ function getFixturesRootDir(): string {
 
 const rootPath = getFixturesRootDir();
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: {
     sourceType: 'module',
@@ -185,7 +185,7 @@ describe('error handling', () => {
   });
 
   describe('when @typescript-eslint/eslint-plugin is not available', () => {
-    const ruleTester = new FlatCompatRuleTester({
+    const ruleTester = new RuleTester({
       parser: require.resolve('@typescript-eslint/parser'),
       parserOptions: {
         sourceType: 'module',

--- a/src/rules/__tests__/valid-describe-callback.test.ts
+++ b/src/rules/__tests__/valid-describe-callback.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../valid-describe-callback';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../valid-expect-in-promise';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../valid-expect';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/__tests__/valid-title.test.ts
+++ b/src/rules/__tests__/valid-title.test.ts
@@ -1,8 +1,8 @@
 import dedent from 'dedent';
 import rule from '../valid-title';
-import { FlatCompatRuleTester, espreeParser } from './test-utils';
+import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2017,

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -1,7 +1,10 @@
 import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import type { TSESTree } from '@typescript-eslint/utils';
 import dedent from 'dedent';
-import { FlatCompatRuleTester, espreeParser } from '../../__tests__/test-utils';
+import {
+  FlatCompatRuleTester as RuleTester,
+  espreeParser,
+} from '../../__tests__/test-utils';
 import {
   type ParsedJestFnCall,
   type ResolvedJestFnWithNode,
@@ -29,7 +32,7 @@ const findESLintVersion = (): number => {
 
 const eslintVersion = findESLintVersion();
 
-const ruleTester = new FlatCompatRuleTester({
+const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
     ecmaVersion: 2015,


### PR DESCRIPTION
This means that `eslint-plugin-eslint-plugin` rules still work, as I forgot they expect a class named `RuleTester`