### PR TITLE
ci: skip repositories that use a lot of memory when smoke testing

### DIFF
--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -6,8 +6,23 @@ import {
 } from 'eslint-remote-tester-repositories';
 import plugin from './src';
 
+// these repos often cause ERR_WORKER_OUT_OF_MEMORY errors, probably because
+// they are large typescript repositories which cause our type-based rules
+// to use a lot of memory
+const reposToIgnore = new Set<string>([
+  'trezor/trezor-suite',
+  'tannerlinsley/react-location',
+  'w-okada/image-analyze-workers',
+  'hubmapconsortium/vitessce',
+  'magiclabs/magic-js',
+  'umbraco/Umbraco.UI',
+  'LaunchMenu/LaunchMenu',
+]);
+
 const config: Config = {
-  repositories: getRepositories({ randomize: true }),
+  repositories: getRepositories({ randomize: true }).filter(repo => {
+    return !reposToIgnore.has(repo);
+  }),
   pathIgnorePattern: getPathIgnorePattern(),
   extensions: ['js', 'jsx', 'ts', 'tsx'],
   concurrentTasks: 3,


### PR DESCRIPTION
I'm hoping this is enough to make this a non-issue, but will re-visit if we still have memory crashes

Resolves #1906