### PR TITLE
chore: disable upcoming `eslint-plugin-eslint-plugin` recommended rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -134,17 +134,6 @@ const config = [
       strict: 'off',
     },
   },
-
-  // todo: these are recommended in eslint-plugin-eslint-plugin v7
-  //  we should work on getting them addressed and switching to error
-  {
-    rules: {
-      'eslint-plugin/no-meta-replaced-by': 'error',
-      'eslint-plugin/no-meta-schema-default': 'warn',
-      'eslint-plugin/require-meta-default-options': 'warn',
-      'eslint-plugin/require-meta-schema-description': 'warn',
-    },
-  },
 ];
 
 module.exports = config;


### PR DESCRIPTION
Turns out these rules are based on new features added in ESLint v9 minor versions, so attempting to address them would give a worse experience for ESLint v8 users

Reverts 7785da69ed0af72898c8b979890b52067dd3cc11
Reverts #1904