### PR TITLE
ci: don't update `uses-with` in actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,10 @@
     {
       "matchFileNames": [".github/**"],
       "groupName": "workflows"
+    },
+    {
+      "matchDepTypes": ["uses-with"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This in itself isn't bad, but for some reason its part of the broader "update GH actions" meaning we get a single PR like #1855 that bumps something we do want and something we don't