### PR TITLE
feat(unbound-method): mark `docs.recommended` and `docs.requiresTypeChecking` as deprecated

### DIFF
--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -51,7 +51,9 @@ const DEFAULT_MESSAGE = 'This rule requires `@typescript-eslint/eslint-plugin`';
 // todo: remove these along with the actual runtime properties below in new major
 declare module '@typescript-eslint/utils/ts-eslint' {
   interface RuleMetaDataDocs {
+    /** @deprecated */
     requiresTypeChecking?: boolean;
+    /** @deprecated */
     recommended?: unknown;
   }
 }
@@ -71,9 +73,11 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         'Enforce unbound methods are called with their expected scope',
+      /** @deprecated */
       requiresTypeChecking: true,
       ...baseRule?.meta.docs,
       // mark this as not recommended
+      /** @deprecated */
       recommended: undefined,
     },
   },


### PR DESCRIPTION
This isn't actually needed but I'd like to do a new release with the changes from #1757 before we do the next major