### PR TITLE
test: only run linting when using ESLint v8

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -37,7 +37,8 @@ const config = {
   ],
 } satisfies Config;
 
-if (semver.major(eslintVersion) >= 9) {
+if (semver.major(eslintVersion) !== 8) {
+  // our eslint config only works for v8
   config.projects = config.projects.filter(
     ({ displayName }) => displayName !== 'lint',
   );


### PR DESCRIPTION
I've not dug into the actual code yet, but I'm pretty sure this is why #1590 is failing CI - more specifically, the latest version of `eslint-plugin-n` (which does not support ESLint v7) is now doing something v7 doesn't support