### PR TITLE
chore: lint "hidden" js files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ const typescriptBanTypesRules = () => {
 };
 
 module.exports = {
+  ignorePatterns: ['!.eslint-doc-generatorrc.js', '!.eslintrc.js'],
   parser: require.resolve('@typescript-eslint/parser'),
   extends: [
     'plugin:eslint-plugin/recommended',
@@ -127,7 +128,7 @@ module.exports = {
       },
     },
     {
-      files: ['.eslintrc.js', 'babel.config.js'],
+      files: ['.eslint-doc-generatorrc.js', '.eslintrc.js', 'babel.config.js'],
       rules: {
         '@typescript-eslint/no-require-imports': 'off',
         'import/no-commonjs': 'off',


### PR DESCRIPTION
ESLint pre-v9 ignores "hidden" files - that is, files prefixed with a dot (.) - meaning our rules were not being enforced; I believe this is not needed in ESLint v9, but while we're on v8 we can explicitly negate ignoring these files to have them linted