### PR TITLE
fix: allow TypeScript@7 in peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
     "@tsconfig/node20": "^20.0.0",
-    "@types/eslint": "^8.4.6",
+    "@types/eslint": "^9.6.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.0.0",
     "@types/semver": "^7.5.8",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
     "jest": "*",
-    "typescript": ">=4.8.4 <6.0.0"
+    "typescript": ">=4.8.4 <7.0.0"
   },
   "peerDependenciesMeta": {
     "@typescript-eslint/eslint-plugin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5390,7 +5390,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^8.0.0
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     jest: "*"
-    typescript: ">=4.8.4 <6.0.0"
+    typescript: ">=4.8.4 <7.0.0"
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2956,13 +2956,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:^8.4.6":
-  version: 8.56.12
-  resolution: "@types/eslint@npm:8.56.12"
+"@types/eslint@npm:^9.6.1":
+  version: 9.6.1
+  resolution: "@types/eslint@npm:9.6.1"
   dependencies:
     "@types/estree": "npm:*"
     "@types/json-schema": "npm:*"
-  checksum: 10c0/e4ca426abe9d55f82b69a3250bec78b6d340ad1e567f91c97ecc59d3b2d6a1d8494955ac62ad0ea14b97519db580611c02be8277cbea370bdfb0f96aa2910504
+  checksum: 10c0/69ba24fee600d1e4c5abe0df086c1a4d798abf13792d8cfab912d76817fe1a894359a1518557d21237fbaf6eda93c5ab9309143dee4c59ef54336d1b3570420e
   languageName: node
   linkType: hard
 
@@ -5354,7 +5354,7 @@ __metadata:
     "@semantic-release/changelog": "npm:^6.0.0"
     "@semantic-release/git": "npm:^10.0.0"
     "@tsconfig/node20": "npm:^20.0.0"
-    "@types/eslint": "npm:^8.4.6"
+    "@types/eslint": "npm:^9.6.1"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^20.0.0"
     "@types/semver": "npm:^7.5.8"


### PR DESCRIPTION
`@typescript-eslint/eslint-plugin` hasn't added support yet, but that doesn't matter to us really