### PR TITLE
chore(deps): update to eslint-plugin-eslint-plugin v7

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@
 const pluginEslintCommentsConfigs = require('@eslint-community/eslint-plugin-eslint-comments/configs');
 const pluginTypeScriptESLint = require('@typescript-eslint/eslint-plugin');
 const parserTypeScriptESLint = require('@typescript-eslint/parser');
-const pluginESLintPlugin = require('eslint-plugin-eslint-plugin');
+const { default: pluginESLintPlugin } = require('eslint-plugin-eslint-plugin');
 const pluginImport = require('eslint-plugin-import');
 const pluginN = require('eslint-plugin-n');
 const pluginPrettier = require('eslint-plugin-prettier');
@@ -30,7 +30,7 @@ const config = [
       reportUnusedDisableDirectives: 'error',
     },
     rules: {
-      ...pluginESLintPlugin.configs['flat/recommended'].rules,
+      ...pluginESLintPlugin.configs.recommended.rules,
       ...pluginEslintCommentsConfigs.recommended.rules,
       ...pluginPrettierRecommended.rules,
     },
@@ -50,10 +50,13 @@ const config = [
       '@typescript-eslint/no-import-type-side-effects': 'error',
       '@typescript-eslint/no-unused-vars': 'error',
       '@eslint-community/eslint-comments/no-unused-disable': 'error',
+      'eslint-plugin/no-meta-schema-default': 'off',
+      'eslint-plugin/require-meta-default-options': 'off',
       'eslint-plugin/require-meta-docs-description': [
         'error',
         { pattern: '^(Enforce|Require|Disallow|Suggest|Prefer)' },
       ],
+      'eslint-plugin/require-meta-schema-description': 'off',
       'eslint-plugin/test-case-property-ordering': 'error',
       'no-else-return': 'error',
       'no-negated-condition': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -50,6 +50,7 @@ const config = [
       '@typescript-eslint/no-import-type-side-effects': 'error',
       '@typescript-eslint/no-unused-vars': 'error',
       '@eslint-community/eslint-comments/no-unused-disable': 'error',
+      // todo: enable once we drop support for ESLint <9.15
       'eslint-plugin/no-meta-schema-default': 'off',
       'eslint-plugin/require-meta-default-options': 'off',
       'eslint-plugin/require-meta-docs-description': [

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-doc-generator": "^2.0.0",
-    "eslint-plugin-eslint-plugin": "^6.0.0",
+    "eslint-plugin-eslint-plugin": "^7.0.0",
     "eslint-plugin-import": "^2.25.1",
     "eslint-plugin-n": "^17.0.0",
     "eslint-plugin-prettier": "^5.0.0",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,28 +1,3 @@
-declare module 'eslint-plugin-eslint-plugin' {
-  import type * as ESLint from 'eslint';
-
-  const plugin: ESLint.ESLint.Plugin & {
-    configs: {
-      all: ESLint.Linter.LegacyConfig;
-      'all-type-checked': ESLint.Linter.LegacyConfig;
-      recommended: ESLint.Linter.LegacyConfig;
-      rules: ESLint.Linter.LegacyConfig;
-      tests: ESLint.Linter.LegacyConfig;
-      'rules-recommended': ESLint.Linter.LegacyConfig;
-      'tests-recommended': ESLint.Linter.LegacyConfig;
-
-      'flat/all': ESLint.Linter.FlatConfig;
-      'flat/all-type-checked': ESLint.Linter.FlatConfig;
-      'flat/recommended': ESLint.Linter.FlatConfig;
-      'flat/rules': ESLint.Linter.FlatConfig;
-      'flat/tests': ESLint.Linter.FlatConfig;
-      'flat/rules-recommended': ESLint.Linter.FlatConfig;
-      'flat/tests-recommended': ESLint.Linter.FlatConfig;
-    };
-  };
-  export = plugin;
-}
-
 // todo: see https://github.com/eslint-community/eslint-plugin-eslint-comments/pull/246
 declare module '@eslint-community/eslint-plugin-eslint-comments/configs' {
   import type * as ESLint from 'eslint';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5242,15 +5242,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-eslint-plugin@npm:^6.0.0":
-  version: 6.5.0
-  resolution: "eslint-plugin-eslint-plugin@npm:6.5.0"
+"eslint-plugin-eslint-plugin@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "eslint-plugin-eslint-plugin@npm:7.0.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
     estraverse: "npm:^5.3.0"
   peerDependencies:
-    eslint: ">=8.23.0"
-  checksum: 10c0/00821d99d842ce5dd19731f2806da344074c689c5e2d2977afd1dac94dac98f53a9a743a48515017beb91390fded003eaee7a9309673b424f2dba9695091a3ee
+    eslint: ">=9.0.0"
+  checksum: 10c0/018582af73035321705626f31d56df93d79ac9fe1ed952ad7be2429f86b32ed090997434d95fdbfa0d3b73c91655050a3017efaf5fdaf06cffb4bf2915c986c3
   languageName: node
   linkType: hard
 
@@ -5311,7 +5311,7 @@ __metadata:
     eslint: "npm:^8.57.0"
     eslint-config-prettier: "npm:^10.0.0"
     eslint-doc-generator: "npm:^2.0.0"
-    eslint-plugin-eslint-plugin: "npm:^6.0.0"
+    eslint-plugin-eslint-plugin: "npm:^7.0.0"
     eslint-plugin-import: "npm:^2.25.1"
     eslint-plugin-n: "npm:^17.0.0"
     eslint-plugin-prettier: "npm:^5.0.0"


### PR DESCRIPTION
New rules disabled for now. Can follow-up individually to enable those.

- https://github.com/eslint-community/eslint-plugin-eslint-plugin/releases/tag/v7.0.0

The plugin now has TypeScript types included.