### PR TITLE
feat(unbound-methods): ignore functions passed to `jest.mocked`

### DIFF
--- a/src/rules/__tests__/unbound-method.test.ts
+++ b/src/rules/__tests__/unbound-method.test.ts
@@ -61,6 +61,7 @@ const validTestCases: string[] = [
     'expect(Console.prototype.log).toHaveBeenCalledTimes(1);',
     'expect(Console.prototype.log).not.toHaveBeenCalled();',
     'expect(Console.prototype.log).toStrictEqual(somethingElse);',
+    'jest.mocked(Console.prototype.log).mockImplementation(() => {});',
   ].map(code => [ConsoleClassAndVariableCode, code].join('\n')),
   dedent`
     expect(() => {

--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -79,6 +79,16 @@ export default createRule<Options, MessageIds>({
       ...baseSelectors,
       MemberExpression(node: TSESTree.MemberExpression): void {
         if (node.parent?.type === AST_NODE_TYPES.CallExpression) {
+          if (
+            node.parent.callee.type === AST_NODE_TYPES.MemberExpression &&
+            node.parent.callee.object.type === AST_NODE_TYPES.Identifier &&
+            node.parent.callee.object.name === 'jest' &&
+            node.parent.callee.property.type === AST_NODE_TYPES.Identifier &&
+            node.parent.callee.property.name === 'mocked'
+          ) {
+            return;
+          }
+
           const jestFnCall = parseJestFnCall(
             findTopMostCallExpression(node.parent),
             context,


### PR DESCRIPTION
Fixes #1596.