### PR TITLE
refactor: remove unnecessary 'as const'

### DIFF
--- a/src/rules/prefer-lowercase-title.ts
+++ b/src/rules/prefer-lowercase-title.ts
@@ -92,7 +92,7 @@ export default createRule<
         additionalProperties: false,
       },
     ],
-  } as const,
+  },
   defaultOptions: [
     { ignore: [], allowedPrefixes: [], ignoreTopLevelDescribe: false },
   ],

--- a/src/rules/utils/__tests__/detectJestVersion.test.ts
+++ b/src/rules/utils/__tests__/detectJestVersion.test.ts
@@ -115,7 +115,7 @@ describe('detectJestVersion', () => {
     it('finds the correct version', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'simple-project' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/jest/package.json': {
           name: 'jest',
           version: '21.0.0',
@@ -133,7 +133,7 @@ describe('detectJestVersion', () => {
     it('finds the correct version', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'mono-repo' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/jest/package.json': {
           name: 'jest',
           version: '19.0.0',
@@ -153,13 +153,13 @@ describe('detectJestVersion', () => {
     it('finds the correct versions', () => {
       const projectDir = setupFakeProject({
         'backend/package.json': { name: 'package-a' },
-        [`backend/node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`backend/node_modules/${relativePathToFn}`]: compiledFn,
         'backend/node_modules/jest/package.json': {
           name: 'jest',
           version: '24.0.0',
         },
         'frontend/package.json': { name: 'package-b' },
-        [`frontend/node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`frontend/node_modules/${relativePathToFn}`]: compiledFn,
         'frontend/node_modules/jest/package.json': {
           name: 'jest',
           version: '15.0.0',
@@ -184,7 +184,7 @@ describe('detectJestVersion', () => {
     it('throws an error', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'no-jest' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/pack/package.json': { name: 'pack' },
       });
 
@@ -199,7 +199,7 @@ describe('detectJestVersion', () => {
     it('uses the cached version', () => {
       const projectDir = setupFakeProject({
         'package.json': { name: 'no-jest' },
-        [`node_modules/${relativePathToFn}` as const]: compiledFn,
+        [`node_modules/${relativePathToFn}`]: compiledFn,
         'node_modules/jest/package.json': { name: 'jest', version: '26.0.0' },
       });
 

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -194,7 +194,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'script' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -220,7 +220,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -246,7 +246,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -272,7 +272,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -298,7 +298,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -327,7 +327,7 @@ ruleTester.run('expect', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -343,7 +343,7 @@ ruleTester.run('expect', rule, {
           line: 3,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -359,7 +359,7 @@ ruleTester.run('expect', rule, {
           line: 4,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -375,7 +375,7 @@ ruleTester.run('expect', rule, {
           line: 5,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -493,7 +493,7 @@ if (eslintVersion >= 8) {
         parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
         errors: [
           {
-            messageId: 'details' as const,
+            messageId: 'details',
             data: expectedParsedJestFnCallResultData({
               name: 'it',
               type: 'test',
@@ -519,7 +519,7 @@ if (eslintVersion >= 8) {
         parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
         errors: [
           {
-            messageId: 'details' as const,
+            messageId: 'details',
             data: expectedParsedJestFnCallResultData({
               name: 'it',
               type: 'test',
@@ -630,7 +630,7 @@ ruleTester.run('global aliases', rule, {
       code: 'context("when there is an error", () => {})',
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -652,7 +652,7 @@ ruleTester.run('global aliases', rule, {
       code: 'context.skip("when there is an error", () => {})',
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -677,7 +677,7 @@ ruleTester.run('global aliases', rule, {
       `,
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'xdescribe',
             type: 'describe',
@@ -703,7 +703,7 @@ ruleTester.run('global aliases', rule, {
       `,
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -719,7 +719,7 @@ ruleTester.run('global aliases', rule, {
           line: 1,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -794,7 +794,7 @@ ruleTester.run('global package source', rule, {
       parserOptions: { sourceType: 'script' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -825,7 +825,7 @@ ruleTester.run('global package source', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -841,7 +841,7 @@ ruleTester.run('global package source', rule, {
           line: 3,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'it',
             type: 'test',
@@ -857,7 +857,7 @@ ruleTester.run('global package source', rule, {
           line: 4,
         },
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -884,7 +884,7 @@ ruleTester.run('global package source', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'expect',
             type: 'expect',
@@ -906,7 +906,7 @@ ruleTester.run('global package source', rule, {
       code: 'context("when there is an error", () => {})',
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'describe',
             type: 'describe',
@@ -1013,7 +1013,7 @@ ruleTester.run('typescript', rule, {
       parserOptions: { sourceType: 'module' },
       errors: [
         {
-          messageId: 'details' as const,
+          messageId: 'details',
           data: expectedParsedJestFnCallResultData({
             name: 'it',
             type: 'test',

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -80,7 +80,7 @@ const MatcherAndMessageSchema: JSONSchema.JSONSchema4 = {
   minItems: 1,
   maxItems: 2,
   additionalItems: false,
-} as const;
+};
 
 type MatcherGroups = 'describe' | 'test' | 'it';
 


### PR DESCRIPTION
As per the comment in https://github.com/jest-community/eslint-plugin-jest/pull/1573, I have removed the unnecessary `as const`.






