### PR TITLE
chore(package): fix repository url; add homepage and bugs urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "eslintplugin",
     "eslint-plugin"
   ],
-  "repository": "jest-community/eslint-plugin-jest",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jest-community/eslint-plugin-jest.git"
+  },
+  "homepage": "https://github.com/jest-community/eslint-plugin-jest#readme",
   "license": "MIT",
   "author": {
     "name": "Jonathan Kim",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "url": "git+https://github.com/jest-community/eslint-plugin-jest.git"
   },
   "homepage": "https://github.com/jest-community/eslint-plugin-jest#readme",
+  "bugs": {
+    "url": "https://github.com/jest-community/eslint-plugin-jest/issues"
+  },
   "license": "MIT",
   "author": {
     "name": "Jonathan Kim",


### PR DESCRIPTION
The repository URL was fixed by simply running `npm pkg fix`, which is [what `npm publish` does prior to publishing](https://docs.npmjs.com/cli/v10/commands/npm-pkg#description).

The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:

![image](https://github.com/user-attachments/assets/6ab18758-5335-46ed-843b-c8ac3e40c1c7)


Compared to eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):

![image](https://github.com/user-attachments/assets/43f6f798-75dc-4d6d-bc00-df886a08a98d)


The [`bugs`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bugs) property was also added to allow for `npm bugs` to work. 

