### PR TITLE
test: ensure that Node process does not output color

### DIFF
--- a/src/rules/utils/__tests__/detectJestVersion.test.ts
+++ b/src/rules/utils/__tests__/detectJestVersion.test.ts
@@ -21,7 +21,11 @@ const runNodeScript = (cwd: string, script: string) => {
   const { stdout, stderr } = spawnSync(
     'node',
     ['-p', script.split('\n').join(' ')],
-    { cwd, encoding: 'utf-8' },
+    {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    },
   );
 
   return { stdout: stdout.trim(), stderr: stderr.trim() };


### PR DESCRIPTION
Apparently #1770 only works in CI because that implies no color - I swear this worked locally too without these, but oh well