### PR TITLE
chore: skip lib checks for now

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "skipLibCheck": false
+    // todo: required due to @typescript-eslint v7 - disable in new major
+    "skipLibCheck": true
   },
   "files": ["eslint-remote-tester.config.ts"],
   "include": ["src/**/*"],


### PR DESCRIPTION
Currently our typechecking is failing due to a conflict between the latest TypeScript and `@typescript-eslint/typescript-estree` v6 - this unblocks us without needing to immediately drop support for that version