### PR TITLE
fix(no-export): check for global `exports` too

### DIFF
--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -14,7 +14,6 @@ ruleTester.run('no-export', rule, {
   valid: [
     'describe("a test", () => { expect(1).toBe(1); })',
     'window.location = "valid"',
-    'module.somethingElse = "foo";',
     'export const myThing = "valid"',
     'export default function () {}',
     'module.exports = function(){}',
@@ -22,6 +21,37 @@ ruleTester.run('no-export', rule, {
     dedent`
       const module = {};
       module.exports = function () {};
+      test('a test', () => {
+        expect(1).toBe(1);
+      });
+    `,
+    dedent`
+      const module = {};
+      module.somethingElse = 'foo';
+      test('a test', () => {
+        expect(1).toBe(1);
+      });
+    `,
+    dedent`
+      module.somethingElse = 'foo';
+      test('a test', () => {
+        expect(1).toBe(1);
+      });
+    `,
+    dedent`
+      function getModule() {
+        return module;
+      }
+
+      getModule().exports = function () {};
+
+      test('a test', () => {
+        expect(1).toBe(1);
+      });
+    `,
+    dedent`
+      const exports = 'exports';
+      module[exports] = function () {};
       test('a test', () => {
         expect(1).toBe(1);
       });
@@ -78,6 +108,16 @@ ruleTester.run('no-export', rule, {
       errors: [{ endColumn: 24, column: 1, messageId: 'unexpectedExport' }],
     },
     {
+      code: dedent`
+        module.export.invalid = function () {};
+
+        test('a test', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
       code: 'module.exports["invalid"] = function() {};  test("a test", () => { expect(1).toBe(1);});',
       errors: [{ endColumn: 26, column: 1, messageId: 'unexpectedExport' }],
     },
@@ -86,8 +126,12 @@ ruleTester.run('no-export', rule, {
       errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
     },
     {
-      code: 'module.export.invalid = function() {}; ;  test("a test", () => { expect(1).toBe(1);});',
-      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
+      code: 'module["exports"] = function() {}; test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 18, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'module.exports.foo.bar = function() {}; test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 23, column: 1, messageId: 'unexpectedExport' }],
     },
     {
       code: dedent`

--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -56,6 +56,13 @@ ruleTester.run('no-export', rule, {
         expect(1).toBe(1);
       });
     `,
+    dedent`
+      let value;
+      value = 'foo';
+      test('a test', () => {
+        expect(1).toBe(1);
+      });
+    `,
   ],
   invalid: [
     {

--- a/src/rules/__tests__/no-export.test.ts
+++ b/src/rules/__tests__/no-export.test.ts
@@ -39,6 +39,13 @@ ruleTester.run('no-export', rule, {
       });
     `,
     dedent`
+      module.export.invalid = function () {};
+
+      test('a test', () => {
+        expect(1).toBe(1);
+      });
+    `,
+    dedent`
       function getModule() {
         return module;
       }
@@ -50,8 +57,8 @@ ruleTester.run('no-export', rule, {
       });
     `,
     dedent`
-      const exports = 'exports';
-      module[exports] = function () {};
+      const exports = {};
+      exports.myThing = 'valid';
       test('a test', () => {
         expect(1).toBe(1);
       });
@@ -115,14 +122,12 @@ ruleTester.run('no-export', rule, {
       errors: [{ endColumn: 24, column: 1, messageId: 'unexpectedExport' }],
     },
     {
-      code: dedent`
-        module.export.invalid = function () {};
-
-        test('a test', () => {
-          expect(1).toBe(1);
-        });
-      `,
-      errors: [{ endColumn: 22, column: 1, messageId: 'unexpectedExport' }],
+      code: 'exports.myThing = "invalid"; test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 16, column: 1, messageId: 'unexpectedExport' }],
+    },
+    {
+      code: 'exports["myThing"] = "invalid"; test("a test", () => { expect(1).toBe(1);});',
+      errors: [{ endColumn: 19, column: 1, messageId: 'unexpectedExport' }],
     },
     {
       code: 'module.exports["invalid"] = function() {};  test("a test", () => { expect(1).toBe(1);});',
@@ -131,14 +136,6 @@ ruleTester.run('no-export', rule, {
     {
       code: 'module.exports = function() {}; ;  test("a test", () => { expect(1).toBe(1);});',
       errors: [{ endColumn: 15, column: 1, messageId: 'unexpectedExport' }],
-    },
-    {
-      code: 'module["exports"] = function() {}; test("a test", () => { expect(1).toBe(1);});',
-      errors: [{ endColumn: 18, column: 1, messageId: 'unexpectedExport' }],
-    },
-    {
-      code: 'module.exports.foo.bar = function() {}; test("a test", () => { expect(1).toBe(1);});',
-      errors: [{ endColumn: 23, column: 1, messageId: 'unexpectedExport' }],
     },
     {
       code: dedent`

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -1,5 +1,58 @@
-import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
+import {
+  AST_NODE_TYPES,
+  type TSESLint,
+  type TSESTree,
+} from '@typescript-eslint/utils';
 import { createRule, isTypeOfJestFnCall, resolveScope } from './utils';
+
+const isGlobalIdentifier = (
+  node: TSESTree.Identifier,
+  name: string,
+  context: TSESLint.RuleContext<string, unknown[]>,
+): boolean =>
+  node.name === name &&
+  resolveScope(context.sourceCode.getScope(node), name) === null;
+
+type MemberExpressionWithIdentifierObject = TSESTree.MemberExpression & {
+  object: TSESTree.Identifier;
+};
+
+const getModuleMemberExpressionRoot = (
+  member: TSESTree.MemberExpression,
+): MemberExpressionWithIdentifierObject | null => {
+  let current = member;
+
+  while (current.object.type === AST_NODE_TYPES.MemberExpression) {
+    current = current.object;
+  }
+
+  return current.object.type === AST_NODE_TYPES.Identifier
+    ? (current as MemberExpressionWithIdentifierObject)
+    : null;
+};
+
+const isCommonJsExportAssignment = (
+  node: TSESTree.AssignmentExpression,
+  context: TSESLint.RuleContext<string, unknown[]>,
+): boolean => {
+  const { left } = node;
+
+  if (left.type !== AST_NODE_TYPES.MemberExpression) {
+    return false;
+  }
+
+  const root = getModuleMemberExpressionRoot(left);
+
+  return (
+    root !== null &&
+    isGlobalIdentifier(root.object, 'module', context) &&
+    ((!root.computed &&
+      root.property.type === AST_NODE_TYPES.Identifier &&
+      /^exports?$/u.test(root.property.name)) ||
+      (root.property.type === AST_NODE_TYPES.Literal &&
+        root.property.value === 'exports'))
+  );
+};
 
 export default createRule({
   name: __filename,
@@ -19,7 +72,7 @@ export default createRule({
       | TSESTree.ExportNamedDeclaration
       | TSESTree.ExportDefaultDeclaration
       | TSESTree.TSExportAssignment
-      | TSESTree.MemberExpression
+      | TSESTree.AssignmentExpression['left']
     > = [];
     let hasTestCase = false;
 
@@ -45,28 +98,9 @@ export default createRule({
       ) {
         exportNodes.push(node);
       },
-      'AssignmentExpression > MemberExpression'(
-        node: TSESTree.MemberExpression,
-      ) {
-        let { object, property } = node;
-
-        if (object.type === AST_NODE_TYPES.MemberExpression) {
-          ({ object, property } = object);
-        }
-
-        if (
-          object.type !== AST_NODE_TYPES.Identifier ||
-          object.name !== 'module' ||
-          resolveScope(context.sourceCode.getScope(object), 'module') !== null
-        ) {
-          return;
-        }
-
-        if (
-          property.type === AST_NODE_TYPES.Identifier &&
-          /^exports?$/u.test(property.name)
-        ) {
-          exportNodes.push(node);
+      AssignmentExpression(node: TSESTree.AssignmentExpression) {
+        if (isCommonJsExportAssignment(node, context)) {
+          exportNodes.push(node.left);
         }
       },
     };

--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -13,47 +13,6 @@ const isGlobalIdentifier = (
   node.name === name &&
   resolveScope(context.sourceCode.getScope(node), name) === null;
 
-type MemberExpressionWithIdentifierObject = TSESTree.MemberExpression & {
-  object: TSESTree.Identifier;
-};
-
-const getModuleMemberExpressionRoot = (
-  member: TSESTree.MemberExpression,
-): MemberExpressionWithIdentifierObject | null => {
-  let current = member;
-
-  while (current.object.type === AST_NODE_TYPES.MemberExpression) {
-    current = current.object;
-  }
-
-  return current.object.type === AST_NODE_TYPES.Identifier
-    ? (current as MemberExpressionWithIdentifierObject)
-    : null;
-};
-
-const isCommonJsExportAssignment = (
-  node: TSESTree.AssignmentExpression,
-  context: TSESLint.RuleContext<string, unknown[]>,
-): boolean => {
-  const { left } = node;
-
-  if (left.type !== AST_NODE_TYPES.MemberExpression) {
-    return false;
-  }
-
-  const root = getModuleMemberExpressionRoot(left);
-
-  return (
-    root !== null &&
-    isGlobalIdentifier(root.object, 'module', context) &&
-    ((!root.computed &&
-      root.property.type === AST_NODE_TYPES.Identifier &&
-      /^exports?$/u.test(root.property.name)) ||
-      (root.property.type === AST_NODE_TYPES.Literal &&
-        root.property.value === 'exports'))
-  );
-};
-
 export default createRule({
   name: __filename,
   meta: {
@@ -72,7 +31,7 @@ export default createRule({
       | TSESTree.ExportNamedDeclaration
       | TSESTree.ExportDefaultDeclaration
       | TSESTree.TSExportAssignment
-      | TSESTree.AssignmentExpression['left']
+      | TSESTree.MemberExpression
     > = [];
     let hasTestCase = false;
 
@@ -98,9 +57,36 @@ export default createRule({
       ) {
         exportNodes.push(node);
       },
-      AssignmentExpression(node: TSESTree.AssignmentExpression) {
-        if (isCommonJsExportAssignment(node, context)) {
-          exportNodes.push(node.left);
+      'AssignmentExpression > MemberExpression'(
+        node: TSESTree.MemberExpression,
+      ) {
+        let { object, property } = node;
+
+        if (
+          object.type === AST_NODE_TYPES.Identifier &&
+          isGlobalIdentifier(object, 'exports', context)
+        ) {
+          exportNodes.push(node);
+
+          return;
+        }
+
+        if (object.type === AST_NODE_TYPES.MemberExpression) {
+          ({ object, property } = object);
+        }
+
+        if (
+          object.type !== AST_NODE_TYPES.Identifier ||
+          !isGlobalIdentifier(object, 'module', context)
+        ) {
+          return;
+        }
+
+        if (
+          property.type === AST_NODE_TYPES.Identifier &&
+          property.name === 'exports'
+        ) {
+          exportNodes.push(node);
         }
       },
     };


### PR DESCRIPTION
# Summary

This pr is based on  #1977. 

Walk the full member chain so nested module.exports.foo.bar assignments are reported, and support module["exports"] string literal access while ignoring computed properties that use local bindings.