### PR TITLE
docs(prefer-called-with): remove references to `toBeCalled` matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Manually fixable by
 | [padding-around-describe-blocks](docs/rules/padding-around-describe-blocks.md)       | Enforce padding around `describe` blocks                                  |     |     | 🔧  |     |
 | [padding-around-expect-groups](docs/rules/padding-around-expect-groups.md)           | Enforce padding around `expect` groups                                    |     |     | 🔧  |     |
 | [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)               | Enforce padding around `test` and `it` blocks                             |     |     | 🔧  |     |
-| [prefer-called-with](docs/rules/prefer-called-with.md)                               | Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`              |     |     |     |     |
+| [prefer-called-with](docs/rules/prefer-called-with.md)                               | Suggest using `toHaveBeenCalledWith()`                                    |     |     |     |     |
 | [prefer-comparison-matcher](docs/rules/prefer-comparison-matcher.md)                 | Suggest using the built-in comparison matchers                            |     |     | 🔧  |     |
 | [prefer-each](docs/rules/prefer-each.md)                                             | Prefer using `.each` rather than manual loops                             |     |     |     |     |
 | [prefer-ending-with-an-expect](docs/rules/prefer-ending-with-an-expect.md)           | Prefer having the last statement in a test be an assertion                |     |     |     |     |

--- a/docs/rules/prefer-called-with.md
+++ b/docs/rules/prefer-called-with.md
@@ -1,10 +1,10 @@
-# Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()` (`prefer-called-with`)
+# Suggest using `toHaveBeenCalledWith()` (`prefer-called-with`)
 
 <!-- end auto-generated rule header -->
 
-The `toBeCalled()` matcher is used to assert that a mock function has been
+The `toHaveBeenCalled()` matcher is used to assert that a mock function has been
 called one or more times, without checking the arguments passed. The assertion
-is stronger when arguments are also validated using the `toBeCalledWith()`
+is stronger when arguments are also validated using the `toHaveBeenCalledWith()`
 matcher. When some arguments are difficult to check, using generic match like
 `expect.anything()` at least enforces number and position of arguments.
 
@@ -24,11 +24,14 @@ expect(someFunction).toHaveBeenCalled();
 The following patterns are not warnings:
 
 ```js
-expect(noArgsFunction).toBeCalledWith();
+expect(noArgsFunction).toHaveBeenCalledWith();
 
-expect(roughArgsFunction).toBeCalledWith(expect.anything(), expect.any(Date));
+expect(roughArgsFunction).toHaveBeenCalledWith(
+  expect.anything(),
+  expect.any(Date),
+);
 
-expect(anyArgsFunction).toBeCalledTimes(1);
+expect(anyArgsFunction).toHaveBeenCalledTimes(1);
 
-expect(uncalledFunction).not.toBeCalled();
+expect(uncalledFunction).not.toHaveBeenCalled();
 ```

--- a/src/rules/prefer-called-with.ts
+++ b/src/rules/prefer-called-with.ts
@@ -4,8 +4,7 @@ export default createRule({
   name: __filename,
   meta: {
     docs: {
-      description:
-        'Suggest using `toBeCalledWith()` or `toHaveBeenCalledWith()`',
+      description: 'Suggest using `toHaveBeenCalledWith()`',
     },
     messages: {
       preferCalledWith: 'Prefer {{ matcherName }}With(/* expected args */)',


### PR DESCRIPTION
This matcher was removed in v30, and the canonical matcher has been present for many versions (though I don't think technically all of them?), so we should mention the removed alias as little as possible