### PR TITLE
refactor: deduplicate TypeScript-based code

### DIFF
--- a/src/rules/no-error-equal.ts
+++ b/src/rules/no-error-equal.ts
@@ -1,105 +1,10 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
-import type ts from 'typescript';
-import { createRule, getAccessorValue, parseJestFnCall } from './utils';
-
-let SymbolFlags: typeof ts.SymbolFlags;
-let TypeFlags: typeof ts.TypeFlags;
-
-function isSymbolFromDefaultLibrary(
-  program: ts.Program,
-  symbol: ts.Symbol,
-): boolean {
-  /* istanbul ignore next */
-  const declarations = symbol.getDeclarations() ?? [];
-
-  for (const declaration of declarations) {
-    const sourceFile = declaration.getSourceFile();
-
-    /* istanbul ignore else */
-    if (program.isSourceFileDefaultLibrary(sourceFile)) {
-      return true;
-    }
-  }
-
-  /* istanbul ignore next */
-  return false;
-}
-
-function isBuiltinSymbolLike(
-  program: ts.Program,
-  type: ts.Type,
-  symbolName: string,
-): boolean {
-  return isBuiltinSymbolLikeRecurser(program, type, subType => {
-    const symbol = subType.getSymbol();
-
-    if (!symbol) {
-      return false;
-    }
-
-    const actualSymbolName = symbol.getName();
-
-    if (
-      actualSymbolName === symbolName &&
-      isSymbolFromDefaultLibrary(program, symbol)
-    ) {
-      return true;
-    }
-
-    return null;
-  });
-}
-
-function isBuiltinSymbolLikeRecurser(
-  program: ts.Program,
-  type: ts.Type,
-  predicate: (subType: ts.Type) => boolean | null,
-): boolean {
-  if (type.isIntersection()) {
-    return type.types.some(t =>
-      isBuiltinSymbolLikeRecurser(program, t, predicate),
-    );
-  }
-  if (type.isUnion()) {
-    return type.types.every(t =>
-      isBuiltinSymbolLikeRecurser(program, t, predicate),
-    );
-  }
-  if (isTypeParameter(type)) {
-    const t = type.getConstraint();
-
-    if (t) {
-      return isBuiltinSymbolLikeRecurser(program, t, predicate);
-    }
-
-    return false;
-  }
-
-  const predicateResult = predicate(type);
-
-  if (typeof predicateResult === 'boolean') {
-    return predicateResult;
-  }
-
-  const symbol = type.getSymbol();
-
-  /* istanbul ignore next */
-  if (symbol && symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
-    const checker = program.getTypeChecker();
-
-    for (const baseType of checker.getBaseTypes(type as ts.InterfaceType)) {
-      if (isBuiltinSymbolLikeRecurser(program, baseType, predicate)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-function isTypeParameter(type: ts.Type): boolean {
-  return (type.flags & TypeFlags.TypeParameter) !== 0;
-}
+import {
+  createRule,
+  getAccessorValue,
+  isBuiltinSymbolLike,
+  parseJestFnCall,
+} from './utils';
 
 export type MessageIds = 'equalError';
 
@@ -121,9 +26,6 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     const services = ESLintUtils.getParserServices(context);
-
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    ({ TypeFlags, SymbolFlags } = require('typescript'));
 
     return {
       CallExpression(node) {

--- a/src/rules/utils/index.ts
+++ b/src/rules/utils/index.ts
@@ -3,3 +3,4 @@ export * from './detectJestVersion';
 export * from './followTypeAssertionChain';
 export * from './misc';
 export * from './parseJestFnCall';
+export * from './ts';

--- a/src/rules/utils/ts.ts
+++ b/src/rules/utils/ts.ts
@@ -1,0 +1,102 @@
+import type ts from 'typescript';
+
+let SymbolFlags: typeof ts.SymbolFlags;
+let TypeFlags: typeof ts.TypeFlags;
+
+function isSymbolFromDefaultLibrary(
+  program: ts.Program,
+  symbol: ts.Symbol,
+): boolean {
+  /* istanbul ignore next */
+  const declarations = symbol.getDeclarations() ?? [];
+
+  for (const declaration of declarations) {
+    const sourceFile = declaration.getSourceFile();
+
+    /* istanbul ignore else */
+    if (program.isSourceFileDefaultLibrary(sourceFile)) {
+      return true;
+    }
+  }
+
+  /* istanbul ignore next */
+  return false;
+}
+
+export function isBuiltinSymbolLike(
+  program: ts.Program,
+  type: ts.Type,
+  symbolName: string,
+): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  ({ TypeFlags, SymbolFlags } = require('typescript'));
+
+  return isBuiltinSymbolLikeRecurser(program, type, subType => {
+    const symbol = subType.getSymbol();
+
+    if (!symbol) {
+      return false;
+    }
+
+    const actualSymbolName = symbol.getName();
+
+    if (
+      actualSymbolName === symbolName &&
+      isSymbolFromDefaultLibrary(program, symbol)
+    ) {
+      return true;
+    }
+
+    return null;
+  });
+}
+
+function isBuiltinSymbolLikeRecurser(
+  program: ts.Program,
+  type: ts.Type,
+  predicate: (subType: ts.Type) => boolean | null,
+): boolean {
+  if (type.isIntersection()) {
+    return type.types.some(t =>
+      isBuiltinSymbolLikeRecurser(program, t, predicate),
+    );
+  }
+  if (type.isUnion()) {
+    return type.types.every(t =>
+      isBuiltinSymbolLikeRecurser(program, t, predicate),
+    );
+  }
+  if (isTypeParameter(type)) {
+    const t = type.getConstraint();
+
+    if (t) {
+      return isBuiltinSymbolLikeRecurser(program, t, predicate);
+    }
+
+    return false;
+  }
+
+  const predicateResult = predicate(type);
+
+  if (typeof predicateResult === 'boolean') {
+    return predicateResult;
+  }
+
+  const symbol = type.getSymbol();
+
+  if (symbol && symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
+    const checker = program.getTypeChecker();
+
+    for (const baseType of checker.getBaseTypes(type as ts.InterfaceType)) {
+      if (isBuiltinSymbolLikeRecurser(program, baseType, predicate)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function isTypeParameter(type: ts.Type): boolean {
+  return (type.flags & TypeFlags.TypeParameter) !== 0;
+}

--- a/src/rules/valid-expect-with-promise.ts
+++ b/src/rules/valid-expect-with-promise.ts
@@ -1,105 +1,10 @@
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
-import type ts from 'typescript';
-import { createRule, getAccessorValue, parseJestFnCall } from './utils';
-
-let SymbolFlags: typeof ts.SymbolFlags;
-let TypeFlags: typeof ts.TypeFlags;
-
-function isSymbolFromDefaultLibrary(
-  program: ts.Program,
-  symbol: ts.Symbol,
-): boolean {
-  /* istanbul ignore next */
-  const declarations = symbol.getDeclarations() ?? [];
-
-  for (const declaration of declarations) {
-    const sourceFile = declaration.getSourceFile();
-
-    /* istanbul ignore else */
-    if (program.isSourceFileDefaultLibrary(sourceFile)) {
-      return true;
-    }
-  }
-
-  /* istanbul ignore next */
-  return false;
-}
-
-function isBuiltinSymbolLike(
-  program: ts.Program,
-  type: ts.Type,
-  symbolName: string,
-): boolean {
-  return isBuiltinSymbolLikeRecurser(program, type, subType => {
-    const symbol = subType.getSymbol();
-
-    if (!symbol) {
-      return false;
-    }
-
-    const actualSymbolName = symbol.getName();
-
-    if (
-      actualSymbolName === symbolName &&
-      isSymbolFromDefaultLibrary(program, symbol)
-    ) {
-      return true;
-    }
-
-    return null;
-  });
-}
-
-function isBuiltinSymbolLikeRecurser(
-  program: ts.Program,
-  type: ts.Type,
-  predicate: (subType: ts.Type) => boolean | null,
-): boolean {
-  if (type.isIntersection()) {
-    return type.types.some(t =>
-      isBuiltinSymbolLikeRecurser(program, t, predicate),
-    );
-  }
-  if (type.isUnion()) {
-    return type.types.every(t =>
-      isBuiltinSymbolLikeRecurser(program, t, predicate),
-    );
-  }
-  if (isTypeParameter(type)) {
-    const t = type.getConstraint();
-
-    if (t) {
-      return isBuiltinSymbolLikeRecurser(program, t, predicate);
-    }
-
-    return false;
-  }
-
-  const predicateResult = predicate(type);
-
-  if (typeof predicateResult === 'boolean') {
-    return predicateResult;
-  }
-
-  const symbol = type.getSymbol();
-
-  /* istanbul ignore next */
-  if (symbol && symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
-    const checker = program.getTypeChecker();
-
-    for (const baseType of checker.getBaseTypes(type as ts.InterfaceType)) {
-      if (isBuiltinSymbolLikeRecurser(program, baseType, predicate)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-function isTypeParameter(type: ts.Type): boolean {
-  return (type.flags & TypeFlags.TypeParameter) !== 0;
-}
+import {
+  createRule,
+  getAccessorValue,
+  isBuiltinSymbolLike,
+  parseJestFnCall,
+} from './utils';
 
 export type MessageIds = 'poorlyExpectedPromise' | 'unneededRejectResolve';
 
@@ -125,9 +30,6 @@ export default createRule<Options, MessageIds>({
   defaultOptions: [],
   create(context) {
     const services = ESLintUtils.getParserServices(context);
-
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    ({ TypeFlags, SymbolFlags } = require('typescript'));
 
     return {
       CallExpression(node) {


### PR DESCRIPTION
Note that these actually came from `@typescript-eslint/type-utils` which ideally we'd have as an optional dependency, but for now I'm keeping things inlined to ensure we don't have that as a hard requirement by mistake (+ its cheap right now)