### PR TITLE
chore: refresh lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "jest": "^30.0.0",
     "jest-runner-eslint": "^2.0.0",
     "lint-staged": "^16.0.0",
-    "markdown-link-check": "~3.12.0",
+    "markdown-link-check": "^3.13.7",
     "pinst": "^3.0.0",
     "prettier": "^3.0.0",
     "rimraf": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,6 +2534,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oozcitak/dom@npm:1.15.10":
+  version: 1.15.10
+  resolution: "@oozcitak/dom@npm:1.15.10"
+  dependencies:
+    "@oozcitak/infra": "npm:1.0.8"
+    "@oozcitak/url": "npm:1.0.4"
+    "@oozcitak/util": "npm:8.3.8"
+  checksum: 10c0/128162dd35fd21976e7589a4b50e980d8fb72e1f90e5675a3baca70b23cfdd87c0df57bff1ec708e7927671247a7233f240a27a4546bb904e069be1b4d4d7a05
+  languageName: node
+  linkType: hard
+
+"@oozcitak/infra@npm:1.0.8":
+  version: 1.0.8
+  resolution: "@oozcitak/infra@npm:1.0.8"
+  dependencies:
+    "@oozcitak/util": "npm:8.3.8"
+  checksum: 10c0/5fa44f02abbad453f5b26b38e2934978c177ef3a1baf8bf53919991135268f55bc89e23f8f3edebf0973c6a7d72d98fededb666c04a8b22ee4ca3048d0d42d25
+  languageName: node
+  linkType: hard
+
+"@oozcitak/url@npm:1.0.4":
+  version: 1.0.4
+  resolution: "@oozcitak/url@npm:1.0.4"
+  dependencies:
+    "@oozcitak/infra": "npm:1.0.8"
+    "@oozcitak/util": "npm:8.3.8"
+  checksum: 10c0/49824e30219b1e3bd0133c7302e79ead18dbfff91bc1ebb2f05b3c2cd670ed07b36af0f933faba2bc3221f65ef068fb7fca7d6c3cb8053fbca45f8cdf5670147
+  languageName: node
+  linkType: hard
+
+"@oozcitak/util@npm:8.3.8":
+  version: 8.3.8
+  resolution: "@oozcitak/util@npm:8.3.8"
+  checksum: 10c0/1c492abcba79f5dd9bd7709331a614114706e6936a899cac6ac90b63bbe8e98da288e664c13c6acb2a38e3c5ffd47b93f824075ba81384d6192cc364bf126775
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -3706,7 +3743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"async@npm:^3.2.5":
+"async@npm:^3.2.6":
   version: 3.2.6
   resolution: "async@npm:3.2.6"
   checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
@@ -4407,13 +4444,6 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
-  languageName: node
-  linkType: hard
-
-"commander@npm:^12.1.0":
-  version: 12.1.0
-  resolution: "commander@npm:12.1.0"
-  checksum: 10c0/6e1996680c083b3b897bfc1cfe1c58dfbcd9842fd43e1aaf8a795fbc237f65efcc860a3ef457b318e73f29a4f4a28f6403c3d653d021d960e4632dd45bde54a9
   languageName: node
   linkType: hard
 
@@ -5449,7 +5479,7 @@ __metadata:
     jest: "npm:^30.0.0"
     jest-runner-eslint: "npm:^2.0.0"
     lint-staged: "npm:^16.0.0"
-    markdown-link-check: "npm:~3.12.0"
+    markdown-link-check: "npm:^3.13.7"
     pinst: "npm:^3.0.0"
     prettier: "npm:^3.0.0"
     rimraf: "npm:^6.0.0"
@@ -7782,7 +7812,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
+"js-yaml@npm:3.14.1, js-yaml@npm:^3.13.1":
   version: 3.14.1
   resolution: "js-yaml@npm:3.14.1"
   dependencies:
@@ -8096,7 +8126,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"link-check@npm:^5.3.0":
+"link-check@npm:^5.5.0":
   version: 5.5.0
   resolution: "link-check@npm:5.5.0"
   dependencies:
@@ -8294,7 +8324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.20, lodash@npm:^4.17.21, lodash@npm:^4.17.4":
+"lodash@npm:^4.17.20, lodash@npm:^4.17.4":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
@@ -8428,22 +8458,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-link-check@npm:~3.12.0":
-  version: 3.12.2
-  resolution: "markdown-link-check@npm:3.12.2"
+"markdown-link-check@npm:^3.13.7":
+  version: 3.14.1
+  resolution: "markdown-link-check@npm:3.14.1"
   dependencies:
-    async: "npm:^3.2.5"
+    async: "npm:^3.2.6"
     chalk: "npm:^5.3.0"
-    commander: "npm:^12.1.0"
-    link-check: "npm:^5.3.0"
-    lodash: "npm:^4.17.21"
+    commander: "npm:^14.0.0"
+    link-check: "npm:^5.5.0"
     markdown-link-extractor: "npm:^4.0.2"
     needle: "npm:^3.3.1"
     progress: "npm:^2.0.3"
     proxy-agent: "npm:^6.4.0"
+    xmlbuilder2: "npm:^3.1.1"
   bin:
     markdown-link-check: markdown-link-check
-  checksum: 10c0/c1d4d2f69322d1ed98437db9f37807f982a3dc9aa1203841f40c71ac4e2a733b6c36311aa6f7f3a6fc34d7713e51c0f3704d55bf59fc607b30360ecfb5465d2d
+  checksum: 10c0/60f2846f2bb0b00e3d5ce7336a0367714ecd15244842c856d94ed3915ce570d4f95c819817996498d5cbf7c1a1e01609defb4c4ff33c2cca74111963bf17d507
   languageName: node
   linkType: hard
 
@@ -11907,6 +11937,18 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
+  languageName: node
+  linkType: hard
+
+"xmlbuilder2@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "xmlbuilder2@npm:3.1.1"
+  dependencies:
+    "@oozcitak/dom": "npm:1.15.10"
+    "@oozcitak/infra": "npm:1.0.8"
+    "@oozcitak/util": "npm:8.3.8"
+    js-yaml: "npm:3.14.1"
+  checksum: 10c0/a3e7dd5cbc052f6b53773a4a9d5efb26b0647aa8868bc1a597478d534e78184263b5b3e495e82613f21d0bf016a24145bb793f6e197e8911139dddba9cd831cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#1833 fails due to type errors from `eslint-plugin-eslint-plugin`, so let's lock it down. We have 2 dependabot errors which are annoying