### PR TITLE
feat(valid-expect): supporting automatically fixing missing `await` in some cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ set to warn in.\
 | [require-to-throw-message](docs/rules/require-to-throw-message.md)           | Require a message for `toThrow()`                                         |     |     |     |     |
 | [require-top-level-describe](docs/rules/require-top-level-describe.md)       | Require test cases and hooks to be inside a `describe` block              |     |     |     |     |
 | [valid-describe-callback](docs/rules/valid-describe-callback.md)             | Enforce valid `describe()` callback                                       | ✅  |     |     |     |
-| [valid-expect](docs/rules/valid-expect.md)                                   | Enforce valid `expect()` usage                                            | ✅  |     |     |     |
+| [valid-expect](docs/rules/valid-expect.md)                                   | Enforce valid `expect()` usage                                            | ✅  |     | 🔧  |     |
 | [valid-expect-in-promise](docs/rules/valid-expect-in-promise.md)             | Require promises that have expectations in their chain to be valid        | ✅  |     |     |     |
 | [valid-title](docs/rules/valid-title.md)                                     | Enforce valid titles                                                      | ✅  |     | 🔧  |     |
 

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -8,7 +8,8 @@
 
 <!-- end auto-generated rule header -->
 
-Note: Test function will be fixed if it is async and does not have await in the
+> [!NOTE]
+> Test function will be fixed if it is async and does not have await in the
 async assertion.
 
 Ensure `expect()` is called with a single argument and there is an actual

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -6,6 +6,9 @@
 🔧 This rule is automatically fixable by the
 [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
+Note: Test function will be fixed if it is async and does not have await in the
+async assertion.
+
 <!-- end auto-generated rule header -->
 
 Ensure `expect()` is called with a single argument and there is an actual

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -3,6 +3,9 @@
 💼 This rule is enabled in the ✅ `recommended`
 [config](https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#shareable-configurations).
 
+🔧 This rule is automatically fixable by the
+[`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 <!-- end auto-generated rule header -->
 
 Ensure `expect()` is called with a single argument and there is an actual

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -8,9 +8,8 @@
 
 <!-- end auto-generated rule header -->
 
-> [!NOTE]
-> Test function will be fixed if it is async and does not have await in the
-async assertion.
+> [!NOTE] Test function will be fixed if it is async and does not have await in
+> the async assertion.
 
 Ensure `expect()` is called with a single argument and there is an actual
 expectation made.

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -6,10 +6,10 @@
 🔧 This rule is automatically fixable by the
 [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
+<!-- end auto-generated rule header -->
+
 Note: Test function will be fixed if it is async and does not have await in the
 async assertion.
-
-<!-- end auto-generated rule header -->
 
 Ensure `expect()` is called with a single argument and there is an actual
 expectation made.

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -571,6 +571,8 @@ ruleTester.run('valid-expect', rule, {
     // usages in async function
     {
       code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.toBeDefined(); });',
       errors: [
         {
           column: 36,
@@ -582,6 +584,8 @@ ruleTester.run('valid-expect', rule, {
     },
     {
       code: 'test("valid-expect", async () => { expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
+      output:
+        'test("valid-expect", async () => { await expect(Promise.resolve(2)).resolves.not.toBeDefined(); });',
       errors: [
         {
           column: 36,
@@ -621,6 +625,12 @@ ruleTester.run('valid-expect', rule, {
           expect(Promise.resolve(1)).rejects.toBeDefined();
         });
       `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(2)).resolves.not.toBeDefined();
+          await expect(Promise.resolve(1)).rejects.toBeDefined();
+        });
+      `,
       errors: [
         {
           line: 2,
@@ -646,6 +656,12 @@ ruleTester.run('valid-expect', rule, {
           expect(Promise.resolve(1)).rejects.toBeDefined();
         });
       `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(2)).resolves.not.toBeDefined();
+          await expect(Promise.resolve(1)).rejects.toBeDefined();
+        });
+      `,
       errors: [
         {
           line: 3,
@@ -665,6 +681,12 @@ ruleTester.run('valid-expect', rule, {
         test("valid-expect", async () => {
           expect(Promise.resolve(2)).resolves.not.toBeDefined();
           return expect(Promise.resolve(1)).rejects.toBeDefined();
+        });
+      `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(2)).resolves.not.toBeDefined();
+          await expect(Promise.resolve(1)).rejects.toBeDefined();
         });
       `,
       options: [{ alwaysAwait: true }],
@@ -691,6 +713,12 @@ ruleTester.run('valid-expect', rule, {
           return expect(Promise.resolve(1)).rejects.toBeDefined();
         });
       `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(2)).resolves.not.toBeDefined();
+          return expect(Promise.resolve(1)).rejects.toBeDefined();
+        });
+      `,
       errors: [
         {
           line: 2,
@@ -709,6 +737,12 @@ ruleTester.run('valid-expect', rule, {
           return expect(Promise.resolve(1)).rejects.toBeDefined();
         });
       `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(2)).resolves.not.toBeDefined();
+          await expect(Promise.resolve(1)).rejects.toBeDefined();
+        });
+      `,
       options: [{ alwaysAwait: true }],
       errors: [
         {
@@ -724,6 +758,12 @@ ruleTester.run('valid-expect', rule, {
         test("valid-expect", async () => {
           await expect(Promise.resolve(2)).toResolve();
           return expect(Promise.resolve(1)).toReject();
+        });
+      `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await expect(Promise.resolve(2)).toResolve();
+          await expect(Promise.resolve(1)).toReject();
         });
       `,
       options: [{ alwaysAwait: true }],
@@ -759,6 +799,27 @@ ruleTester.run('valid-expect', rule, {
       code: dedent`
         test("valid-expect", () => {
           Promise.reject(expect(Promise.resolve(2)).resolves.not.toBeDefined());
+        });
+      `,
+      errors: [
+        {
+          line: 2,
+          column: 3,
+          endColumn: 72,
+          messageId: 'promisesWithAsyncAssertionsMustBeAwaited',
+          data: { orReturned: ' or returned' },
+        },
+      ],
+    },
+    {
+      code: dedent`
+        test("valid-expect", async () => {
+          Promise.reject(expect(Promise.resolve(2)).resolves.not.toBeDefined());
+        });
+      `,
+      output: dedent`
+        test("valid-expect", async () => {
+          await Promise.reject(expect(Promise.resolve(2)).resolves.not.toBeDefined());
         });
       `,
       errors: [
@@ -958,6 +1019,14 @@ ruleTester.run('valid-expect', rule, {
           return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
             await expect(Promise.resolve(2)).resolves.toBe(1);
             expect(Promise.resolve(4)).resolves.toBe(4);
+          });
+        });
+      `,
+      output: dedent`
+        test("valid-expect", () => {
+          return expect(functionReturningAPromise()).resolves.toEqual(1).then(async () => {
+            await expect(Promise.resolve(2)).resolves.toBe(1);
+            await expect(Promise.resolve(4)).resolves.toBe(4);
           });
         });
       `,


### PR DESCRIPTION
When `await` is missing ,  it's adding `await`.
Relates to https://github.com/jest-community/eslint-plugin-jest/issues/1140

