### PR TITLE
test(no-deprecated-functions): remove unneeded async function

### DIFF
--- a/src/rules/__tests__/no-deprecated-functions.test.ts
+++ b/src/rules/__tests__/no-deprecated-functions.test.ts
@@ -96,7 +96,7 @@ describe('the rule', () => {
   describe.each<JestVersion>([
     14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
   ])('when using jest version %i', jestVersion => {
-    beforeEach(async () => {
+    beforeEach(() => {
       detectJestVersionMock.mockReturnValue(jestVersion);
     });
 


### PR DESCRIPTION
This no longer needs to be `async`