### PR TITLE
chore: mark remote tester config as a module

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,7 +106,12 @@ module.exports = {
       globals,
     },
     {
-      files: ['src/**/*', 'dangerfile.ts', './jest.config.ts'],
+      files: [
+        'src/**/*',
+        'dangerfile.ts',
+        './jest.config.ts',
+        './eslint-remote-tester.config.ts',
+      ],
       parserOptions: {
         sourceType: 'module',
       },

--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -1,5 +1,3 @@
-'use strict';
-
 import type { Config } from 'eslint-remote-tester';
 import {
   getPathIgnorePattern,


### PR DESCRIPTION
Since its a module we don't need `use strict`