### PR TITLE
ci: don't run smoketest on `tannerlinsley/react-table`

### DIFF
--- a/eslint-remote-tester.config.ts
+++ b/eslint-remote-tester.config.ts
@@ -16,6 +16,7 @@ const reposToIgnore = new Set<string>([
   'magiclabs/magic-js',
   'Synerise/synerise-design',
   'tannerlinsley/react-location',
+  'tannerlinsley/react-table',
   'trezor/trezor-suite',
   'umbraco/Umbraco.UI',
   'w-okada/image-analyze-workers',


### PR DESCRIPTION
We've had a few OOM failures from the smoketest on this repo lately

Resolves #1957