### PR TITLE
test: simplify detection of ESLint major version

### DIFF
--- a/src/rules/__tests__/test-utils.ts
+++ b/src/rules/__tests__/test-utils.ts
@@ -8,7 +8,8 @@ const eslintRequire = createRequire(require.resolve('eslint'));
 
 export const espreeParser = eslintRequire.resolve('espree');
 
-export const usingFlatConfig = semver.major(eslintVersion) >= 9;
+export const eslintMajorVersion = semver.major(eslintVersion);
+export const usingFlatConfig = eslintMajorVersion >= 9;
 
 export class FlatCompatRuleTester extends TSESLint.RuleTester {
   public constructor(testerConfig?: TSESLint.RuleTesterConfig) {

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -1,8 +1,8 @@
-import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
 import type { TSESTree } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import {
   FlatCompatRuleTester as RuleTester,
+  eslintMajorVersion,
   espreeParser,
 } from '../../__tests__/test-utils';
 import {
@@ -13,24 +13,6 @@ import {
   isSupportedAccessor,
   parseJestFnCall,
 } from '../../utils';
-
-const findESLintVersion = (): number => {
-  const eslintPath = require.resolve('eslint/package.json');
-
-  const eslintPackageJson =
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require(eslintPath) as JSONSchemaForNPMPackageJsonFiles;
-
-  if (!eslintPackageJson.version) {
-    throw new Error('eslint package.json does not have a version!');
-  }
-
-  const [majorVersion] = eslintPackageJson.version.split('.');
-
-  return parseInt(majorVersion, 10);
-};
-
-const eslintVersion = findESLintVersion();
 
 const ruleTester = new RuleTester({
   parser: espreeParser,
@@ -463,7 +445,7 @@ ruleTester.run('esm', rule, {
   invalid: [],
 });
 
-if (eslintVersion >= 8) {
+if (eslintMajorVersion >= 8) {
   ruleTester.run('esm (dynamic)', rule, {
     valid: [
       {


### PR DESCRIPTION
How we're doing it currently isn't super bad or anything, but in other places we're just importing the `package.json` which is a lot smaller, and moving this into test utils makes it a lot easier to use in other tests (which I'll be doing shortly, though ironically this'll then go away very quickly after as we're dropping support for ESLint v7 which is what we need this for)