### PR TITLE
feat: allow `@typescript-eslint` v8

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,24 @@
 'use strict';
 
+const {
+  version: typescriptESLintPluginVersion,
+} = require('@typescript-eslint/eslint-plugin/package.json');
+const semver = require('semver');
 const globals = require('./src/globals.json');
+
+const typescriptBanTypesRules = () => {
+  if (semver.major(typescriptESLintPluginVersion) === 8) {
+    return {
+      '@typescript-eslint/no-empty-object-type': 'error',
+      '@typescript-eslint/no-unsafe-function-type': 'error',
+      '@typescript-eslint/no-wrapper-object-types': 'error',
+    };
+  }
+
+  return {
+    '@typescript-eslint/ban-types': 'error',
+  };
+};
 
 module.exports = {
   parser: require.resolve('@typescript-eslint/parser'),
@@ -30,7 +48,7 @@ module.exports = {
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',
-    '@typescript-eslint/ban-types': 'error',
+    ...typescriptBanTypesRules(),
     '@typescript-eslint/consistent-type-imports': [
       'error',
       { disallowTypeAnnotations: false, fixStyle: 'inline-type-imports' },

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -73,17 +73,23 @@ jobs:
       matrix:
         node-version: [16.x, 18.x, 20.x, 21.x, 22.x]
         eslint-version: [7, 8, 9]
-        ts-eslint-plugin-version: [6, 7]
+        ts-eslint-plugin-version: [6, 7, 8]
         exclude:
           # ts-eslint/plugin@7 doesn't support node@16
           - node-version: 16.x
             ts-eslint-plugin-version: 7
+          # ts-eslint/plugin@8 doesn't support node@16
+          - node-version: 16.x
+            ts-eslint-plugin-version: 8
           # eslint@9 doesn't support node@16
           - node-version: 16.x
             eslint-version: 9
           # ts-eslint/plugin@7 doesn't support eslint@7
           - eslint-version: 7
             ts-eslint-plugin-version: 7
+          # ts-eslint/plugin@8 doesn't support eslint@7
+          - eslint-version: 7
+            ts-eslint-plugin-version: 8
     runs-on: ubuntu-latest
 
     steps:

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -42,17 +42,17 @@ if (semver.major(eslintVersion) !== 8) {
   config.projects = config.projects.filter(
     ({ displayName }) => displayName !== 'lint',
   );
+}
 
-  // jest/unbound-method doesn't work when using @typescript-eslint v6
-  if (semver.major(typescriptESLintPluginVersion) === 6) {
-    for (const project of config.projects) {
-      project.testPathIgnorePatterns.push(
-        '<rootDir>/src/rules/__tests__/unbound-method.test.ts',
-      );
-      project.coveragePathIgnorePatterns.push(
-        '<rootDir>/src/rules/unbound-method.ts',
-      );
-    }
+// jest/unbound-method seems to only be happy with @typescript-eslint v7 right now...
+if (semver.major(typescriptESLintPluginVersion) !== 7) {
+  for (const project of config.projects) {
+    project.testPathIgnorePatterns.push(
+      '<rootDir>/src/rules/__tests__/unbound-method.test.ts',
+    );
+    project.coveragePathIgnorePatterns.push(
+      '<rootDir>/src/rules/unbound-method.ts',
+    );
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^6.0.0 || ^7.0.0"
+    "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",
@@ -106,7 +106,7 @@
     "typescript": "^5.0.4"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
     "jest": "*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5199,7 +5199,7 @@ __metadata:
     ts-node: ^10.2.1
     typescript: ^5.0.4
   peerDependencies:
-    "@typescript-eslint/eslint-plugin": ^6.0.0 || ^7.0.0
+    "@typescript-eslint/eslint-plugin": ^6.0.0 || ^7.0.0 || ^8.0.0
     eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
     jest: "*"
   peerDependenciesMeta:


### PR DESCRIPTION
Unsurprisingly we don't have to actually do anything for this support - I'm not worried about the `unbound-method` tests as [this weirdness happened before](https://github.com/jest-community/eslint-plugin-jest/pull/1534#issuecomment-2027752670) and I plan to do a new major soon which'll get all this cleaned up; everything is working fine locally

Resolves #1633
Resolves #1623