### PR TITLE
Es lint 9 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ doing:
 ```
 
 If you are using `eslint` version 9 or higher,
+
 ```js
 import jestPlugin from "eslint-plugin-jest";
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ can omit the `eslint-plugin-` prefix:
 If you are using `eslint` version 9 or higher,
 
 ```js
+import jestPlugin from "eslint-plugin-jest";
+
+// ...
+
 plugins: {
     jest: jestPlugin,
 },
@@ -69,6 +73,21 @@ doing:
 {
   "env": {
     "jest/globals": true
+  }
+}
+```
+
+If you are using `eslint` version 9 or higher,
+```js
+import jestPlugin from "eslint-plugin-jest";
+
+//...
+
+{
+languageOptions: {
+  globals: {
+      ...jestPlugin.environments.globals.latest
+    }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ can omit the `eslint-plugin-` prefix:
 }
 ```
 
+If you are using `eslint` version 9 or higher,
+
+```js
+plugins: {
+    jest: jestPlugin,
+},
+```
+
 Then configure the rules you want to use under the rules section.
 
 ```json

--- a/src/globals.latest.json
+++ b/src/globals.latest.json
@@ -1,0 +1,15 @@
+{
+  "afterAll": "readonly",
+  "afterEach": "readonly",
+  "beforeAll": "readonly",
+  "beforeEach": "readonly",
+  "describe": "readonly",
+  "expect": "readonly",
+  "fit": "readonly",        
+  "it": "readonly",
+  "jest": "readonly",
+  "test": "readonly",
+  "xdescribe": "readonly",
+  "xit": "readonly",
+  "xtest": "readonly"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   version as packageVersion,
 } from '../package.json';
 import globals from './globals.json';
+import latestGlobals from "./globals.latest.json";
 
 type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
   meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
@@ -82,6 +83,9 @@ const plugin = {
     globals: {
       globals,
     },
+    latest: {
+      latestGlobals,
+    }
   },
   rules,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   version as packageVersion,
 } from '../package.json';
 import globals from './globals.json';
-import latestGlobals from "./globals.latest.json";
+import latestGlobals from './globals.latest.json';
 
 type RuleModule = TSESLint.RuleModule<string, unknown[]> & {
   meta: Required<Pick<TSESLint.RuleMetaData<string>, 'docs'>>;
@@ -85,7 +85,7 @@ const plugin = {
     },
     latest: {
       latestGlobals,
-    }
+    },
   },
   rules,
 };


### PR DESCRIPTION
#1660

# What I do
- I write for basically config in es-lint 9 version.
- I make file about global variables json file for es-lint 9 version.

# Describe
- I write docs with `If you are using `eslint` version 9 or higher,` about env & plugin part.
- In the latest es-lint, value of global variable must be `readonly` or `writeable`. So I make the json file.

# Additional
- I don't know where to write the part about setting up rules. The related API already exists.
- Currently I have a very basic `jest es-lint` setup. Are there any other places where something goes wrong? I don't know because I haven't experienced it.