### PR TITLE
docs(prefer-equality-matcher): fix !== example

### DIFF
--- a/docs/rules/prefer-equality-matcher.md
+++ b/docs/rules/prefer-equality-matcher.md
@@ -30,5 +30,5 @@ Examples of **correct** code for this rule:
 ```js
 expect(x).toBe(5);
 expect(name).not.toEqual('Carl');
-expect(myObj).toStrictEqual(thatObj);
+expect(myObj).not.toStrictEqual(thatObj);
 ```


### PR DESCRIPTION
There is a minor mistake in the docs which claims the following to be equivalent,

```js
expect(myObj !== thatObj).toStrictEqual(true);
```

```js
expect(myObj).toStrictEqual(thatObj);
```

where it should be

```js
expect(myObj).not.toStrictEqual(thatObj);
```
