### PR TITLE
refactor: strict typing and deprecation fix in type definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const plugin = {
     | 'flat/all'
     | 'flat/recommended'
     | 'flat/style',
-    Pick<Required<TSESLint.Linter.Config>, 'rules'>
+    Pick<Required<TSESLint.ClassicConfig.Config>, 'rules'>
   >,
   environments: {
     globals: {

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -113,37 +113,33 @@ const invalidTestCases: Array<TSESLint.InvalidTestCase<MessageIds, Options>> = [
     ],
   },
   // toThrow matchers call the expected value (which is expected to be a function)
-  ...toThrowMatchers.map<TSESLint.InvalidTestCase<MessageIds, Options>>(
-    matcher => ({
-      code: dedent`
+  ...toThrowMatchers.map(matcher => ({
+    code: dedent`
       ${ConsoleClassAndVariableCode}
 
       expect(console.log).${matcher}();
     `,
-      errors: [
-        {
-          line: 9,
-          messageId: 'unboundWithoutThisAnnotation',
-        },
-      ],
-    }),
-  ),
+    errors: [
+      {
+        line: 9,
+        messageId: 'unboundWithoutThisAnnotation' as const,
+      },
+    ],
+  })),
   // toThrow matchers call the expected value (which is expected to be a function)
-  ...toThrowMatchers.map<TSESLint.InvalidTestCase<MessageIds, Options>>(
-    matcher => ({
-      code: dedent`
+  ...toThrowMatchers.map(matcher => ({
+    code: dedent`
       ${ConsoleClassAndVariableCode}
 
       expect(console.log).not.${matcher}();
     `,
-      errors: [
-        {
-          line: 9,
-          messageId: 'unboundWithoutThisAnnotation',
-        },
-      ],
-    }),
-  ),
+    errors: [
+      {
+        line: 9,
+        messageId: 'unboundWithoutThisAnnotation' as const,
+      },
+    ],
+  })),
 ];
 
 const requireRule = (throwWhenRequiring: boolean) => {

--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -54,7 +54,7 @@ const toThrowMatchers = [
   'toThrowError',
   'toThrowErrorMatchingSnapshot',
   'toThrowErrorMatchingInlineSnapshot',
-];
+] as const;
 
 const validTestCases: string[] = [
   ...[
@@ -113,33 +113,37 @@ const invalidTestCases: Array<TSESLint.InvalidTestCase<MessageIds, Options>> = [
     ],
   },
   // toThrow matchers call the expected value (which is expected to be a function)
-  ...toThrowMatchers.map(matcher => ({
-    code: dedent`
+  ...toThrowMatchers.map<TSESLint.InvalidTestCase<MessageIds, Options>>(
+    matcher => ({
+      code: dedent`
       ${ConsoleClassAndVariableCode}
 
       expect(console.log).${matcher}();
     `,
-    errors: [
-      {
-        line: 9,
-        messageId: 'unboundWithoutThisAnnotation' as const,
-      },
-    ],
-  })),
+      errors: [
+        {
+          line: 9,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    }),
+  ),
   // toThrow matchers call the expected value (which is expected to be a function)
-  ...toThrowMatchers.map(matcher => ({
-    code: dedent`
+  ...toThrowMatchers.map<TSESLint.InvalidTestCase<MessageIds, Options>>(
+    matcher => ({
+      code: dedent`
       ${ConsoleClassAndVariableCode}
 
       expect(console.log).not.${matcher}();
     `,
-    errors: [
-      {
-        line: 9,
-        messageId: 'unboundWithoutThisAnnotation' as const,
-      },
-    ],
-  })),
+      errors: [
+        {
+          line: 9,
+          messageId: 'unboundWithoutThisAnnotation',
+        },
+      ],
+    }),
+  ),
 ];
 
 const requireRule = (throwWhenRequiring: boolean) => {

--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -92,7 +92,7 @@ export default createRule<
         additionalProperties: false,
       },
     ],
-  } as const,
+  },
   defaultOptions: [
     { ignore: [], allowedPrefixes: [], ignoreTopLevelDescribe: false },
   ],
@@ -134,7 +134,7 @@ export default createRule<
         if (
           !firstCharacter ||
           firstCharacter === firstCharacter.toLowerCase() ||
-          ignores.includes(jestFnCall.name as IgnorableFunctionExpressions)
+          ignores.includes(jestFnCall.name)
         ) {
           return;
         }

--- a/src/rules/require-hook.ts
+++ b/src/rules/require-hook.ts
@@ -39,9 +39,11 @@ const shouldBeInHook = (
     case AST_NODE_TYPES.ExpressionStatement:
       return shouldBeInHook(node.expression, context, allowedFunctionCalls);
     case AST_NODE_TYPES.CallExpression:
+      const nodeName = getNodeName(node);
+
       return !(
         isJestFnCall(node, context) ||
-        allowedFunctionCalls.includes(getNodeName(node) as string)
+        (nodeName && allowedFunctionCalls.includes(nodeName))
       );
     case AST_NODE_TYPES.VariableDeclaration: {
       if (node.kind === 'const') {

--- a/src/rules/utils/__tests__/detectJestVersion.test.ts
+++ b/src/rules/utils/__tests__/detectJestVersion.test.ts
@@ -115,7 +115,7 @@ describe('detectJestVersion', () => {
     it('finds the correct version', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'simple-project' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/jest/package.json': {
           name: 'jest',
           version: '21.0.0',
@@ -133,7 +133,7 @@ describe('detectJestVersion', () => {
     it('finds the correct version', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'mono-repo' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/jest/package.json': {
           name: 'jest',
           version: '19.0.0',
@@ -153,13 +153,13 @@ describe('detectJestVersion', () => {
     it('finds the correct versions', () => {
       const projectDir = setupFakeProject({
         'backend/package.json': { name: 'package-a' },
-        [`backend/node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`backend/node_modules/${relativePathToFn}`]: compiledFn,
         'backend/node_modules/jest/package.json': {
           name: 'jest',
           version: '24.0.0',
         },
         'frontend/package.json': { name: 'package-b' },
-        [`frontend/node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`frontend/node_modules/${relativePathToFn}`]: compiledFn,
         'frontend/node_modules/jest/package.json': {
           name: 'jest',
           version: '15.0.0',
@@ -184,7 +184,7 @@ describe('detectJestVersion', () => {
     it('throws an error', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'no-jest' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/pack/package.json': { name: 'pack' },
       });
 
@@ -199,7 +199,7 @@ describe('detectJestVersion', () => {
     it('uses the cached version', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'no-jest' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/jest/package.json': { name: 'jest', version: '26.0.0' },
       });
 

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -194,7 +194,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'script' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -220,7 +220,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -246,7 +246,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -272,7 +272,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -298,7 +298,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -327,7 +327,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -343,7 +343,7 @@ ruleTester.run('expect', rule, {
           line: 3,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -359,7 +359,7 @@ ruleTester.run('expect', rule, {
           line: 4,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -375,7 +375,7 @@ ruleTester.run('expect', rule, {
           line: 5,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -493,7 +493,7 @@ if (eslintVersion >= 8) {
         parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
         errors: [
           {
-            messageId: 'details' as const,
+            messageId: 'details',
             data: expectedParsedJestFnCallResultData({
               name: 'it',
               type: 'test',
@@ -519,7 +519,7 @@ if (eslintVersion >= 8) {
         parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
         errors: [
           {
-            messageId: 'details' as const,
+            messageId: 'details',
             data: expectedParsedJestFnCallResultData({
               name: 'it',
               type: 'test',
@@ -630,7 +630,7 @@ ruleTester.run('global aliases', rule, {
       code: 'context("when there is an error", () => {})',
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -652,7 +652,7 @@ ruleTester.run('global aliases', rule, {
       code: 'context.skip("when there is an error", () => {})',
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -677,7 +677,7 @@ ruleTester.run('global aliases', rule, {
       `,
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'xdescribe',
             type: 'describe',
@@ -703,7 +703,7 @@ ruleTester.run('global aliases', rule, {
       `,
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -719,7 +719,7 @@ ruleTester.run('global aliases', rule, {
           line: 1,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -794,7 +794,7 @@ ruleTester.run('global package source', rule, {
       parserOptions: { sourceType: 'script' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -825,7 +825,7 @@ ruleTester.run('global package source', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -841,7 +841,7 @@ ruleTester.run('global package source', rule, {
           line: 3,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'it',
             type: 'test',
@@ -857,7 +857,7 @@ ruleTester.run('global package source', rule, {
           line: 4,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -884,7 +884,7 @@ ruleTester.run('global package source', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -906,7 +906,7 @@ ruleTester.run('global package source', rule, {
       code: 'context("when there is an error", () => {})',
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -1013,7 +1013,7 @@ ruleTester.run('typescript', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'it',
             type: 'test',

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -98,7 +98,7 @@ const isPromiseMethodThatUsesValue = (
   ) {
     const nodeName = getNodeName(node.argument);
 
-    if (nodeName && ['Promise.all', 'Promise.allSettled'].includes(nodeName)) {
+    if (['Promise.all', 'Promise.allSettled'].includes(nodeName as string)) {
       const [firstArg] = node.argument.arguments;
 
       if (
@@ -110,8 +110,7 @@ const isPromiseMethodThatUsesValue = (
     }
 
     if (
-      nodeName &&
-      ['Promise.resolve', 'Promise.reject'].includes(nodeName) &&
+      ['Promise.resolve', 'Promise.reject'].includes(nodeName as string) &&
       node.argument.arguments.length === 1
     ) {
       return isIdentifier(node.argument.arguments[0], name);

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -98,7 +98,7 @@ const isPromiseMethodThatUsesValue = (
   ) {
     const nodeName = getNodeName(node.argument);
 
-    if (['Promise.all', 'Promise.allSettled'].includes(nodeName as string)) {
+    if (nodeName && ['Promise.all', 'Promise.allSettled'].includes(nodeName)) {
       const [firstArg] = node.argument.arguments;
 
       if (
@@ -110,7 +110,8 @@ const isPromiseMethodThatUsesValue = (
     }
 
     if (
-      ['Promise.resolve', 'Promise.reject'].includes(nodeName as string) &&
+      nodeName &&
+      ['Promise.resolve', 'Promise.reject'].includes(nodeName) &&
       node.argument.arguments.length === 1
     ) {
       return isIdentifier(node.argument.arguments[0], name);

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -74,13 +74,13 @@ const compileMatcherPatterns = (
 type CompiledMatcherAndMessage = [matcher: RegExp, message?: string];
 type MatcherAndMessage = [matcher: string, message?: string];
 
-const MatcherAndMessageSchema: JSONSchema.JSONSchema4 = {
+const MatcherAndMessageSchema = {
   type: 'array',
   items: { type: 'string' },
   minItems: 1,
   maxItems: 2,
   additionalItems: false,
-} as const;
+} as const satisfies JSONSchema.JSONSchema4;
 
 type MatcherGroups = 'describe' | 'test' | 'it';
 


### PR DESCRIPTION
I apologize for the sudden PR, but I'd like to propose some strict typing enhancements.
Please consider the following changes:

- Updated deprecated type definitions for TSESLint.Linter.Config.
- Removed unnecessary type assertions and enhanced strict typing.

Note: As this is the first PR for this repository, please feel free to provide any feedback or suggestions if there are any deficiencies.