### PR TITLE
ci: check package npm links via the registry

### DIFF
--- a/markdown_link_check_config.json
+++ b/markdown_link_check_config.json
@@ -6,5 +6,11 @@
         "Accept-Encoding": "br, gzip, deflate"
       }
     }
+  ],
+  "replacementPatterns": [
+      {
+      "pattern": "^https://www\\.npmjs\\.com/package",
+      "replacement": "https://registry.npmjs.org"
+    }
   ]
 }


### PR DESCRIPTION
It seems that NPM have decided to block non-browser requests for package pages, so instead we can check the package exists in the registry as it should then also have a valid package page