### PR TITLE
chore: update package urls for homepage, repository, and bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,14 @@
     "eslintplugin",
     "eslint-plugin"
   ],
-  "repository": "jest-community/eslint-plugin-jest",
+  "homepage": "https://github.com/jest-community/eslint-plugin-jest#readme",
+  "bugs": {
+    "url": "https://github.com/jest-community/eslint-plugin-jest/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jest-community/eslint-plugin-jest.git"
+  },
   "license": "MIT",
   "author": {
     "name": "Jonathan Kim",
@@ -30,8 +37,8 @@
     "prettier:check": "prettier --check 'docs/**/*.md' README.md '.github/**' package.json tsconfig.json src/globals.json .yarnrc.yml",
     "prettier:write": "prettier --write 'docs/**/*.md' README.md '.github/**' package.json tsconfig.json src/globals.json .yarnrc.yml",
     "postpublish": "pinst --enable",
-    "test": "jest",
     "regenerate-docs": "yarn prepack && eslint-doc-generator",
+    "test": "jest",
     "typecheck": "tsc -p ."
   },
   "commitlint": {


### PR DESCRIPTION
Re-PR of https://github.com/jest-community/eslint-plugin-jest/pull/1673, with `npx sort-package-json` ran.


> The repository URL was fixed by simply running `npm pkg fix`, which is [what `npm publish` does prior to publishing](https://docs.npmjs.com/cli/v10/commands/npm-pkg#description).
> 
> The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code when using a proxy registry like in Azure DevOps:
> 
> ![image](https://private-user-images.githubusercontent.com/43814140/387210314-6ab18758-5335-46ed-843b-c8ac3e40c1c7.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzY3NTc3ODQsIm5iZiI6MTczNjc1NzQ4NCwicGF0aCI6Ii80MzgxNDE0MC8zODcyMTAzMTQtNmFiMTg3NTgtNTMzNS00NmVkLTg0M2ItYzhhYzNlNDBjMWM3LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAxMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMTEzVDA4MzgwNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWU4MDcyMjU3YmRjYmQ3NzRiNWYzNzJiZGUxZTZiOWNhNGEzOGQ0ODkxYzMwMWMyZWViOTVjOWFlOTJlZTAxZTcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.QueJmcO5vwEJKgiNBu9f5QU2-5wtpeBY2Aahy_HIZqI)
> 
> Compared to eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):
> 
> ![image](https://private-user-images.githubusercontent.com/43814140/387206674-43f6f798-75dc-4d6d-bc00-df886a08a98d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzY3NTc3ODQsIm5iZiI6MTczNjc1NzQ4NCwicGF0aCI6Ii80MzgxNDE0MC8zODcyMDY2NzQtNDNmNmY3OTgtNzVkYy00ZDZkLWJjMDAtZGY4ODZhMDhhOThkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAxMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMTEzVDA4MzgwNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTJlMDBkNTMyMDk3NjZmNzJiYTBjMmU3NThjYTM5Yzg5YTcxNDRlODEzNzVkYjg0NjI5ODczMDQ4YWQ2ODhjNWYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.SugS1SupOOD-GPkaUBekItPMsRygEHUgJCIc3_hF9JY)
> 
> The [`bugs`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bugs) property was also added to allow for `npm bugs` to work.

