### PR TITLE
fix(no-unnecessary-assertion): ignore `resolve` and `reject` chains (for now)

### DIFF
--- a/src/rules/__tests__/no-unnecessary-assertion.test.ts
+++ b/src/rules/__tests__/no-unnecessary-assertion.test.ts
@@ -146,6 +146,49 @@ const generateValidCases = (
     `,
     `expect(${thing}).not.${matcher}()`,
     `expect("hello" as ${thing}).${matcher}();`,
+    dedent`
+      declare function mx(): Promise<string | ${thing}>;
+
+      it('is async', async () => {
+        await expect(mx()).resolves.${matcher}();
+      });
+    `,
+    dedent`
+      declare function mx(): Promise<string | ${thing}>;
+
+      it('is async', async () => {
+        await expect(mx()).rejects.${matcher}();
+      });
+    `,
+    dedent`
+      declare function mx(): Promise<string | ${thing}>;
+
+      it('is async', async () => {
+        await expect(mx()).rejects.not.${matcher}();
+      });
+    `,
+    dedent`
+      declare function mx(): Promise<string | ${thing}>;
+
+      it('is async', async () => {
+        expect(await mx()).not.${matcher}();
+      });
+    `,
+    // todo: ideally we should be able to catch these
+    dedent`
+      declare function mx(): Promise<string>;
+
+      it('is async', async () => {
+        await expect(mx()).resolves.${matcher}();
+      });
+    `,
+    dedent`
+      declare function mx(): Promise<string>;
+
+      it('is async', async () => {
+        await expect(mx()).rejects.not.${matcher}();
+      });
+    `,
   ];
 };
 
@@ -297,6 +340,41 @@ const generateInvalidCases = (
         },
       ],
     },
+
+    {
+      code: dedent`
+        declare function mx(): Promise<string>;
+
+        it('is async', async () => {
+          expect(await mx()).${matcher}();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unnecessaryAssertion',
+          data: { thing },
+          line: 4,
+        },
+      ],
+    },
+
+    // todo: ideally we should support promises
+    // {
+    //   code: dedent`
+    //     declare function mx(): Promise<string>;
+    //
+    //     it('is async', async () => {
+    //       await expect(mx()).resolves.${matcher}();
+    //     });
+    //   `,
+    //   errors: [
+    //     {
+    //       messageId: 'unnecessaryAssertion',
+    //       data: { thing },
+    //       line: 3,
+    //     },
+    //   ],
+    // },
 
     // todo: ideally support these
     // {

--- a/src/rules/no-unnecessary-assertion.ts
+++ b/src/rules/no-unnecessary-assertion.ts
@@ -72,6 +72,11 @@ export default createRule<Options, MessageIds>({
           return;
         }
 
+        // todo: we should support resolving promise types
+        if (jestFnCall.modifiers.some(nod => getAccessorValue(nod) !== 'not')) {
+          return;
+        }
+
         const [argument] = jestFnCall.head.node.parent.arguments;
 
         const isNullable = canBe(


### PR DESCRIPTION
Ideally we should actually resolve the underlying resolution type of the Promise, but for now we'll just ignore assertions with those modifiers since false negatives is better than false positives