### PR TITLE
chore: always use `@typescript-eslint` v8 linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,24 +1,6 @@
 'use strict';
 
-const {
-  version: typescriptESLintPluginVersion,
-} = require('@typescript-eslint/eslint-plugin/package.json');
-const semver = require('semver');
 const globals = require('./src/globals.json');
-
-const typescriptBanTypesRules = () => {
-  if (semver.major(typescriptESLintPluginVersion) === 8) {
-    return {
-      '@typescript-eslint/no-empty-object-type': 'error',
-      '@typescript-eslint/no-unsafe-function-type': 'error',
-      '@typescript-eslint/no-wrapper-object-types': 'error',
-    };
-  }
-
-  return {
-    '@typescript-eslint/ban-types': 'error',
-  };
-};
 
 module.exports = {
   ignorePatterns: ['!.eslint-doc-generatorrc.js', '!.eslintrc.js'],
@@ -49,7 +31,9 @@ module.exports = {
     '@typescript-eslint/array-type': ['error', { default: 'array-simple' }],
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/ban-ts-comment': 'error',
-    ...typescriptBanTypesRules(),
+    '@typescript-eslint/no-empty-object-type': 'error',
+    '@typescript-eslint/no-unsafe-function-type': 'error',
+    '@typescript-eslint/no-wrapper-object-types': 'error',
     '@typescript-eslint/consistent-type-imports': [
       'error',
       { disallowTypeAnnotations: false, fixStyle: 'inline-type-imports' },


### PR DESCRIPTION
We no longer need this conditional since we only use `@typescript-eslint` v8