### PR TITLE
chore: add `30` to `JestVersion` type

### DIFF
--- a/src/rules/utils/detectJestVersion.ts
+++ b/src/rules/utils/detectJestVersion.ts
@@ -17,6 +17,7 @@ export type JestVersion =
   | 27
   | 28
   | 29
+  | 30
   | number;
 
 let cachedJestVersion: JestVersion | null = null;


### PR DESCRIPTION
I don't think this needs a dedicated release since the specific value is mainly a vanity thing 😄 