### PR TITLE
fix(padding-around-test-blocks): update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Manually fixable by
 | [padding-around-before-each-blocks](docs/rules/padding-around-before-each-blocks.md) | Enforce padding around `beforeEach` blocks                                |     |     | 🔧  |     |
 | [padding-around-describe-blocks](docs/rules/padding-around-describe-blocks.md)       | Enforce padding around `describe` blocks                                  |     |     | 🔧  |     |
 | [padding-around-expect-groups](docs/rules/padding-around-expect-groups.md)           | Enforce padding around `expect` groups                                    |     |     | 🔧  |     |
-| [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around test blocks                                        |     |     | 🔧  |     |
+| [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around `test` blocks                                      |     |     | 🔧  |     |
 | [prefer-called-with](docs/rules/prefer-called-with.md)                               | Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`              |     |     |     |     |
 | [prefer-comparison-matcher](docs/rules/prefer-comparison-matcher.md)                 | Suggest using the built-in comparison matchers                            |     |     | 🔧  |     |
 | [prefer-each](docs/rules/prefer-each.md)                                             | Prefer using `.each` rather than manual loops                             |     |     |     |     |

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Manually fixable by
 | [padding-around-before-each-blocks](docs/rules/padding-around-before-each-blocks.md) | Enforce padding around `beforeEach` blocks                                |     |     | 🔧  |     |
 | [padding-around-describe-blocks](docs/rules/padding-around-describe-blocks.md)       | Enforce padding around `describe` blocks                                  |     |     | 🔧  |     |
 | [padding-around-expect-groups](docs/rules/padding-around-expect-groups.md)           | Enforce padding around `expect` groups                                    |     |     | 🔧  |     |
-| [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around `test` blocks                                      |     |     | 🔧  |     |
+| [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around `test` and `it` blocks                             |     |     | 🔧  |     |
 | [prefer-called-with](docs/rules/prefer-called-with.md)                               | Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`              |     |     |     |     |
 | [prefer-comparison-matcher](docs/rules/prefer-comparison-matcher.md)                 | Suggest using the built-in comparison matchers                            |     |     | 🔧  |     |
 | [prefer-each](docs/rules/prefer-each.md)                                             | Prefer using `.each` rather than manual loops                             |     |     |     |     |

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Manually fixable by
 | [padding-around-before-each-blocks](docs/rules/padding-around-before-each-blocks.md) | Enforce padding around `beforeEach` blocks                                |     |     | 🔧  |     |
 | [padding-around-describe-blocks](docs/rules/padding-around-describe-blocks.md)       | Enforce padding around `describe` blocks                                  |     |     | 🔧  |     |
 | [padding-around-expect-groups](docs/rules/padding-around-expect-groups.md)           | Enforce padding around `expect` groups                                    |     |     | 🔧  |     |
-| [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around afterAll blocks                                    |     |     | 🔧  |     |
+| [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around test blocks                                        |     |     | 🔧  |     |
 | [prefer-called-with](docs/rules/prefer-called-with.md)                               | Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`              |     |     |     |     |
 | [prefer-comparison-matcher](docs/rules/prefer-comparison-matcher.md)                 | Suggest using the built-in comparison matchers                            |     |     | 🔧  |     |
 | [prefer-each](docs/rules/prefer-each.md)                                             | Prefer using `.each` rather than manual loops                             |     |     |     |     |

--- a/docs/rules/padding-around-test-blocks.md
+++ b/docs/rules/padding-around-test-blocks.md
@@ -1,4 +1,4 @@
-# Enforce padding around test blocks (`padding-around-test-blocks`)
+# Enforce padding around `test` blocks (`padding-around-test-blocks`)
 
 🔧 This rule is automatically fixable by the
 [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).

--- a/docs/rules/padding-around-test-blocks.md
+++ b/docs/rules/padding-around-test-blocks.md
@@ -1,4 +1,4 @@
-# Enforce padding around `test` blocks (`padding-around-test-blocks`)
+# Enforce padding around `test` and `it` blocks (`padding-around-test-blocks`)
 
 🔧 This rule is automatically fixable by the
 [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).

--- a/docs/rules/padding-around-test-blocks.md
+++ b/docs/rules/padding-around-test-blocks.md
@@ -1,4 +1,4 @@
-# Enforce padding around afterAll blocks (`padding-around-test-blocks`)
+# Enforce padding around test blocks (`padding-around-test-blocks`)
 
 🔧 This rule is automatically fixable by the
 [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).

--- a/src/rules/padding-around-test-blocks.ts
+++ b/src/rules/padding-around-test-blocks.ts
@@ -27,6 +27,6 @@ export const config = [
 
 export default createPaddingRule(
   __filename,
-  'Enforce padding around `test` blocks',
+  'Enforce padding around `test` and `it` blocks',
   config,
 );

--- a/src/rules/padding-around-test-blocks.ts
+++ b/src/rules/padding-around-test-blocks.ts
@@ -27,6 +27,6 @@ export const config = [
 
 export default createPaddingRule(
   __filename,
-  'Enforce padding around test blocks',
+  'Enforce padding around `test` blocks',
   config,
 );

--- a/src/rules/padding-around-test-blocks.ts
+++ b/src/rules/padding-around-test-blocks.ts
@@ -27,6 +27,6 @@ export const config = [
 
 export default createPaddingRule(
   __filename,
-  'Enforce padding around afterAll blocks',
+  'Enforce padding around test blocks',
   config,
 );


### PR DESCRIPTION
I have fixed the `padding-around-test-blocks` rule documentation.