### PR TITLE
refactor: don't return the result of void functions

### DIFF
--- a/src/rules/utils/padding.ts
+++ b/src/rules/utils/padding.ts
@@ -268,13 +268,15 @@ const testPadding = (
       nodeMatchesType(prevNode, prevType, paddingContext) &&
       nodeMatchesType(nextNode, nextType, paddingContext)
     ) {
-      return testType(paddingType);
+      testType(paddingType);
+
+      return;
     }
   }
 
   // There were no matching padding rules for the prevNode, nextNode,
   // paddingType combination... so we'll use PaddingType.Any which is always ok
-  return testType(PaddingType.Any);
+  testType(PaddingType.Any);
 };
 
 /**

--- a/src/rules/valid-describe-callback.ts
+++ b/src/rules/valid-describe-callback.ts
@@ -46,10 +46,12 @@ export default createRule({
         }
 
         if (node.arguments.length < 1) {
-          return context.report({
+          context.report({
             messageId: 'nameAndCallback',
             loc: node.loc,
           });
+
+          return;
         }
 
         const [, callback] = node.arguments;


### PR DESCRIPTION
This is at best confusing, and at worst can let a bug slip through if the function starts to return a value