### PR TITLE
refactor(prefer-importing-jest-globals): use `AST_NODE_TYPES` constant instead of string literal

### DIFF
--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -67,7 +67,7 @@ export default createRule({
     return {
       ImportDeclaration(node: TSESTree.ImportDeclaration) {
         node.specifiers.forEach(specifier => {
-          if (specifier.type === 'ImportSpecifier') {
+          if (specifier.type === AST_NODE_TYPES.ImportSpecifier) {
             importedFunctionsWithSource[specifier.local.name] =
               node.source.value;
           }


### PR DESCRIPTION
I missed this during review/refactoring 😅 