### PR TITLE
ci: have `renovate` skip updating `@types/node`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "helpers:disableTypesNodeMajor"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
We want to use `@types/node` for the _oldest_ version of Node that we support