### PR TITLE
docs(valid-expect): use valid alert syntax

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -10,8 +10,10 @@
 
 <!-- end auto-generated rule header -->
 
-> [!NOTE] Test function will be fixed if it is async and does not have await in
-> the async assertion.
+> [!NOTE]
+>
+> Test function will be fixed if it is `async` and does not have `await` in the
+> async assertion.
 
 Ensure `expect()` is called with a single argument and there is an actual
 expectation made.


### PR DESCRIPTION
Noticed while looking over other stuff