### PR TITLE
fix(prefer-mock-return-shorthand): ignore async implementations

### DIFF
--- a/src/rules/__tests__/prefer-mock-return-shorthand.test.ts
+++ b/src/rules/__tests__/prefer-mock-return-shorthand.test.ts
@@ -5,7 +5,7 @@ import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
 const ruleTester = new RuleTester({
   parser: espreeParser,
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
   },
 });
 
@@ -30,6 +30,13 @@ ruleTester.run('prefer-mock-shorthand', rule, {
     'jest.fn(() => ({}))',
     'aVariable.mockImplementation',
     'aVariable.mockImplementation()',
+    'jest.fn().mockImplementation(async () => 1);',
+    'jest.fn().mockImplementation(async function () {});',
+    dedent`
+      jest.fn().mockImplementation(async function () {
+        return 42;
+      });
+    `,
     dedent`
       aVariable.mockImplementation(() => {
         if (true) {
@@ -350,12 +357,14 @@ ruleTester.run('prefer-mock-shorthand', rule, {
       code: dedent`
         aVariable
           .mockImplementation(() => 42)
+          .mockImplementation(async () => 42)
           .mockImplementation(() => Promise.resolve(42))
           .mockReturnValue("hello world")
       `,
       output: dedent`
         aVariable
           .mockReturnValue(42)
+          .mockImplementation(async () => 42)
           .mockReturnValue(Promise.resolve(42))
           .mockReturnValue("hello world")
       `,
@@ -370,7 +379,7 @@ ruleTester.run('prefer-mock-shorthand', rule, {
           messageId: 'useMockShorthand',
           data: { replacement: 'mockReturnValue' },
           column: 4,
-          line: 3,
+          line: 4,
         },
       ],
     },

--- a/src/rules/prefer-mock-return-shorthand.ts
+++ b/src/rules/prefer-mock-return-shorthand.ts
@@ -61,7 +61,7 @@ export default createRule({
 
         const [arg] = node.arguments;
 
-        if (!isFunction(arg) || arg.params.length !== 0) {
+        if (!isFunction(arg) || arg.params.length !== 0 || arg.async) {
           return;
         }
 


### PR DESCRIPTION
I think ideally `prefer-mock-promise-shorthand` should deal with this, which it currently doesn't, but oh well