### PR TITLE
refactor: use simple array syntax

### DIFF
--- a/src/rules/__tests__/test-utils.ts
+++ b/src/rules/__tests__/test-utils.ts
@@ -17,7 +17,7 @@ export class FlatCompatRuleTester extends TSESLint.RuleTester {
 
   public override run<
     TMessageIds extends string,
-    TOptions extends Readonly<unknown[]>,
+    TOptions extends readonly unknown[],
   >(
     ruleName: string,
     rule: TSESLint.RuleModule<TMessageIds, TOptions>,


### PR DESCRIPTION
`@typescript-eslint/array-type` has gotten smarter in the latest version of v7, so this makes it happy