### PR TITLE
chore: update `eslint-remote-tester`

### DIFF
--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -32,7 +32,6 @@ const config: Config = {
   concurrentTasks: 3,
   cache: false,
   logLevel: 'info',
-  // @ts-expect-error todo: https://github.com/AriPerkkio/eslint-remote-tester/pull/628
   eslintConfig: [
     plugin.configs['flat/all'],
     { languageOptions: { parser, parserOptions: { project: true } } },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5492,8 +5492,8 @@ __metadata:
   linkType: hard
 
 "eslint-remote-tester@npm:^4.0.0":
-  version: 4.0.3
-  resolution: "eslint-remote-tester@npm:4.0.3"
+  version: 4.0.4
+  resolution: "eslint-remote-tester@npm:4.0.4"
   dependencies:
     "@babel/code-frame": "npm:^7.27.1"
     JSONStream: "npm:^1.3.5"
@@ -5501,7 +5501,7 @@ __metadata:
     ink: "npm:^3.2.0"
     object-hash: "npm:^3.0.0"
     react: "npm:^17.0.2"
-    simple-git: "npm:^3.28.0"
+    simple-git: "npm:^3.30.0"
   peerDependencies:
     eslint: ">=9"
     importx: ">=0.3.5"
@@ -5513,7 +5513,7 @@ __metadata:
       optional: true
   bin:
     eslint-remote-tester: dist/index.js
-  checksum: 10c0/b05d976bd252443f87a9366f1757a4af7b0bc0dceda868375d800ff6d48196eee62210189c69e9eb5bf308abb2fca6d4fd0172a62d5c2d2fc91aa24ac985acab
+  checksum: 10c0/b473177aee7e6f2de94f8d0485da166c95af6cd4a72f3771d30051f10e3aee20960485ce8a1a86ea9987465752a69d8a2776d3dbb2399790ee7bbdbb9f9f3f64
   languageName: node
   linkType: hard
 
@@ -10445,7 +10445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.28.0":
+"simple-git@npm:^3.30.0":
   version: 3.30.0
   resolution: "simple-git@npm:3.30.0"
   dependencies:


### PR DESCRIPTION
I fixed the types for `eslintConfig` so that it is now valid to pass in an array of config items