### PR TITLE
feat(valid-expect): support using typechecking to ensure `toThrow` type assertions are passed a function

### DIFF
--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -49,6 +49,10 @@ This rule is enabled by default.
 {
   type: 'object',
   properties: {
+    typecheck: {
+      type: 'boolean',
+      default: false,
+    },
     alwaysAwait: {
       type: 'boolean',
       default: false,

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -71,6 +71,14 @@ This rule is enabled by default.
 }
 ```
 
+### `typecheck`
+
+Use TypeScript type information to check that `toThrow` assertions are being
+passed a callable.
+
+This option requires type information from `@typescript-eslint/parser`, such as
+a configured `parserOptions.project`.
+
 ### `alwaysAwait`
 
 Enforces to use `await` inside block statements. Using `return` will trigger a

--- a/docs/rules/valid-expect.md
+++ b/docs/rules/valid-expect.md
@@ -73,8 +73,8 @@ This rule is enabled by default.
 
 ### `typecheck`
 
-Use TypeScript type information to check that `toThrow` assertions are being
-passed a callable.
+Use TypeScript type information to check that `toThrow` type assertions are
+being passed a callable.
 
 This option requires type information from `@typescript-eslint/parser`, such as
 a configured `parserOptions.project`.

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -368,7 +368,6 @@ new RuleTester({
     {
       code: 'expect(1 as unknown).toThrow()',
       options: [{ typecheck: true }],
-      output: 'expect(() => 1 as unknown).toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -381,7 +380,30 @@ new RuleTester({
     {
       code: 'expect(1 as any).toThrow()',
       options: [{ typecheck: true }],
-      output: 'expect(() => 1 as any).toThrow()',
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1 as any | (() => void)).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1 as any | string).toThrow()',
+      options: [{ typecheck: true }],
       errors: [
         {
           messageId: 'toThrowWithoutCallable',

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -1,6 +1,246 @@
+import path from 'path';
 import dedent from 'dedent';
 import rule from '../valid-expect';
-import { FlatCompatRuleTester as RuleTester, espreeParser } from './test-utils';
+import {
+  FlatCompatRuleTester as RuleTester,
+  createRuleRequirerTester,
+  espreeParser,
+  getFixturesRootDir,
+} from './test-utils';
+
+const rootPath = getFixturesRootDir();
+const fixtureFilename = path.join(rootPath, 'file.ts');
+
+const { requireRule, withFixtureFilename } = createRuleRequirerTester<
+  readonly unknown[],
+  string
+>('../valid-expect', 'typescript', fixtureFilename);
+
+new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    sourceType: 'module',
+    tsconfigRootDir: rootPath,
+    project: './tsconfig.json',
+    disallowAutomaticSingleRunInference: true,
+  },
+}).run('valid-expect (typecheck option)', requireRule(false), {
+  valid: withFixtureFilename([
+    {
+      code: 'expect(() => {}).toThrow()',
+      options: [{ typecheck: true }],
+    },
+    {
+      code: 'expect(function () {}).toThrow()',
+      options: [{ typecheck: true }],
+    },
+
+    {
+      code: dedent`
+        function mx() { return 1; }
+
+        expect(mx()).toBe(1);
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        function mx() { return 1; }
+
+        expect(() => mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        function mx() { return 1; }
+
+        expect(mx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        function mx() { return () => {}; }
+
+        expect(mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+
+    {
+      code: dedent`
+        const mx = () => { return 1; };
+
+        expect(mx()).toBe(1);
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => { return 1; };
+
+        expect(() => mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => { return 1; };
+
+        expect(mx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => { return () => {} };
+
+        expect(mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => { return () => {} };
+
+        expect(() => { mx() }).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+
+    {
+      code: dedent`
+        const mx = () => 1;
+
+        expect(mx()).toBe(1);
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => "hello world";
+
+        expect(() => mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => 5;
+
+        expect(mx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => () => {};
+
+        expect(mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => () => {};
+
+        expect(() => { mx() }).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => () => {};
+
+        expect(function() { mx() }).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+
+    {
+      code: dedent`
+        class Mx { sayHello() {} }
+
+        expect(new Mx().sayHello).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        class Mx { sayHello() { return () => {} } }
+
+        expect(new Mx().sayHello).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+  ]),
+  invalid: withFixtureFilename([
+    {
+      code: 'expect(1).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect("hello world").toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(function () { return "hello world" }()).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        class Mx { sayHello() {} }
+
+        expect(new Mx().sayHello()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          column: 8,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        class Mx { sayHello() { return () => {} } }
+
+        expect(new Mx().sayHello()()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          column: 8,
+          line: 3,
+        },
+      ],
+    },
+  ]),
+});
 
 const ruleTester = new RuleTester({
   parser: espreeParser,

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -61,6 +61,14 @@ new RuleTester({
     },
     {
       code: dedent`
+        function mx() { return 1; }
+
+        expect(mx).toThrowError();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
         function mx() { return () => {}; }
 
         expect(mx()).toThrow();
@@ -89,6 +97,14 @@ new RuleTester({
         const mx = () => { return 1; };
 
         expect(mx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => { return 1; };
+
+        expect(mx).toThrowErrorMatchingSnapshot();
       `,
       options: [{ typecheck: true }],
     },
@@ -130,6 +146,14 @@ new RuleTester({
         const mx = () => 5;
 
         expect(mx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
+        const mx = () => 5;
+
+        expect(mx).toThrowErrorMatchingInlineSnapshot();
       `,
       options: [{ typecheck: true }],
     },
@@ -182,6 +206,43 @@ new RuleTester({
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1).toThrowError()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrowError' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingSnapshot()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrowErrorMatchingSnapshot' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1).toThrowErrorMatchingInlineSnapshot()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrowErrorMatchingInlineSnapshot' },
           column: 8,
           line: 1,
         },
@@ -193,6 +254,7 @@ new RuleTester({
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
           column: 8,
           line: 1,
         },
@@ -204,6 +266,19 @@ new RuleTester({
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(function () { return "hello world" }()).toThrowError()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrowError' },
           column: 8,
           line: 1,
         },
@@ -219,6 +294,7 @@ new RuleTester({
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
           column: 8,
           line: 3,
         },
@@ -234,6 +310,23 @@ new RuleTester({
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 3,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        class Mx { sayHello() { return () => {} } }
+
+        expect(new Mx().sayHello()()).toThrowErrorMatchingInlineSnapshot();
+      `,
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrowErrorMatchingInlineSnapshot' },
           column: 8,
           line: 3,
         },

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -162,6 +162,22 @@ new RuleTester({
       code: 'expect(function () {}).toThrow()',
       options: [{ typecheck: true }],
     },
+    {
+      code: 'expect(1 as () => void).toThrow();',
+      options: [{ typecheck: true }],
+    },
+    {
+      code: 'expect(1 as unknown as () => void).toThrow();',
+      options: [{ typecheck: true }],
+    },
+    {
+      code: 'expect(1 as any as () => void).toThrow();',
+      options: [{ typecheck: true }],
+    },
+    {
+      code: 'expect(1 as unknown & (() => void)).toThrow()',
+      options: [{ typecheck: true }],
+    },
 
     {
       code: dedent`
@@ -279,6 +295,14 @@ new RuleTester({
     },
     {
       code: dedent`
+        const mx = function () { return 1; };
+
+        expect(mx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+    {
+      code: dedent`
         const mx = () => 5;
 
         expect(mx).toThrowErrorMatchingInlineSnapshot();
@@ -330,6 +354,54 @@ new RuleTester({
   invalid: withFixtureFilename([
     {
       code: 'expect(1).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1 as unknown).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1 as any).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1 as string | (() => void)).toThrow()',
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1 as (() => void) | string).toThrow()',
       options: [{ typecheck: true }],
       errors: [
         {
@@ -409,6 +481,40 @@ new RuleTester({
           data: { matcher: 'toThrowError' },
           column: 8,
           line: 1,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const mx = function () {
+          return Math.random() > 0.5 ? () => {} : null;
+        };
+
+        expect(mx()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 5,
+        },
+      ],
+    },
+    {
+      code: dedent`
+        const mx = () => () => {};
+
+        expect(mx()()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 3,
         },
       ],
     },

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -1,4 +1,6 @@
 import path from 'path';
+import * as tsParser from '@typescript-eslint/parser';
+import { TSESLint } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import rule from '../valid-expect';
 import {
@@ -6,15 +8,141 @@ import {
   createRuleRequirerTester,
   espreeParser,
   getFixturesRootDir,
+  usingFlatConfig,
 } from './test-utils';
 
 const rootPath = getFixturesRootDir();
 const fixtureFilename = path.join(rootPath, 'file.ts');
 
-const { requireRule, withFixtureFilename } = createRuleRequirerTester<
-  readonly unknown[],
-  string
->('../valid-expect', 'typescript', fixtureFilename);
+const { TSESLintPluginRef, requireRule, withFixtureFilename } =
+  createRuleRequirerTester<readonly unknown[], string>(
+    '../valid-expect',
+    'typescript',
+    fixtureFilename,
+  );
+
+describe('typecheck option availability', () => {
+  const parser = '@typescript-eslint/parser';
+
+  const createLinter = () => {
+    const linter = new TSESLint.Linter();
+
+    if (!usingFlatConfig) {
+      linter.defineParser(parser, tsParser);
+      linter.defineRule('valid-expect', requireRule(false));
+    }
+
+    return linter;
+  };
+
+  afterEach(() => {
+    TSESLintPluginRef.throwWhenRequiring = false;
+  });
+
+  it('does not require typescript when the rule is imported', () => {
+    expect(() => requireRule(true)).not.toThrow();
+  });
+
+  describe('when typecheck is disabled', () => {
+    it('does not require typechecking', () => {
+      const linter = createLinter();
+
+      expect(() => {
+        /* istanbul ignore if */
+        if (usingFlatConfig) {
+          linter.verify('expect(() => {}).toThrow()', [
+            {
+              plugins: { jest: { rules: { 'valid-expect': rule } } },
+              languageOptions: {
+                parser: tsParser,
+                parserOptions: { sourceType: 'module' },
+              },
+              rules: { 'jest/valid-expect': ['error', { typecheck: false }] },
+            },
+          ]);
+
+          return;
+        }
+
+        linter.verify('expect(() => {}).toThrow()', {
+          parser,
+          parserOptions: { sourceType: 'module' },
+          rules: { 'valid-expect': ['error', { typecheck: false }] },
+        });
+      }).not.toThrow();
+    });
+
+    it('does not require typescript', () => {
+      const linter = createLinter();
+
+      TSESLintPluginRef.throwWhenRequiring = true;
+
+      expect(() => {
+        /* istanbul ignore if */
+        if (usingFlatConfig) {
+          linter.verify('expect(() => {}).toThrow()', [
+            {
+              plugins: { jest: { rules: { 'valid-expect': rule } } },
+              languageOptions: {
+                parser: tsParser,
+                parserOptions: {
+                  sourceType: 'module',
+                  tsconfigRootDir: rootPath,
+                  project: './tsconfig.json',
+                  disallowAutomaticSingleRunInference: true,
+                },
+              },
+              rules: { 'jest/valid-expect': ['error', { typecheck: false }] },
+            },
+          ]);
+
+          return;
+        }
+
+        linter.verify('expect(() => {}).toThrow()', {
+          parser,
+          parserOptions: {
+            sourceType: 'module',
+            tsconfigRootDir: rootPath,
+            project: './tsconfig.json',
+            disallowAutomaticSingleRunInference: true,
+          },
+          rules: { 'valid-expect': ['error', { typecheck: false }] },
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('when typecheck is enabled', () => {
+    it('requires typechecking', () => {
+      const linter = createLinter();
+
+      expect(() => {
+        /* istanbul ignore if */
+        if (usingFlatConfig) {
+          linter.verify('expect(() => {}).toThrow()', [
+            {
+              plugins: { jest: { rules: { 'valid-expect': rule } } },
+              languageOptions: {
+                parser: tsParser,
+                parserOptions: { sourceType: 'module' },
+              },
+              rules: { 'jest/valid-expect': ['error', { typecheck: true }] },
+            },
+          ]);
+
+          return;
+        }
+
+        linter.verify('expect(() => {}).toThrow()', {
+          parser,
+          parserOptions: { sourceType: 'module' },
+          rules: { 'valid-expect': ['error', { typecheck: true }] },
+        });
+      }).toThrow(/requires type information|parserOptions/iu);
+    });
+  });
+});
 
 new RuleTester({
   parser: require.resolve('@typescript-eslint/parser'),

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -350,12 +350,33 @@ new RuleTester({
       `,
       options: [{ typecheck: true }],
     },
+    {
+      code: dedent`
+        class Mx { sayHello() { return () => {} } }
+
+        expect(new Mx().sayHello, 123).toThrow();
+      `,
+      options: [{ typecheck: true, maxArgs: 2 }],
+    },
   ]),
   invalid: withFixtureFilename([
     {
       code: 'expect(1).toThrow()',
       options: [{ typecheck: true }],
       output: 'expect(() => 1).toThrow()',
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 1,
+        },
+      ],
+    },
+    {
+      code: 'expect(1, 123).toThrow()',
+      options: [{ typecheck: true, maxArgs: 2 }],
+      output: 'expect(() => 1, 123).toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -355,6 +355,7 @@ new RuleTester({
     {
       code: 'expect(1).toThrow()',
       options: [{ typecheck: true }],
+      output: 'expect(() => 1).toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -367,6 +368,7 @@ new RuleTester({
     {
       code: 'expect(1 as unknown).toThrow()',
       options: [{ typecheck: true }],
+      output: 'expect(() => 1 as unknown).toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -379,6 +381,7 @@ new RuleTester({
     {
       code: 'expect(1 as any).toThrow()',
       options: [{ typecheck: true }],
+      output: 'expect(() => 1 as any).toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -415,6 +418,7 @@ new RuleTester({
     {
       code: 'expect(1).toThrowError()',
       options: [{ typecheck: true }],
+      output: 'expect(() => 1).toThrowError()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -427,6 +431,7 @@ new RuleTester({
     {
       code: 'expect(1).toThrowErrorMatchingSnapshot()',
       options: [{ typecheck: true }],
+      output: 'expect(() => 1).toThrowErrorMatchingSnapshot()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -439,6 +444,7 @@ new RuleTester({
     {
       code: 'expect(1).toThrowErrorMatchingInlineSnapshot()',
       options: [{ typecheck: true }],
+      output: 'expect(() => 1).toThrowErrorMatchingInlineSnapshot()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -451,6 +457,7 @@ new RuleTester({
     {
       code: 'expect("hello world").toThrow()',
       options: [{ typecheck: true }],
+      output: 'expect(() => "hello world").toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -463,6 +470,7 @@ new RuleTester({
     {
       code: 'expect(function () { return "hello world" }()).toThrow()',
       options: [{ typecheck: true }],
+      output: 'expect(() => function () { return "hello world" }()).toThrow()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -475,6 +483,8 @@ new RuleTester({
     {
       code: 'expect(function () { return "hello world" }()).toThrowError()',
       options: [{ typecheck: true }],
+      output:
+        'expect(() => function () { return "hello world" }()).toThrowError()',
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -509,6 +519,11 @@ new RuleTester({
         expect(mx()()).toThrow();
       `,
       options: [{ typecheck: true }],
+      output: dedent`
+        const mx = () => () => {};
+
+        expect(() => mx()()).toThrow();
+      `,
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -525,6 +540,11 @@ new RuleTester({
         expect(new Mx().sayHello()).toThrow();
       `,
       options: [{ typecheck: true }],
+      output: dedent`
+        class Mx { sayHello() {} }
+
+        expect(() => new Mx().sayHello()).toThrow();
+      `,
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -541,6 +561,11 @@ new RuleTester({
         expect(new Mx().sayHello()()).toThrow();
       `,
       options: [{ typecheck: true }],
+      output: dedent`
+        class Mx { sayHello() { return () => {} } }
+
+        expect(() => new Mx().sayHello()()).toThrow();
+      `,
       errors: [
         {
           messageId: 'toThrowWithoutCallable',
@@ -557,6 +582,11 @@ new RuleTester({
         expect(new Mx().sayHello()()).toThrowErrorMatchingInlineSnapshot();
       `,
       options: [{ typecheck: true }],
+      output: dedent`
+        class Mx { sayHello() { return () => {} } }
+
+        expect(() => new Mx().sayHello()()).toThrowErrorMatchingInlineSnapshot();
+      `,
       errors: [
         {
           messageId: 'toThrowWithoutCallable',

--- a/src/rules/__tests__/valid-expect.test.ts
+++ b/src/rules/__tests__/valid-expect.test.ts
@@ -358,8 +358,44 @@ new RuleTester({
       `,
       options: [{ typecheck: true, maxArgs: 2 }],
     },
+
+    {
+      code: dedent`
+        const pMx = Promise.resolve(() => {});
+
+        expect(await pMx).toThrow();
+      `,
+      options: [{ typecheck: true }],
+    },
+
+    {
+      code: dedent`
+        it('is a test', async () => {
+          const pMx = Promise.resolve(() => {});
+
+          expect(await pMx).toThrow();
+        });
+      `,
+      options: [{ typecheck: true }],
+    },
   ]),
   invalid: withFixtureFilename([
+    {
+      code: dedent`
+        const pMx = Promise.resolve(() => {});
+
+        expect((await pMx)()).toThrow();
+      `,
+      options: [{ typecheck: true }],
+      errors: [
+        {
+          messageId: 'toThrowWithoutCallable',
+          data: { matcher: 'toThrow' },
+          column: 8,
+          line: 3,
+        },
+      ],
+    },
     {
       code: 'expect(1).toThrow()',
       options: [{ typecheck: true }],

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -368,14 +368,24 @@ export default createRule<[Options], MessageIds>({
             'toThrowErrorMatchingInlineSnapshot',
           ].includes(getAccessorValue(matcher))
         ) {
-          const type = services.getTypeAtLocation(expect.arguments[0]);
+          const [firstArg] = expect.arguments;
+
+          const type = services.getTypeAtLocation(firstArg);
 
           if (type.getCallSignatures().length === 0) {
             context.report({
               messageId: 'toThrowWithoutCallable',
               data: { matcher: getAccessorValue(matcher) },
-              node: expect.arguments[0],
+              node: firstArg,
               fix(fixer) {
+                // might be possible to fix, but could be messy, so leaving it for now
+                if (
+                  firstArg.type === AST_NODE_TYPES.CallExpression &&
+                  firstArg.callee.type === AST_NODE_TYPES.AwaitExpression
+                ) {
+                  return null;
+                }
+
                 // unions are not safe to fix, since the value might be a callable
                 if (type.isUnion()) {
                   return null;
@@ -389,7 +399,7 @@ export default createRule<[Options], MessageIds>({
                   return null;
                 }
 
-                return fixer.insertTextBefore(expect.arguments[0], '() => ');
+                return fixer.insertTextBefore(firstArg, '() => ');
               },
             });
           }

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -10,6 +10,7 @@ import {
   type TSESLint,
   type TSESTree,
 } from '@typescript-eslint/utils';
+import type ts from 'typescript';
 import {
   type FunctionExpression,
   ModifierName,
@@ -375,8 +376,16 @@ export default createRule<[Options], MessageIds>({
               data: { matcher: getAccessorValue(matcher) },
               node: expect.arguments[0],
               fix(fixer) {
-                // unions are not safe to fix, since they only _might_ be a callable
+                // unions are not safe to fix, since the value might be a callable
                 if (type.isUnion()) {
+                  return null;
+                }
+
+                // eslint-disable-next-line @typescript-eslint/no-require-imports
+                const { TypeFlags } = require('typescript') as typeof ts;
+
+                // any and unknown is not safe to fix, since they might be a callable
+                if (type.flags & (TypeFlags.Any | TypeFlags.Unknown)) {
                   return null;
                 }
 

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -367,14 +367,21 @@ export default createRule<[Options], MessageIds>({
             'toThrowErrorMatchingInlineSnapshot',
           ].includes(getAccessorValue(matcher))
         ) {
-          if (
-            services.getTypeAtLocation(expect.arguments[0]).getCallSignatures()
-              .length === 0
-          ) {
+          const type = services.getTypeAtLocation(expect.arguments[0]);
+
+          if (type.getCallSignatures().length === 0) {
             context.report({
               messageId: 'toThrowWithoutCallable',
               data: { matcher: getAccessorValue(matcher) },
               node: expect.arguments[0],
+              fix(fixer) {
+                // unions are not safe to fix, since they only _might_ be a callable
+                if (type.isUnion()) {
+                  return null;
+                }
+
+                return fixer.insertTextBefore(expect.arguments[0], '() => ');
+              },
             });
           }
         }

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -152,7 +152,7 @@ export default createRule<[Options], MessageIds>({
     },
     messages: {
       toThrowWithoutCallable:
-        'Expect should be provided a function when using toThrow',
+        'Expect should be provided a function when using {{ matcher }}',
       tooManyArgs: 'Expect takes at most {{ amount }} argument{{ s }}',
       notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
       modifierUnknown: 'Expect has an unknown modifier',
@@ -360,7 +360,12 @@ export default createRule<[Options], MessageIds>({
         if (
           services &&
           expect.arguments.length > 0 &&
-          ['toThrow', 'toThrowError'].includes(getAccessorValue(matcher))
+          [
+            'toThrow',
+            'toThrowError',
+            'toThrowErrorMatchingSnapshot',
+            'toThrowErrorMatchingInlineSnapshot',
+          ].includes(getAccessorValue(matcher))
         ) {
           if (
             services.getTypeAtLocation(expect.arguments[0]).getCallSignatures()
@@ -368,6 +373,7 @@ export default createRule<[Options], MessageIds>({
           ) {
             context.report({
               messageId: 'toThrowWithoutCallable',
+              data: { matcher: getAccessorValue(matcher) },
               node: expect.arguments[0],
             });
           }

--- a/src/rules/valid-expect.ts
+++ b/src/rules/valid-expect.ts
@@ -5,6 +5,8 @@
 
 import {
   AST_NODE_TYPES,
+  ESLintUtils,
+  type ParserServicesWithTypeInformation,
   type TSESLint,
   type TSESTree,
 } from '@typescript-eslint/utils';
@@ -123,6 +125,7 @@ const promiseArrayExceptionKey = ({ start, end }: TSESTree.SourceLocation) =>
   `${start.line}:${start.column}-${end.line}:${end.column}`;
 
 interface Options {
+  typecheck?: boolean;
   alwaysAwait?: boolean;
   asyncMatchers?: string[];
   minArgs?: number;
@@ -130,6 +133,7 @@ interface Options {
 }
 
 type MessageIds =
+  | 'toThrowWithoutCallable'
   | 'tooManyArgs'
   | 'notEnoughArgs'
   | 'modifierUnknown'
@@ -147,6 +151,8 @@ export default createRule<[Options], MessageIds>({
       description: 'Enforce valid `expect()` usage',
     },
     messages: {
+      toThrowWithoutCallable:
+        'Expect should be provided a function when using toThrow',
       tooManyArgs: 'Expect takes at most {{ amount }} argument{{ s }}',
       notEnoughArgs: 'Expect requires at least {{ amount }} argument{{ s }}',
       modifierUnknown: 'Expect has an unknown modifier',
@@ -162,6 +168,10 @@ export default createRule<[Options], MessageIds>({
       {
         type: 'object',
         properties: {
+          typecheck: {
+            type: 'boolean',
+            default: false,
+          },
           alwaysAwait: {
             type: 'boolean',
             default: false,
@@ -185,6 +195,7 @@ export default createRule<[Options], MessageIds>({
   },
   defaultOptions: [
     {
+      typecheck: false,
       alwaysAwait: false,
       asyncMatchers: defaultAsyncMatchers,
       minArgs: 1,
@@ -195,6 +206,7 @@ export default createRule<[Options], MessageIds>({
     context,
     [
       {
+        typecheck,
         alwaysAwait,
         asyncMatchers = defaultAsyncMatchers,
         minArgs = 1,
@@ -242,6 +254,12 @@ export default createRule<[Options], MessageIds>({
 
       return topMostMemberExpression;
     };
+
+    let services: ParserServicesWithTypeInformation | null = null;
+
+    if (typecheck) {
+      services = ESLintUtils.getParserServices(context);
+    }
 
     return {
       CallExpression(node) {
@@ -336,6 +354,24 @@ export default createRule<[Options], MessageIds>({
         }
 
         const { matcher } = jestFnCall;
+
+        // when typechecking is available then for toThrow assertions check
+        // that "expect" is being passed a callable, rather than a value
+        if (
+          services &&
+          expect.arguments.length > 0 &&
+          ['toThrow', 'toThrowError'].includes(getAccessorValue(matcher))
+        ) {
+          if (
+            services.getTypeAtLocation(expect.arguments[0]).getCallSignatures()
+              .length === 0
+          ) {
+            context.report({
+              messageId: 'toThrowWithoutCallable',
+              node: expect.arguments[0],
+            });
+          }
+        }
 
         const parentNode = matcher.parent.parent;
         const shouldBeAwaited =


### PR DESCRIPTION
Resolves #1329