### PR TITLE
docs: update references to Jest v30

### DIFF
--- a/docs/rules/no-alias-methods.md
+++ b/docs/rules/no-alias-methods.md
@@ -10,7 +10,7 @@ This rule _warns_ in the 🎨 `style`
 
 <!-- end auto-generated rule header -->
 
-> These aliases are going to be removed in the next major version of Jest - see
+> These aliases have been removed in Jest v30 - see
 > <https://github.com/jestjs/jest/issues/13164> for more
 
 Several Jest methods have alias names, such as `toThrow` having the alias of

--- a/docs/rules/no-deprecated-functions.md
+++ b/docs/rules/no-deprecated-functions.md
@@ -53,5 +53,5 @@ Jest 27.
 
 ### `jest.genMockFromModule`
 
-This function was renamed to `createMockFromModule` in Jest 26, and is scheduled
-for removal in Jest 30.
+This function was renamed to `createMockFromModule` in Jest 26, and removed in
+Jest 30.


### PR DESCRIPTION
"the next major version of Jest" is now out and its v30