### PR TITLE
chore: don't skip lib checks

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,7 @@
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    // todo: required due to @typescript-eslint v7 - disable in new major
-    "skipLibCheck": true
+    "skipLibCheck": false
   },
   "files": ["eslint-remote-tester.config.ts"],
   "include": ["src/**/*"],


### PR DESCRIPTION
We should be able to do this now that we're using `@typescript-eslint` v8 in development and when typechecking