### PR TITLE
chore: run prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,15 @@ enabled in.\
 set to warn in.\
 ✅ Set in the `recommended`
 [configuration](https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#shareable-configurations).\
-🎨 Set in the `style` [configuration](https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#shareable-configurations).\
-🔧 Automatically fixable by the
+🎨
+Set in the `style`
+[configuration](https://github.com/jest-community/eslint-plugin-jest/blob/main/README.md#shareable-configurations).\
+🔧
+Automatically fixable by the
 [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).\
-💡 Manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+💡
+Manually fixable by
+[editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
 
 | Name                                                                         | Description                                                               | 💼  | ⚠️  | 🔧  | 💡  |
 | :--------------------------------------------------------------------------- | :------------------------------------------------------------------------ | :-- | :-- | :-- | :-- |


### PR DESCRIPTION
Renovate keeps merging PRs with failing CI 🙁 

I've added some required CI checks to the repo's config now (LTS on all 3 OSes, typescript and prettier), so hopefully that won't happen again

https://github.com/jest-community/eslint-plugin-jest/pull/1603