### PR TITLE
fix(no-large-snapshots): use a far better message for when an unexpected snapshot is found

### DIFF
--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -80,7 +80,7 @@ export default createRule<[RuleOptions], MessageId>({
     },
     messages: {
       noSnapshot:
-        'Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long',
+        'Expected to not encounter a Jest snapshot but one was found that is {{ lineCount }} lines long',
       tooLongSnapshots:
         'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
     },

--- a/src/rules/no-large-snapshots.ts
+++ b/src/rules/no-large-snapshots.ts
@@ -79,7 +79,8 @@ export default createRule<[RuleOptions], MessageId>({
       description: 'Disallow large snapshots',
     },
     messages: {
-      noSnapshot: '`{{ lineCount }}`s should begin with lowercase',
+      noSnapshot:
+        'Expected to not encounter a Jest snapshot but was found with {{ lineCount }} lines long',
       tooLongSnapshots:
         'Expected Jest snapshot to be smaller than {{ lineLimit }} lines but was {{ lineCount }} lines long',
     },


### PR DESCRIPTION
The incorrect message was introduced by #278