### PR TITLE
chore: add missing `'use strict'` directive

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { format } = require('prettier');
 const { prettier: prettierRC } = require('./package.json');
 


### PR DESCRIPTION
Added a missing `'use strict'` directive to the only CJS file in this repo without one.

Test failures unrelated, occurring on the main branch.