### PR TITLE
chore: remove `semantic-release` branch config

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,6 @@
     "singleQuote": true
   },
   "release": {
-    "branches": [
-      "main",
-      {
-        "name": "next",
-        "prerelease": true
-      }
-    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
`main` is finally supported out of the box: https://github.com/semantic-release/semantic-release/pull/1737#issuecomment-2105027110