### PR TITLE
ci: run `docs` job on `push`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -129,7 +129,6 @@ jobs:
       os: windows-latest
 
   docs:
-    if: ${{ github.event_name == 'pull_request' }}
     needs: prepare-yarn-cache-ubuntu
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I'm guessing this job was made required as part of trying to get Renovate to stop merging PRs that are failing CI