### PR TITLE
chore: ignore `.yarn` directory when running `prettier`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 CHANGELOG.md
 src/rules/__tests__/fixtures/
+.yarn/


### PR DESCRIPTION
Sometimes I run `prettier` by itself manually, which currently tries to format `.yarn` 😅 