### PR TITLE
test: deduplicate typescript-related code

### DIFF
--- a/src/rules/__tests__/no-error-equal.test.ts
+++ b/src/rules/__tests__/no-error-equal.test.ts
@@ -1,12 +1,11 @@
 import path from 'path';
-import type { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import type { MessageIds, Options } from '../no-error-equal';
-import { FlatCompatRuleTester as RuleTester } from './test-utils';
-
-function getFixturesRootDir(): string {
-  return path.join(__dirname, 'fixtures');
-}
+import {
+  FlatCompatRuleTester as RuleTester,
+  createRuleRequirerTester,
+  getFixturesRootDir,
+} from './test-utils';
 
 const rootPath = getFixturesRootDir();
 
@@ -20,35 +19,12 @@ const ruleTester = new RuleTester({
   },
 });
 
-const fixtureFilename = path.join(rootPath, 'file.ts');
-
-const requireRule = (throwWhenRequiring: boolean) => {
-  jest.resetModules();
-
-  TSESLintPluginRef.throwWhenRequiring = throwWhenRequiring;
-
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require('../no-error-equal').default;
-};
-
-const TSESLintPluginRef: { throwWhenRequiring: boolean } = {
-  throwWhenRequiring: false,
-};
-
-jest.mock('typescript', () => {
-  if (TSESLintPluginRef.throwWhenRequiring) {
-    throw new (class extends Error {
-      public code;
-
-      constructor(message?: string) {
-        super(message);
-        this.code = 'MODULE_NOT_FOUND';
-      }
-    })();
-  }
-
-  return jest.requireActual('typescript');
-});
+const { TSESLintPluginRef, requireRule, withFixtureFilename } =
+  createRuleRequirerTester<Options, MessageIds>(
+    '../no-error-equal',
+    'typescript',
+    path.join(rootPath, 'file.ts'),
+  );
 
 describe('error handling', () => {
   afterAll(() => {
@@ -59,24 +35,6 @@ describe('error handling', () => {
     expect(() => requireRule(true)).not.toThrow();
   });
 });
-
-const withFixtureFilename = <
-  T extends Array<
-    | (TSESLint.ValidTestCase<Options> | string)
-    | TSESLint.InvalidTestCase<MessageIds, Options>
-  >,
->(
-  cases: T,
-): T extends Array<TSESLint.InvalidTestCase<MessageIds, Options>>
-  ? Array<TSESLint.InvalidTestCase<MessageIds, Options>>
-  : Array<TSESLint.ValidTestCase<Options>> => {
-  // @ts-expect-error this is fine, and will go away later once we upgrade
-  return cases.map(code => {
-    const test = typeof code === 'string' ? { code } : code;
-
-    return { filename: fixtureFilename, ...test };
-  });
-};
 
 ruleTester.run('no-error-equal', requireRule(false), {
   valid: withFixtureFilename([

--- a/src/rules/__tests__/no-unnecessary-assertion.test.ts
+++ b/src/rules/__tests__/no-unnecessary-assertion.test.ts
@@ -2,11 +2,11 @@ import path from 'path';
 import type { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import type { MessageIds, Options } from '../no-unnecessary-assertion';
-import { FlatCompatRuleTester as RuleTester } from './test-utils';
-
-function getFixturesRootDir(): string {
-  return path.join(__dirname, 'fixtures');
-}
+import {
+  FlatCompatRuleTester as RuleTester,
+  createRuleRequirerTester,
+  getFixturesRootDir,
+} from './test-utils';
 
 const rootPath = getFixturesRootDir();
 
@@ -20,35 +20,12 @@ const ruleTester = new RuleTester({
   },
 });
 
-const fixtureFilename = path.join(rootPath, 'file.ts');
-
-const requireRule = (throwWhenRequiring: boolean) => {
-  jest.resetModules();
-
-  TSESLintPluginRef.throwWhenRequiring = throwWhenRequiring;
-
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  return require('../no-unnecessary-assertion').default;
-};
-
-const TSESLintPluginRef: { throwWhenRequiring: boolean } = {
-  throwWhenRequiring: false,
-};
-
-jest.mock('typescript', () => {
-  if (TSESLintPluginRef.throwWhenRequiring) {
-    throw new (class extends Error {
-      public code;
-
-      constructor(message?: string) {
-        super(message);
-        this.code = 'MODULE_NOT_FOUND';
-      }
-    })();
-  }
-
-  return jest.requireActual('typescript');
-});
+const { TSESLintPluginRef, requireRule, withFixtureFilename } =
+  createRuleRequirerTester<Options, MessageIds>(
+    '../no-unnecessary-assertion',
+    'typescript',
+    path.join(rootPath, 'file.ts'),
+  );
 
 describe('error handling', () => {
   afterAll(() => {
@@ -59,24 +36,6 @@ describe('error handling', () => {
     expect(() => requireRule(true)).not.toThrow();
   });
 });
-
-const withFixtureFilename = <
-  T extends Array<
-    | (TSESLint.ValidTestCase<Options> | string)
-    | TSESLint.InvalidTestCase<MessageIds, Options>
-  >,
->(
-  cases: T,
-): T extends Array<TSESLint.InvalidTestCase<MessageIds, Options>>
-  ? Array<TSESLint.InvalidTestCase<MessageIds, Options>>
-  : Array<TSESLint.ValidTestCase<Options>> => {
-  // @ts-expect-error this is fine, and will go away later once we upgrade
-  return cases.map(code => {
-    const test = typeof code === 'string' ? { code } : code;
-
-    return { filename: fixtureFilename, ...test };
-  });
-};
 
 ruleTester.run('no-unnecessary-assertion (general)', requireRule(false), {
   valid: withFixtureFilename([


### PR DESCRIPTION
It's a bit rougher than I'd usually do, but in this case I think its worth it and I'm hoping I can clean things up after we've gotten through the ESLint v10 major as we'll no longer need to handle legacy config vs flat config