### PR TITLE
ci: disable rules that require typechecking in smoke test

### DIFF
--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -26,9 +26,14 @@ const config: Config = {
     },
     extends: ['plugin:jest/all'],
     rules: {
-      // this requires type information, which is not really feasible when
-      // linting a bunch of randomly picked open-source js & ts projects
+      // these rules require type information, which is not really feasible
+      // when linting a bunch of randomly picked open-source js & ts projects
+      //
+      // todo: try to see if we can actually get these working
+      'jest/no-error-equal': 'off',
+      'jest/no-unnecessary-assertion': 'off',
       'jest/unbound-method': 'off',
+      'jest/valid-expect-with-promise': 'off',
     },
   },
 };


### PR DESCRIPTION
I forgot about this - now that we have a few more rules, ideally we should try to get them running but for now this'll unblock the rest of the run

Resolves #1899