### PR TITLE
chore: use lowest node version we support for smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -22,7 +22,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 'lts/*'
+          # This is set to the lowest Node.js version we support
+          node-version: 20
           cache: 'yarn'
       - run: |
           yarn install


### PR DESCRIPTION
#1834

Added the GH comment in https://github.com/jest-community/eslint-plugin-jest/pull/1790#discussion_r2179450116 as an actual code comment for future reference