### PR TITLE
fix(prefer-importing-jest-globals): preserve `require` property renames

### DIFF
--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -324,6 +324,86 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
     },
     {
       code: dedent`
+        const {describe: context} = require('@jest/globals');
+        context("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      output: dedent`
+        const { describe: context, expect, test } = require('@jest/globals');
+        context("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      errors: [
+        {
+          endColumn: 7,
+          column: 3,
+          line: 3,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const {describe: context} = require('@jest/globals');
+        describe("something", () => {
+          context("suite", () => {
+            test("foo");
+            expect(true).toBeDefined();
+          })
+        })
+      `,
+      output: dedent`
+        const { describe, describe: context, expect, test } = require('@jest/globals');
+        describe("something", () => {
+          context("suite", () => {
+            test("foo");
+            expect(true).toBeDefined();
+          })
+        })
+      `,
+      errors: [
+        {
+          endColumn: 9,
+          column: 1,
+          line: 2,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const {describe: []} = require('@jest/globals');
+        describe("something", () => {
+          context("suite", () => {
+            test("foo");
+            expect(true).toBeDefined();
+          })
+        })
+      `,
+      output: dedent`
+        const { describe, expect, test } = require('@jest/globals');
+        describe("something", () => {
+          context("suite", () => {
+            test("foo");
+            expect(true).toBeDefined();
+          })
+        })
+      `,
+      errors: [
+        {
+          endColumn: 9,
+          column: 1,
+          line: 2,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
         const {describe} = require(\`@jest/globals\`);
         describe("suite", () => {
           test("foo");

--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -171,11 +171,23 @@ export default createRule({
               for (const property of requireNode.declarations[0].id
                 .properties) {
                 if (
-                  property.type === AST_NODE_TYPES.Property &&
-                  isSupportedAccessor(property.key)
+                  property.type !== AST_NODE_TYPES.Property ||
+                  !isSupportedAccessor(property.key)
                 ) {
-                  functionsToImport.add(getAccessorValue(property.key));
+                  continue;
                 }
+
+                let importName = getAccessorValue(property.key);
+
+                if (isSupportedAccessor(property.value)) {
+                  const local = getAccessorValue(property.value);
+
+                  if (importName !== local) {
+                    importName += `: ${local}`;
+                  }
+                }
+
+                functionsToImport.add(importName);
               }
             }
 


### PR DESCRIPTION
Follow up to #1753