### PR TITLE
ci: get smoketest workflow passing again

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,7 @@ jobs:
           yarn install
           yarn build
           yarn link
+          ln -s ../ node_modules/eslint-plugin-jest
       - uses: AriPerkkio/eslint-remote-tester-run-action@v4
         with:
           issue-title: 'Results of weekly scheduled smoke test'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'yarn'
       - run: |
           yarn install
           yarn build

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - run: |
           npm install --legacy-peer-deps
           npm run build

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -27,10 +27,9 @@ jobs:
         with:
           node-version: 20
       - run: |
-          npm install --legacy-peer-deps
-          npm run build
-          npm link
-          npm link eslint-plugin-jest
+          yarn install
+          yarn build
+          yarn link
       - uses: AriPerkkio/eslint-remote-tester-run-action@v4
         with:
           issue-title: 'Results of weekly scheduled smoke test'

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * SUN'
   workflow_dispatch:
+  push:
+    branches:
+      - ci/dont-use-npm
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * SUN'
   workflow_dispatch:
-  push:
-    branches:
-      - ci/dont-use-npm
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -29,7 +29,6 @@ jobs:
       - run: |
           yarn install
           yarn build
-          yarn link
           ln -s ../ node_modules/eslint-plugin-jest
       - uses: AriPerkkio/eslint-remote-tester-run-action@v4
         with:

--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -5,7 +5,7 @@ import {
 } from 'eslint-remote-tester-repositories';
 
 const config: Config = {
-  repositories: getRepositories({ randomize: true }).slice(0, 1),
+  repositories: getRepositories({ randomize: true }),
   pathIgnorePattern: getPathIgnorePattern(),
   extensions: ['js', 'jsx', 'ts', 'tsx'],
   concurrentTasks: 3,

--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -5,7 +5,7 @@ import {
 } from 'eslint-remote-tester-repositories';
 
 const config: Config = {
-  repositories: getRepositories({ randomize: true }),
+  repositories: getRepositories({ randomize: true }).slice(0, 1),
   pathIgnorePattern: getPathIgnorePattern(),
   extensions: ['js', 'jsx', 'ts', 'tsx'],
   concurrentTasks: 3,

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-n": "^17.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "eslint-remote-tester": "^3.0.0",
-    "eslint-remote-tester-repositories": "~2.0.0",
+    "eslint-remote-tester-repositories": "^1.0.0",
     "husky": "^9.0.1",
     "is-ci": "^4.0.0",
     "jest": "^30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5295,7 +5295,7 @@ __metadata:
     eslint-plugin-n: "npm:^17.0.0"
     eslint-plugin-prettier: "npm:^5.0.0"
     eslint-remote-tester: "npm:^3.0.0"
-    eslint-remote-tester-repositories: "npm:~2.0.0"
+    eslint-remote-tester-repositories: "npm:^1.0.0"
     husky: "npm:^9.0.1"
     is-ci: "npm:^4.0.0"
     jest: "npm:^30.0.0"
@@ -5361,10 +5361,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-remote-tester-repositories@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "eslint-remote-tester-repositories@npm:2.0.1"
-  checksum: 10c0/0efae02033c86258057550c4032bcb5bc41f37678e742630c003a73138ac68cad894b70e0664c39cee3d5f904c870eec4d32a024f2f39cb041884fc39ceab906
+"eslint-remote-tester-repositories@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "eslint-remote-tester-repositories@npm:1.0.1"
+  checksum: 10c0/ac3c097f83b0e1bd19b7863c986522a290673c2918c23507cebe77a8d45706a75e6f1ec622d203b610c5176834f485e2b3b96e204e1fc61ba2f5665ec113ce88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently `npm` errors as we've technically got peer dependency violations due to [`jest-runner-eslint` not officially supporting Jest v30](https://github.com/jest-community/jest-runner-eslint/pull/291) (or ESLint v9 for that matter), so I've finally switched us to using Yarn to setup this job.

This has also revealed that we might not yet be able to use v2 of the repositories package so I've downgraded that for now but will revisit once the job is working again