### PR TITLE
test: automatically skip ecma 2022 tests when using ESLint v7

### DIFF
--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -2,7 +2,6 @@ import type { TSESTree } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import {
   FlatCompatRuleTester as RuleTester,
-  eslintMajorVersion,
   espreeParser,
 } from '../../__tests__/test-utils';
 import {
@@ -445,82 +444,80 @@ ruleTester.run('esm', rule, {
   invalid: [],
 });
 
-if (eslintMajorVersion >= 8) {
-  ruleTester.run('esm (dynamic)', rule, {
-    valid: [
-      {
-        code: dedent`
-          const { it } = await import('./test-utils');
+ruleTester.run('esm (dynamic)', rule, {
+  valid: [
+    {
+      code: dedent`
+        const { it } = await import('./test-utils');
 
-          it('is not a jest function', () => {});
-        `,
-        parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
-      },
-      {
-        code: dedent`
-          const { it } = await import(\`./test-utils\`);
+        it('is not a jest function', () => {});
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+    },
+    {
+      code: dedent`
+        const { it } = await import(\`./test-utils\`);
 
-          it('is not a jest function', () => {});
-        `,
-        parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
-      },
-    ],
-    invalid: [
-      {
-        code: dedent`
-          const { it } = await import("@jest/globals");
+        it('is not a jest function', () => {});
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+    },
+  ],
+  invalid: [
+    {
+      code: dedent`
+        const { it } = await import("@jest/globals");
 
-          it('is a jest function', () => {});
-        `,
-        parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
-        errors: [
-          {
-            messageId: 'details',
-            data: expectedParsedJestFnCallResultData({
-              name: 'it',
-              type: 'test',
-              head: {
-                original: 'it',
-                local: 'it',
-                type: 'import',
-                node: 'it',
-              },
-              members: [],
-            }),
-            column: 1,
-            line: 3,
-          },
-        ],
-      },
-      {
-        code: dedent`
-          const { it } = await import(\`@jest/globals\`);
+        it('is a jest function', () => {});
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [
+        {
+          messageId: 'details',
+          data: expectedParsedJestFnCallResultData({
+            name: 'it',
+            type: 'test',
+            head: {
+              original: 'it',
+              local: 'it',
+              type: 'import',
+              node: 'it',
+            },
+            members: [],
+          }),
+          column: 1,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const { it } = await import(\`@jest/globals\`);
 
-          it('is a jest function', () => {});
-        `,
-        parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
-        errors: [
-          {
-            messageId: 'details',
-            data: expectedParsedJestFnCallResultData({
-              name: 'it',
-              type: 'test',
-              head: {
-                original: 'it',
-                local: 'it',
-                type: 'import',
-                node: 'it',
-              },
-              members: [],
-            }),
-            column: 1,
-            line: 3,
-          },
-        ],
-      },
-    ],
-  });
-}
+        it('is a jest function', () => {});
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [
+        {
+          messageId: 'details',
+          data: expectedParsedJestFnCallResultData({
+            name: 'it',
+            type: 'test',
+            head: {
+              original: 'it',
+              local: 'it',
+              type: 'import',
+              node: 'it',
+            },
+            members: [],
+          }),
+          column: 1,
+          line: 3,
+        },
+      ],
+    },
+  ],
+});
 
 ruleTester.run('cjs', rule, {
   valid: [


### PR DESCRIPTION
While arguably this is using our custom tester for more than it was intended, since we only have one condition when we skip tests which'll be going away soon but that I want to use in a few other places first, this will mean less work elsewhere