### PR TITLE
fix(prefer-importing-jest-globals): don't add imports in the middle of statements

### DIFF
--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -304,11 +304,11 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
       `,
       // todo: this shouldn't be indenting the "test"
       output: dedent`
+        const { expect, test } = require('@jest/globals');
         const source = 'globals';
         const {describe} = require(\`@jest/\${source}\`);
         describe("suite", () => {
-          const { expect, test } = require('@jest/globals');
-        test("foo");
+          test("foo");
           expect(true).toBeDefined();
         })
       `,
@@ -407,8 +407,8 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
         });
       `,
       output: dedent`
-        const { pending } = require('actions');
         const { describe, test } = require('@jest/globals');
+        const { pending } = require('actions');
         describe('foo', () => {
           test.each(['hello', 'world'])("%s", (a) => {});
         });
@@ -552,12 +552,12 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
         const onClick = jest.fn();
         describe("suite", () => {
           test("foo");
-        expect(onClick).toHaveBeenCalled();
+          expect(onClick).toHaveBeenCalled();
         })
       `,
       output: dedent`
-        console.log('hello');
         const { describe, expect, jest, test } = require('@jest/globals');
+        console.log('hello');
         const onClick = jest.fn();
         describe("suite", () => {
           test("foo");

--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -548,22 +548,22 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
     },
     {
       code: dedent`
-          console.log('hello');
-          const onClick = jest.fn();
-          describe("suite", () => {
-            test("foo");
-            expect(onClick).toHaveBeenCalled();
-          })
-          `,
+        console.log('hello');
+        const onClick = jest.fn();
+        describe("suite", () => {
+          test("foo");
+        expect(onClick).toHaveBeenCalled();
+        })
+      `,
       output: dedent`
-          console.log('hello');
-          const { describe, expect, jest, test } = require('@jest/globals');
-          const onClick = jest.fn();
-          describe("suite", () => {
-            test("foo");
-            expect(onClick).toHaveBeenCalled();
-          })
-          `,
+        console.log('hello');
+        const { describe, expect, jest, test } = require('@jest/globals');
+        const onClick = jest.fn();
+        describe("suite", () => {
+          test("foo");
+          expect(onClick).toHaveBeenCalled();
+        })
+      `,
       errors: [
         {
           endColumn: 21,
@@ -575,21 +575,21 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
     },
     {
       code: dedent`
-      console.log('hello');
-      const onClick = jest.fn();
-      describe("suite", () => {
-        test("foo");
-        expect(onClick).toHaveBeenCalled();
-      })
+        console.log('hello');
+        const onClick = jest.fn();
+        describe("suite", () => {
+          test("foo");
+          expect(onClick).toHaveBeenCalled();
+        })
       `,
       output: dedent`
-      import { describe, expect, jest, test } from '@jest/globals';
-      console.log('hello');
-      const onClick = jest.fn();
-      describe("suite", () => {
-        test("foo");
-        expect(onClick).toHaveBeenCalled();
-      })
+        import { describe, expect, jest, test } from '@jest/globals';
+        console.log('hello');
+        const onClick = jest.fn();
+        describe("suite", () => {
+          test("foo");
+          expect(onClick).toHaveBeenCalled();
+        })
       `,
       parserOptions: { sourceType: 'module' },
       errors: [

--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -228,8 +228,8 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
         });
       `,
       output: dedent`
-        import { pending } from 'actions';
         import { describe, test } from '@jest/globals';
+        import { pending } from 'actions';
         describe('foo', () => {
           test.each(['hello', 'world'])("%s", (a) => {});
         });
@@ -541,6 +541,61 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
         {
           endColumn: 9,
           column: 1,
+          line: 2,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+          console.log('hello');
+          const onClick = jest.fn();
+          describe("suite", () => {
+            test("foo");
+            expect(onClick).toHaveBeenCalled();
+          })
+          `,
+      output: dedent`
+          console.log('hello');
+          const { describe, expect, jest, test } = require('@jest/globals');
+          const onClick = jest.fn();
+          describe("suite", () => {
+            test("foo");
+            expect(onClick).toHaveBeenCalled();
+          })
+          `,
+      errors: [
+        {
+          endColumn: 21,
+          column: 17,
+          line: 2,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+      console.log('hello');
+      const onClick = jest.fn();
+      describe("suite", () => {
+        test("foo");
+        expect(onClick).toHaveBeenCalled();
+      })
+      `,
+      output: dedent`
+      import { describe, expect, jest, test } from '@jest/globals';
+      console.log('hello');
+      const onClick = jest.fn();
+      describe("suite", () => {
+        test("foo");
+        expect(onClick).toHaveBeenCalled();
+      })
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 21,
+          column: 17,
           line: 2,
           messageId: 'preferImportingJestGlobal',
         },

--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -21,22 +21,6 @@ const createFixerImports = (
     : `const { ${allImportsFormatted} } = require('@jest/globals');`;
 };
 
-const findInsertionPoint = (reportingNode: TSESTree.Node) => {
-  let currentNode = reportingNode;
-
-  while (
-    currentNode.parent &&
-    currentNode.parent.type !== AST_NODE_TYPES.Program &&
-    currentNode.parent.type !== AST_NODE_TYPES.VariableDeclaration
-  ) {
-    currentNode = currentNode.parent;
-  }
-
-  return currentNode.parent?.type === AST_NODE_TYPES.VariableDeclaration
-    ? currentNode.parent
-    : reportingNode;
-};
-
 const allJestFnTypes: JestFnType[] = [
   'hook',
   'describe',
@@ -167,12 +151,8 @@ export default createRule({
             );
 
             if (requireNode?.type !== AST_NODE_TYPES.VariableDeclaration) {
-              const insertBeforeNode = isModule
-                ? firstNode
-                : findInsertionPoint(reportingNode);
-
               return fixer.insertTextBefore(
-                insertBeforeNode,
+                firstNode,
                 `${createFixerImports(isModule, functionsToImport)}\n`,
               );
             }

--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -21,6 +21,22 @@ const createFixerImports = (
     : `const { ${allImportsFormatted} } = require('@jest/globals');`;
 };
 
+const findInsertionPoint = (reportingNode: TSESTree.Node) => {
+  let currentNode = reportingNode;
+
+  while (
+    currentNode.parent &&
+    currentNode.parent.type !== AST_NODE_TYPES.Program &&
+    currentNode.parent.type !== AST_NODE_TYPES.VariableDeclaration
+  ) {
+    currentNode = currentNode.parent;
+  }
+
+  return currentNode.parent?.type === AST_NODE_TYPES.VariableDeclaration
+    ? currentNode.parent
+    : reportingNode;
+};
+
 const allJestFnTypes: JestFnType[] = [
   'hook',
   'describe',
@@ -151,8 +167,12 @@ export default createRule({
             );
 
             if (requireNode?.type !== AST_NODE_TYPES.VariableDeclaration) {
+              const insertBeforeNode = isModule
+                ? firstNode
+                : findInsertionPoint(reportingNode);
+
               return fixer.insertTextBefore(
-                reportingNode,
+                insertBeforeNode,
                 `${createFixerImports(isModule, functionsToImport)}\n`,
               );
             }


### PR DESCRIPTION
The current fixer implementation for prefer-importing-jest-globals inserts the `import` directly before the reporting node. This works fine when the reporting node is a function call.
```
describe(...)
```
results in
```
import { describe } from 'jest/globals';
describe(...)
```

But it breaks when the reporting node is part of a variable declaration
```
const onClick = jest.fn();
```
results in 
```
const onClick = import { jest } from '@jest/globals';
jest.fn();
```

This change updates the fixer so new imports are inserted at the top of the file.
```
console.log('foo');
const onClick = jest.fn();
```
results in 
```
import { jest } from '@jest/globals';
console.log('foo')
const onClick = jest.fn();
```

Existing imports are unchanged
```
console.log('foo');
import { describe } from '@jest/globals';
describe('the thing', () => {
  const onClick = jest.fn();
}
```
results in 
```
console.log('foo');
import { describe, jest } from '@jest/globals';
describe('the thing', () => {
  const onClick = jest.fn();
}
```

Resolves #1634