### PR TITLE
fix: handle string-based import names when resolving Jest functions

### DIFF
--- a/src/rules/__tests__/no-hooks.test.ts
+++ b/src/rules/__tests__/no-hooks.test.ts
@@ -50,6 +50,17 @@ ruleTester.run('no-hooks', rule, {
       ],
     },
     {
+      code: dedent`
+        import { 'afterEach' as afterEachTest } from '@jest/globals';
+
+        afterEachTest(() => {})
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [
+        { messageId: 'unexpectedHook', data: { hookName: HookName.afterEach } },
+      ],
+    },
+    {
       code: 'beforeEach(() => {}); afterEach(() => { jest.resetModules() });',
       options: [{ allow: [HookName.afterEach] }],
       errors: [

--- a/src/rules/__tests__/require-top-level-describe.test.ts
+++ b/src/rules/__tests__/require-top-level-describe.test.ts
@@ -109,6 +109,16 @@ ruleTester.run('require-top-level-describe', rule, {
       errors: [{ messageId: 'unexpectedHook' }],
     },
     {
+      code: dedent`
+        import { 'describe' as describe, afterAll as onceEverythingIsDone } from '@jest/globals';
+
+        describe("test suite", () => {});
+        onceEverythingIsDone("my test", () => {})
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [{ messageId: 'unexpectedHook' }],
+    },
+    {
       code: "it.skip('test', () => {});",
       errors: [{ messageId: 'unexpectedTestCase' }],
     },

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -441,7 +441,34 @@ ruleTester.run('esm', rule, {
       parserOptions: { sourceType: 'module', ecmaVersion: 2017 },
     },
   ],
-  invalid: [],
+  invalid: [
+    {
+      code: dedent`
+        import { 'describe' as it } from '@jest/globals';
+
+        it('is a jest function', () => {});
+      `,
+      parserOptions: { sourceType: 'module', ecmaVersion: 2022 },
+      errors: [
+        {
+          messageId: 'details',
+          data: expectedParsedJestFnCallResultData({
+            name: 'describe',
+            type: 'describe',
+            head: {
+              original: 'describe',
+              local: 'it',
+              type: 'import',
+              node: 'it',
+            },
+            members: [],
+          }),
+          column: 1,
+          line: 3,
+        },
+      ],
+    },
+  ],
 });
 
 ruleTester.run('esm (dynamic)', rule, {

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -452,9 +452,15 @@ const describeImportDefAsImport = (
     return null;
   }
 
+  let imported = def.node.imported.name ?? '';
+
+  if ('value' in def.node.imported) {
+    imported = def.node.imported.value as string;
+  }
+
   return {
     source: def.parent.source.value,
-    imported: def.node.imported.name,
+    imported,
     local: def.node.local.name,
   };
 };


### PR DESCRIPTION
While there's no reason to actually do this for our identifiers, official support for this was added in `@typescript-eslint/parser` v8 meaning we need to handle this somehow, so this just preserves it 🤷 

Relates to #1756 and #1757 - the actual logic will be improved once we're using `@typescript-eslint` v8 since then the types will actually exist