### PR TITLE
fix(valid-expect-in-promise): don't crash on `it.todo`

### DIFF
--- a/src/rules/__tests__/valid-expect-in-promise.test.ts
+++ b/src/rules/__tests__/valid-expect-in-promise.test.ts
@@ -14,6 +14,7 @@ ruleTester.run('valid-expect-in-promise', rule, {
     "test('something', () => Promise.resolve().then(() => expect(1).toBe(2)));",
     'Promise.resolve().then(() => expect(1).toBe(2))',
     'const x = Promise.resolve().then(() => expect(1).toBe(2))',
+    'it.todo("something")',
     dedent`
       it('is valid', () => {
         const promise = loadNumber().then(number => {

--- a/src/rules/valid-expect-in-promise.ts
+++ b/src/rules/valid-expect-in-promise.ts
@@ -76,7 +76,9 @@ const isTestCaseCallWithCallbackArg = (
   const callbackArgIndex = Number(isJestEach);
 
   return (
-    isFunction(callback) && callback.params.length === 1 + callbackArgIndex
+    callback &&
+    isFunction(callback) &&
+    callback.params.length === 1 + callbackArgIndex
   );
 };
 


### PR DESCRIPTION
I think this is still a win overall since it found a hole in our test suite 🤷 