### PR TITLE
ci: have renovate group GHA workflow updates into a single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,11 @@
     "automerge": true
   },
   "rangeStrategy": "replace",
-  "postUpdateOptions": ["yarnDedupeHighest"]
+  "postUpdateOptions": ["yarnDedupeHighest"],
+  "packageRules": [
+    {
+      "matchFileNames": [".github/**"],
+      "groupName": "workflows"
+    }
+  ]
 }


### PR DESCRIPTION
This should be nicer than having a dedicated PR-per-workflow