### PR TITLE
chore: ensure types are available for `semver`

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/eslint": "^8.4.6",
     "@types/jest": "^29.0.0",
     "@types/node": "^16.0.0",
+    "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@typescript-eslint/utils": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2860,7 +2860,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.5.0":
+"@types/semver@npm:^7.5.0, @types/semver@npm:^7.5.8":
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
   checksum: ea6f5276f5b84c55921785a3a27a3cd37afee0111dfe2bcb3e03c31819c197c782598f17f0b150a69d453c9584cd14c4c4d7b9a55d2c5e6cacd4d66fdb3b3663
@@ -5200,6 +5200,7 @@ __metadata:
     "@types/eslint": ^8.4.6
     "@types/jest": ^29.0.0
     "@types/node": ^16.0.0
+    "@types/semver": ^7.5.8
     "@typescript-eslint/eslint-plugin": ^6.0.0
     "@typescript-eslint/parser": ^6.0.0
     "@typescript-eslint/utils": ^6.0.0


### PR DESCRIPTION
Apparently we were depending on this implicitly (which surprises me), and #1708 updated `conventional-changelog-writer` to a version that no longer has this as a dependency, causing CI to fail in some cases because only some versions of `@typescript-eslint` depend on them.