### PR TITLE
fix(prefer-importing-jest-globals): handle string-based import names

### DIFF
--- a/src/rules/__tests__/prefer-importing-jest-globals.test.ts
+++ b/src/rules/__tests__/prefer-importing-jest-globals.test.ts
@@ -24,6 +24,16 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
     },
     {
       code: dedent`
+        // with import
+        import { 'test' as test, expect } from '@jest/globals';
+        test('should pass', () => {
+            expect(true).toBeDefined();
+        });
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+    },
+    {
+      code: dedent`
         test('should pass', () => {
             expect(true).toBeDefined();
         });
@@ -64,6 +74,13 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
         itChecks("foo");
       `,
       parserOptions: { sourceType: 'module' },
+    },
+    {
+      code: dedent`
+        import { 'it' as itChecks } from '@jest/globals';
+        itChecks("foo");
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
     },
     {
       code: dedent`
@@ -154,6 +171,56 @@ ruleTester.run('prefer-importing-jest-globals', rule, {
           endColumn: 9,
           column: 1,
           line: 2,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { 'describe' as describe } from '@jest/globals';
+        describe("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      output: dedent`
+        import { 'describe' as describe, expect, test } from '@jest/globals';
+        describe("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [
+        {
+          endColumn: 7,
+          column: 3,
+          line: 3,
+          messageId: 'preferImportingJestGlobal',
+        },
+      ],
+    },
+    {
+      code: dedent`
+        import { 'describe' as context } from '@jest/globals';
+        context("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      output: dedent`
+        import { 'describe' as context, expect, test } from '@jest/globals';
+        context("suite", () => {
+          test("foo");
+          expect(true).toBeDefined();
+        })
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [
+        {
+          endColumn: 7,
+          column: 3,
+          line: 3,
           messageId: 'preferImportingJestGlobal',
         },
       ],

--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -116,15 +116,16 @@ export default createRule({
 
             if (importNode?.type === AST_NODE_TYPES.ImportDeclaration) {
               for (const specifier of importNode.specifiers) {
-                if (
-                  specifier.type === AST_NODE_TYPES.ImportSpecifier &&
-                  specifier.imported?.name
-                ) {
-                  let importName = specifier.imported.name;
+                if (specifier.type === AST_NODE_TYPES.ImportSpecifier) {
+                  let importName = specifier.imported.name ?? '';
                   const local = getAccessorValue(specifier.local);
 
                   if (local !== importName) {
                     importName = `${importName} as ${local}`;
+                  }
+
+                  if ('value' in specifier.imported) {
+                    importName = `'${specifier.imported.value}'${importName}`;
                   }
 
                   functionsToImport.add(importName);


### PR DESCRIPTION
While there's no reason to actually do this for our identifiers, official support for this was added in `@typescript-eslint/parser` v8 meaning we need to handle this somehow, so this just preserves it 🤷 