### PR TITLE
fix(prefer-to-have-been-called-times): actually check that current matcher is `toHaveLength`

### DIFF
--- a/src/rules/__tests__/prefer-to-have-been-called-times.test.ts
+++ b/src/rules/__tests__/prefer-to-have-been-called-times.test.ts
@@ -18,6 +18,9 @@ ruleTester.run('prefer-to-have-been-called-times', rule, {
     'expect(fn).toHaveBeenCalledTimes(0);',
     'expect(fn);',
     'expect(method.mock.calls[0][0]).toStrictEqual(value);',
+    'expect(fn.mock.length).toEqual(1);',
+    'expect(fn.mock.calls).toEqual([]);',
+    'expect(fn.mock.calls).toContain(1, 2, 3);',
   ],
 
   invalid: [

--- a/src/rules/__tests__/prefer-to-have-been-called.test.ts
+++ b/src/rules/__tests__/prefer-to-have-been-called.test.ts
@@ -18,6 +18,9 @@ ruleTester.run('prefer-to-have-been-called', rule, {
     'expect(method).not.toHaveBeenCalledTimes(...x)',
     'expect(a);',
     'expect(method).not.resolves.toHaveBeenCalledTimes(0);',
+    'expect(method).toBe([])',
+    'expect(fn.mock.calls).toEqual([])',
+    'expect(fn.mock.calls).toContain(1, 2, 3)',
   ],
 
   invalid: [

--- a/src/rules/prefer-to-have-been-called-times.ts
+++ b/src/rules/prefer-to-have-been-called-times.ts
@@ -30,6 +30,12 @@ export default createRule({
           return;
         }
 
+        const { matcher } = jestFnCall;
+
+        if (!isSupportedAccessor(matcher, 'toHaveLength')) {
+          return;
+        }
+
         const [argument] = expect.arguments;
 
         // check if the last property in the chain is `calls`
@@ -49,8 +55,6 @@ export default createRule({
         ) {
           return;
         }
-
-        const { matcher } = jestFnCall;
 
         context.report({
           messageId: 'preferMatcher',


### PR DESCRIPTION
Resolves #1877