### PR TITLE
refactor: remove unneeded optional chains and other conditions

### DIFF
--- a/src/rules/max-expects.ts
+++ b/src/rules/max-expects.ts
@@ -36,7 +36,7 @@ export default createRule({
 
     const maybeResetCount = (node: FunctionExpression) => {
       const isTestFn =
-        node.parent?.type !== AST_NODE_TYPES.CallExpression ||
+        node.parent.type !== AST_NODE_TYPES.CallExpression ||
         isTypeOfJestFnCall(node.parent, context, ['test']);
 
       if (isTestFn) {
@@ -58,7 +58,7 @@ export default createRule({
 
         if (
           jestFnCall?.type !== 'expect' ||
-          jestFnCall.head.node.parent?.type === AST_NODE_TYPES.MemberExpression
+          jestFnCall.head.node.parent.type === AST_NODE_TYPES.MemberExpression
         ) {
           return;
         }

--- a/src/rules/no-standalone-expect.ts
+++ b/src/rules/no-standalone-expect.ts
@@ -19,19 +19,12 @@ const getBlockType = (
 ): 'function' | 'describe' | null => {
   const func = statement.parent;
 
-  /* istanbul ignore if */
-  if (!func) {
-    throw new Error(
-      `Unexpected BlockStatement. No parent defined. - please file a github issue at https://github.com/jest-community/eslint-plugin-jest`,
-    );
-  }
-
   // functionDeclaration: function func() {}
   if (func.type === AST_NODE_TYPES.FunctionDeclaration) {
     return 'function';
   }
 
-  if (isFunction(func) && func.parent) {
+  if (isFunction(func)) {
     const expr = func.parent;
 
     // arrow function or function expr
@@ -94,7 +87,7 @@ export default createRule<
 
         if (jestFnCall?.type === 'expect') {
           if (
-            jestFnCall.head.node.parent?.type ===
+            jestFnCall.head.node.parent.type ===
               AST_NODE_TYPES.MemberExpression &&
             jestFnCall.members.length === 1 &&
             !['assertions', 'hasAssertions'].includes(
@@ -152,7 +145,7 @@ export default createRule<
       },
 
       ArrowFunctionExpression(node) {
-        if (node.parent?.type !== AST_NODE_TYPES.CallExpression) {
+        if (node.parent.type !== AST_NODE_TYPES.CallExpression) {
           callStack.push('arrow');
         }
       },

--- a/src/rules/no-unneeded-async-expect-function.ts
+++ b/src/rules/no-unneeded-async-expect-function.ts
@@ -27,7 +27,7 @@ export default createRule({
 
         const { parent } = jestFnCall.head.node;
 
-        if (parent?.type !== AST_NODE_TYPES.CallExpression) {
+        if (parent.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 
@@ -36,7 +36,7 @@ export default createRule({
         if (
           !awaitNode ||
           !isFunction(awaitNode) ||
-          !awaitNode?.async ||
+          !awaitNode.async ||
           awaitNode.body.type !== AST_NODE_TYPES.BlockStatement ||
           awaitNode.body.body.length !== 1
         ) {

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -77,7 +77,7 @@ export default createRule({
 
         const { parent: expect } = jestFnCall.head.node;
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) {
+        if (expect.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 
@@ -90,7 +90,7 @@ export default createRule({
         const matcherArg = getFirstMatcherArg(jestFnCall);
 
         if (
-          comparison?.type !== AST_NODE_TYPES.BinaryExpression ||
+          comparison.type !== AST_NODE_TYPES.BinaryExpression ||
           isComparingToString(comparison) ||
           !EqualityMatcher.hasOwnProperty(getAccessorValue(matcher)) ||
           !isBooleanLiteral(matcherArg)

--- a/src/rules/prefer-equality-matcher.ts
+++ b/src/rules/prefer-equality-matcher.ts
@@ -35,7 +35,7 @@ export default createRule({
 
         const { parent: expect } = jestFnCall.head.node;
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) {
+        if (expect.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 
@@ -48,7 +48,7 @@ export default createRule({
         const matcherArg = getFirstMatcherArg(jestFnCall);
 
         if (
-          comparison?.type !== AST_NODE_TYPES.BinaryExpression ||
+          comparison.type !== AST_NODE_TYPES.BinaryExpression ||
           (comparison.operator !== '===' && comparison.operator !== '!==') ||
           !EqualityMatcher.hasOwnProperty(getAccessorValue(matcher)) ||
           !isBooleanLiteral(matcherArg)

--- a/src/rules/prefer-expect-resolves.ts
+++ b/src/rules/prefer-expect-resolves.ts
@@ -26,13 +26,13 @@ export default createRule({
 
       const { parent } = jestFnCall.head.node;
 
-      if (parent?.type !== AST_NODE_TYPES.CallExpression) {
+      if (parent.type !== AST_NODE_TYPES.CallExpression) {
         return;
       }
 
       const [awaitNode] = parent.arguments;
 
-      if (awaitNode?.type === AST_NODE_TYPES.AwaitExpression) {
+      if (awaitNode.type === AST_NODE_TYPES.AwaitExpression) {
         context.report({
           node: awaitNode,
           messageId: 'expectResolves',

--- a/src/rules/prefer-importing-jest-globals.ts
+++ b/src/rules/prefer-importing-jest-globals.ts
@@ -86,7 +86,7 @@ export default createRule({
 
         const isModule =
           context.parserOptions.sourceType === 'module' ||
-          context.languageOptions?.sourceType === 'module';
+          context.languageOptions.sourceType === 'module';
 
         context.report({
           node: reportingNode,

--- a/src/rules/prefer-spy-on.ts
+++ b/src/rules/prefer-spy-on.ts
@@ -48,7 +48,7 @@ const getAutoFixMockImplementation = (
   context: TSESLint.RuleContext<'useJestSpyOn', unknown[]>,
 ): string => {
   const hasMockImplementationAlready =
-    jestFnCall.parent?.type === AST_NODE_TYPES.MemberExpression &&
+    jestFnCall.parent.type === AST_NODE_TYPES.MemberExpression &&
     jestFnCall.parent.property.type === AST_NODE_TYPES.Identifier &&
     jestFnCall.parent.property.name === 'mockImplementation';
 

--- a/src/rules/prefer-to-be.ts
+++ b/src/rules/prefer-to-be.ts
@@ -73,7 +73,7 @@ const reportPreferToBe = (
         replaceAccessorFixer(fixer, expectFnCall.matcher, `toBe${whatToBe}`),
       ];
 
-      if (expectFnCall.args?.length && whatToBe !== '') {
+      if (expectFnCall.args.length && whatToBe !== '') {
         fixes.push(removeExtraArgumentsFixer(fixer, context, func, 0));
       }
 

--- a/src/rules/prefer-to-contain.ts
+++ b/src/rules/prefer-to-contain.ts
@@ -59,7 +59,7 @@ export default createRule({
 
         const { parent: expect } = jestFnCall.head.node;
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) {
+        if (expect.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 

--- a/src/rules/prefer-to-have-been-called-times.ts
+++ b/src/rules/prefer-to-have-been-called-times.ts
@@ -26,7 +26,7 @@ export default createRule({
 
         const { parent: expect } = jestFnCall.head.node;
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) {
+        if (expect.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 
@@ -40,7 +40,7 @@ export default createRule({
 
         // check if the last property in the chain is `calls`
         if (
-          argument?.type !== AST_NODE_TYPES.MemberExpression ||
+          argument.type !== AST_NODE_TYPES.MemberExpression ||
           !isSupportedAccessor(argument.property, 'calls')
         ) {
           return;

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -32,7 +32,7 @@ export default createRule({
 
         const { parent: expect } = jestFnCall.head.node;
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) {
+        if (expect.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 
@@ -41,7 +41,7 @@ export default createRule({
 
         if (
           !EqualityMatcher.hasOwnProperty(getAccessorValue(matcher)) ||
-          argument?.type !== AST_NODE_TYPES.MemberExpression ||
+          argument.type !== AST_NODE_TYPES.MemberExpression ||
           !isSupportedAccessor(argument.property, 'length')
         ) {
           return;

--- a/src/rules/unbound-method.ts
+++ b/src/rules/unbound-method.ts
@@ -76,7 +76,7 @@ export default createRule<Options, MessageIds>({
     return {
       ...baseSelectors,
       MemberExpression(node: TSESTree.MemberExpression): void {
-        if (node.parent?.type === AST_NODE_TYPES.CallExpression) {
+        if (node.parent.type === AST_NODE_TYPES.CallExpression) {
           const jestFnCall = parseJestFnCall(
             findTopMostCallExpression(node.parent),
             context,

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -146,7 +146,7 @@ export const getTestCallExpressionsFromDeclaredVariables = (
       .map(({ identifier }) => identifier.parent)
       .filter(
         (node): node is TSESTree.CallExpression =>
-          node?.type === AST_NODE_TYPES.CallExpression &&
+          node.type === AST_NODE_TYPES.CallExpression &&
           isTypeOfJestFnCall(node, context, ['test']),
       ),
   );

--- a/src/rules/utils/parseJestFnCall.ts
+++ b/src/rules/utils/parseJestFnCall.ts
@@ -316,7 +316,7 @@ const parseJestFnCallWithReasonInner = (
     }
 
     if (result === 'matcher-not-found') {
-      if (node.parent?.type === AST_NODE_TYPES.MemberExpression) {
+      if (node.parent.type === AST_NODE_TYPES.MemberExpression) {
         return 'matcher-not-called';
       }
     }
@@ -328,7 +328,7 @@ const parseJestFnCallWithReasonInner = (
   if (
     chain
       .slice(0, chain.length - 1)
-      .some(nod => nod.parent?.type !== AST_NODE_TYPES.MemberExpression)
+      .some(nod => nod.parent.type !== AST_NODE_TYPES.MemberExpression)
   ) {
     return null;
   }
@@ -337,8 +337,8 @@ const parseJestFnCallWithReasonInner = (
   // parsing e.g. x().y.z(), we'll incorrectly find & parse "x()" even though
   // the full chain is not a valid jest function call chain
   if (
-    node.parent?.type === AST_NODE_TYPES.CallExpression ||
-    node.parent?.type === AST_NODE_TYPES.MemberExpression
+    node.parent.type === AST_NODE_TYPES.CallExpression ||
+    node.parent.type === AST_NODE_TYPES.MemberExpression
   ) {
     return null;
   }
@@ -364,10 +364,7 @@ const findModifiersAndMatcher = (
   for (const member of members) {
     // check if the member is being called, which means it is the matcher
     // (and also the end of the entire "expect" call chain)
-    if (
-      member.parent?.type === AST_NODE_TYPES.MemberExpression &&
-      member.parent.parent?.type === AST_NODE_TYPES.CallExpression
-    ) {
+    if (member.parent.parent.type === AST_NODE_TYPES.CallExpression) {
       return {
         matcher: member,
         args: member.parent.parent.arguments,
@@ -501,7 +498,7 @@ const describeVariableDefAsImport = (
     return null;
   }
 
-  if (def.name.parent?.type !== AST_NODE_TYPES.Property) {
+  if (def.name.parent.type !== AST_NODE_TYPES.Property) {
     return null;
   }
 

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -76,9 +76,7 @@ const isTestCaseCallWithCallbackArg = (
   const callbackArgIndex = Number(isJestEach);
 
   return (
-    callback &&
-    isFunction(callback) &&
-    callback.params.length === 1 + callbackArgIndex
+    isFunction(callback) && callback.params.length === 1 + callbackArgIndex
   );
 };
 
@@ -314,7 +312,7 @@ const isDirectlyWithinTestCaseCall = (
       parent = parent.parent;
 
       return (
-        parent?.type === AST_NODE_TYPES.CallExpression &&
+        parent.type === AST_NODE_TYPES.CallExpression &&
         isTypeOfJestFnCall(parent, context, ['test'])
       );
     }
@@ -421,11 +419,10 @@ export default createRule({
 
         const { parent } = findTopMostCallExpression(node);
 
-        // if we don't have a parent (which is technically impossible at runtime)
-        // or our parent is not directly within the test case, we stop checking
+        // if our parent is not directly within the test case, we stop checking
         // because we're most likely in the body of a function being defined
         // within the test, which we can't track
-        if (!parent || !isDirectlyWithinTestCaseCall(parent, context)) {
+        if (!isDirectlyWithinTestCaseCall(parent, context)) {
           return;
         }
 

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -28,7 +28,6 @@ import {
 const getPromiseCallExpressionNode = (node: TSESTree.Node) => {
   if (
     node.type === AST_NODE_TYPES.ArrayExpression &&
-    node.parent &&
     node.parent.type === AST_NODE_TYPES.CallExpression
   ) {
     node = node.parent;
@@ -37,8 +36,7 @@ const getPromiseCallExpressionNode = (node: TSESTree.Node) => {
   if (
     node.type === AST_NODE_TYPES.CallExpression &&
     node.callee.type === AST_NODE_TYPES.MemberExpression &&
-    isSupportedAccessor(node.callee.object, 'Promise') &&
-    node.parent
+    isSupportedAccessor(node.callee.object, 'Promise')
   ) {
     return node;
   }
@@ -90,8 +88,7 @@ const getParentIfThenified = (node: TSESTree.Node): TSESTree.Node => {
     isSupportedAccessor(grandParentNode.callee.property) &&
     ['then', 'catch'].includes(
       getAccessorValue(grandParentNode.callee.property),
-    ) &&
-    grandParentNode.parent
+    )
   ) {
     // Just in case `then`s are chained look one above.
     return getParentIfThenified(grandParentNode);
@@ -112,7 +109,7 @@ const isAcceptableReturnNode = (
     return true;
   }
 
-  if (node.type === AST_NODE_TYPES.ConditionalExpression && node.parent) {
+  if (node.type === AST_NODE_TYPES.ConditionalExpression) {
     return isAcceptableReturnNode(node.parent, allowReturn);
   }
 
@@ -252,7 +249,7 @@ export default createRule<[Options], MessageIds>({
 
         if (typeof jestFnCall === 'string') {
           const reportingNode =
-            node.parent?.type === AST_NODE_TYPES.MemberExpression
+            node.parent.type === AST_NODE_TYPES.MemberExpression
               ? findTopMostMemberExpression(node.parent).property
               : node;
 
@@ -292,7 +289,7 @@ export default createRule<[Options], MessageIds>({
 
         const { parent: expect } = jestFnCall.head.node;
 
-        if (expect?.type !== AST_NODE_TYPES.CallExpression) {
+        if (expect.type !== AST_NODE_TYPES.CallExpression) {
           return;
         }
 


### PR DESCRIPTION
The majority of these are because `@typescript-eslint` changed their types a while back so that `parent` is only potentially optional on generic nodes, but there's a few others that have also crept in which I found with `@typescript-eslint/no-unnecessary-condition`