### PR TITLE
fix(prefer-importing-jest-globals): preserve `as` imports

### DIFF
--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -106,6 +106,60 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
     },
     {
       code: dedent`
+        import { describe as context } from '@jest/globals';
+        context("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      output: dedent`
+        import { describe as context, expect, test } from '@jest/globals';
+        context("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 7,
+          column: 3,
+          line: 3,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { describe as context } from '@jest/globals';
+        describe("something", () => {
+          context("suite", () => {
+            test("foo");
+            expect(true).toBeDefined();
+          })
+        })
+      `,
+      output: dedent`
+        import { describe, describe as context, expect, test } from '@jest/globals';
+        describe("something", () => {
+          context("suite", () => {
+            test("foo");
+            expect(true).toBeDefined();
+          })
+        })
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [
+        {
+          endColumn: 9,
+          column: 1,
+          line: 2,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
         jest.useFakeTimers();
         describe("suite", () => {
           test("foo");

--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -120,7 +120,14 @@ export default createRule({
                   specifier.type === AST_NODE_TYPES.ImportSpecifier &&
                   specifier.imported?.name
                 ) {
-                  functionsToImport.add(specifier.imported.name);
+                  let importName = specifier.imported.name;
+                  const local = getAccessorValue(specifier.local);
+
+                  if (local !== importName) {
+                    importName = `${importName} as ${local}`;
+                  }
+
+                  functionsToImport.add(importName);
                 }
 
                 if (specifier.type === AST_NODE_TYPES.ImportDefaultSpecifier) {


### PR DESCRIPTION
I'll handle `require` in a follow up