### PR TITLE
fix(no-commented-out-tests): make message less ambiguous

### DIFF
--- a/src/rules/no-commented-out-tests.ts
+++ b/src/rules/no-commented-out-tests.ts
@@ -14,7 +14,7 @@ export default createRule({
       description: 'Disallow commented out tests',
     },
     messages: {
-      commentedTests: 'Some tests seem to be commented',
+      commentedTests: 'Do not comment out tests',
     },
     schema: [],
     type: 'suggestion',


### PR DESCRIPTION
The current message seems like a general observation rather than an indicator of an issue