### PR TITLE
feat: add types to package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -133,5 +133,11 @@ module.exports = {
         'import/no-commonjs': 'off',
       },
     },
+    {
+      files: ['*.d.ts'],
+      rules: {
+        strict: 'off',
+      },
+    },
   ],
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,28 @@
+import type { Linter, Rule } from 'eslint';
+
+declare const plugin: {
+  meta: {
+    name: string;
+    version: string;
+  };
+  environments: {
+    globals: {
+      globals: {
+        [key: string]: boolean;
+      };
+    };
+  };
+  configs: {
+    all: Linter.LegacyConfig;
+    recommended: Linter.LegacyConfig;
+    style: Linter.LegacyConfig;
+    'flat/all': Linter.FlatConfig;
+    'flat/recommended': Linter.FlatConfig;
+    'flat/style': Linter.FlatConfig;
+  };
+  rules: {
+    [key: string]: Rule.RuleModule;
+  };
+};
+
+export = plugin;

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "url": "jkimbo.com"
   },
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "files": [
     "docs/",
-    "lib/"
+    "lib/",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "babel --extensions .js,.ts src --out-dir lib --copy-files && rimraf --glob lib/__tests__ 'lib/**/__tests__'",


### PR DESCRIPTION
Fixes https://github.com/jest-community/eslint-plugin-jest/issues/1469

I opted to generate the types manually with a hard coded `index.d.ts` file given that the types are very straightforward and the result works much better with typescript-eslint in my experience vs simply relying on `tsc` generated types.