### PR TITLE
fix: add optional peer dependency on TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,13 +124,17 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "eslint": "^8.57.0 || ^9.0.0",
-    "jest": "*"
+    "jest": "*",
+    "typescript": ">=4.8.4 <6.0.0"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {
       "optional": true
     },
     "jest": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5377,10 +5377,13 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^8.0.0
     eslint: ^8.57.0 || ^9.0.0
     jest: "*"
+    typescript: ">=4.8.4 <6.0.0"
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":
       optional: true
     jest:
+      optional: true
+    typescript:
       optional: true
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Just pushing https://www.runpkg.com/?@typescript-eslint/utils@8.54.0/package.json#71 up

I noticed this in my work project


```
Package eslint-plugin-jest@npm:29.12.1 [869e6] is requested to provide typescript by its descendants

eslint-plugin-jest@npm:29.12.1 [869e6]
└─ @typescript-eslint/utils@npm:8.53.1 [a6790] (via >=4.8.4 <6.0.0)
   └─ @typescript-eslint/typescript-estree@npm:8.53.1 [5da47] (via >=4.8.4 <6.0.0)
      ├─ @typescript-eslint/project-service@npm:8.53.1 [20213] (via >=4.8.4 <6.0.0)
      │  └─ @typescript-eslint/tsconfig-utils@npm:8.53.1 [20213] (via >=4.8.4 <6.0.0)
      ├─ @typescript-eslint/tsconfig-utils@npm:8.53.1 [20213] (via >=4.8.4 <6.0.0)
      └─ ts-api-utils@npm:2.4.0 [20213] (via >=4.8.4)

✘ Package eslint-plugin-jest@npm:29.12.1 [869e6] does not provide typescript.
```