### PR TITLE
feat(no-conditional-in-test): only report optional chaining when `allowOptionalChaining` is false

### DIFF
--- a/docs/rules/no-conditional-in-test.md
+++ b/docs/rules/no-conditional-in-test.md
@@ -12,7 +12,7 @@ devoted to it.
 ## Rule details
 
 This rule reports on any use of a conditional statement such as `if`, `switch`,
-ternary expressions, and optional chaining.
+and ternary expressions.
 
 Examples of **incorrect** code for this rule:
 
@@ -34,10 +34,6 @@ it('bar', () => {
   }
 
   expect(fixtures.length).toBeGreaterThan(-1);
-});
-
-it('baz', () => {
-  const value = obj?.bar;
 });
 
 it('qux', async () => {
@@ -81,11 +77,47 @@ const promiseValue = something => {
   return something instanceof Promise ? something : Promise.resolve(something);
 };
 
-it('baz', () => {
-  const value = obj!.bar;
-});
-
 it('qux', async () => {
   await expect(promiseValue()).resolves.toBe(1);
+});
+```
+
+## Options
+
+```json
+{
+  "jest/no-conditional-in-test": [
+    "error",
+    {
+      "allowOptionalChaining": true
+    }
+  ]
+}
+```
+
+### `allowOptionalChaining`
+
+Default: `true`
+
+When set to `false`, optional chaining (`?.`) inside test bodies will be
+reported as a conditional.
+
+Examples of **incorrect** code when `allowOptionalChaining` is `false`:
+
+```js
+it('foo', () => {
+  const value = obj?.bar;
+});
+
+it('bar', () => {
+  obj?.foo();
+});
+```
+
+Examples of **correct** code when `allowOptionalChaining` is `false`:
+
+```js
+it('foo', () => {
+  const value = obj!.bar;
 });
 ```

--- a/src/rules/__tests__/no-conditional-in-test.test.ts
+++ b/src/rules/__tests__/no-conditional-in-test.test.ts
@@ -954,46 +954,106 @@ ruleTester.run('optional chaining', rule, {
   valid: [
     'const x = obj?.foo',
     dedent`
-      const foo = obj?.bar;
-
       it('foo', () => {
-        expect(foo).toBe(undefined);
-      });
-    `,
-    dedent`
-      describe('foo', () => {
-        const val = obj?.bar;
+        const value = obj?.bar;
       })
     `,
     dedent`
-      describe('foo', () => {
-        beforeEach(() => {
-          const val = obj?.bar;
-        });
+      it('foo', () => {
+        obj?.foo?.bar;
       })
     `,
     dedent`
-      describe('foo', () => {
-        afterEach(() => {
-          const val = obj?.bar;
-        });
+      it('foo', () => {
+        obj?.foo();
       })
     `,
     dedent`
-      const values = something.map(thing => thing?.foo);
+      it('foo', () => {
+        obj?.[key];
+      })
+    `,
+    dedent`
+      test('foo', () => {
+        obj?.bar;
+      })
+    `,
+    dedent`
+      it('is valid', () => {
+        const values = something.map(thing => thing?.foo);
 
-      it('valid', () => {
         expect(values).toStrictEqual(['foo']);
       });
     `,
-    dedent`
-      describe('valid', () => {
+  ],
+  invalid: [],
+});
+
+ruleTester.run('optional chaining with allowOptionalChaining=false', rule, {
+  valid: [
+    {
+      code: 'const x = obj?.foo',
+      options: [{ allowOptionalChaining: false }],
+    },
+    {
+      code: dedent`
+        const foo = obj?.bar;
+
+        it('foo', () => {
+          expect(foo).toBe(undefined);
+        });
+      `,
+      options: [{ allowOptionalChaining: false }],
+    },
+    {
+      code: dedent`
+        describe('foo', () => {
+          const val = obj?.bar;
+        })
+      `,
+      options: [{ allowOptionalChaining: false }],
+    },
+    {
+      code: dedent`
+        describe('foo', () => {
+          beforeEach(() => {
+            const val = obj?.bar;
+          });
+        })
+      `,
+      options: [{ allowOptionalChaining: false }],
+    },
+    {
+      code: dedent`
+        describe('foo', () => {
+          afterEach(() => {
+            const val = obj?.bar;
+          });
+        })
+      `,
+      options: [{ allowOptionalChaining: false }],
+    },
+    {
+      code: dedent`
         const values = something.map(thing => thing?.foo);
-        it('still valid', () => {
+
+        it('valid', () => {
           expect(values).toStrictEqual(['foo']);
         });
-      });
-    `,
+      `,
+      options: [{ allowOptionalChaining: false }],
+    },
+    {
+      code: dedent`
+        describe('valid', () => {
+          const values = something.map(thing => thing?.foo);
+          it('still valid', () => {
+            expect(values).toStrictEqual(['foo']);
+          });
+        });
+      `,
+      options: [{ allowOptionalChaining: false }],
+    },
   ],
   invalid: [
     {
@@ -1002,6 +1062,7 @@ ruleTester.run('optional chaining', rule, {
           const value = obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1016,6 +1077,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.foo?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1030,6 +1092,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.foo();
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1044,6 +1107,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.[key];
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1058,6 +1122,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1072,6 +1137,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1086,6 +1152,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1100,6 +1167,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1114,6 +1182,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1128,6 +1197,7 @@ ruleTester.run('optional chaining', rule, {
           obj?.bar;
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1144,6 +1214,7 @@ ruleTester.run('optional chaining', rule, {
           })
         })
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',
@@ -1160,6 +1231,7 @@ ruleTester.run('optional chaining', rule, {
           expect(values).toStrictEqual(['foo']);
         });
       `,
+      options: [{ allowOptionalChaining: false }],
       errors: [
         {
           messageId: 'conditionalInTest',

--- a/src/rules/no-conditional-in-test.ts
+++ b/src/rules/no-conditional-in-test.ts
@@ -1,7 +1,11 @@
 import type { TSESTree } from '@typescript-eslint/utils';
 import { createRule, isTypeOfJestFnCall } from './utils';
 
-export default createRule({
+interface RuleOptions {
+  allowOptionalChaining?: boolean;
+}
+
+export default createRule<[RuleOptions], 'conditionalInTest'>({
   name: __filename,
   meta: {
     docs: {
@@ -11,10 +15,20 @@ export default createRule({
       conditionalInTest: 'Avoid having conditionals in tests',
     },
     type: 'problem',
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowOptionalChaining: {
+            type: 'boolean',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
-  defaultOptions: [],
-  create(context) {
+  defaultOptions: [{ allowOptionalChaining: true }],
+  create(context, [{ allowOptionalChaining }]) {
     let inTestCase = false;
 
     const maybeReportConditional = (node: TSESTree.Node) => {
@@ -41,7 +55,9 @@ export default createRule({
       SwitchStatement: maybeReportConditional,
       ConditionalExpression: maybeReportConditional,
       LogicalExpression: maybeReportConditional,
-      ChainExpression: maybeReportConditional,
+      ...(!allowOptionalChaining && {
+        ChainExpression: maybeReportConditional,
+      }),
     };
   },
 });


### PR DESCRIPTION
As per the comments in this [issue](https://github.com/jest-community/eslint-plugin-jest/issues/1928), I have implemented this as an option so that it is no longer the default.

Resolves #1928 (again)