### PR TITLE
refactor(expect-expect): remove unneeded array

### DIFF
--- a/src/rules/expect-expect.ts
+++ b/src/rules/expect-expect.ts
@@ -65,7 +65,7 @@ export default createRule<
         properties: {
           assertFunctionNames: {
             type: 'array',
-            items: [{ type: 'string' }],
+            items: { type: 'string' },
           },
           additionalTestBlockFunctions: {
             type: 'array',


### PR DESCRIPTION
This doesn't need to be an array since we only allow one type of item.