### PR TITLE
fix: update semantic-release config so new v29 major is marked as latest on `npm`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,13 @@
     "singleQuote": true
   },
   "release": {
+    "branches": [
+      "main",
+      {
+        "name": "next",
+        "prerelease": true
+      }
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",


### PR DESCRIPTION
This reverts #1585 which'll hopefully mean next time `semantic-release` will prefix the version with `-next` - I'm landing it as a `fix` so that it'll end up marking a v29.x.x version as the latest on `npm`