### PR TITLE
docs(no-restricted-matchers): fix typo

### DIFF
--- a/docs/rules/no-restricted-matchers.md
+++ b/docs/rules/no-restricted-matchers.md
@@ -46,7 +46,7 @@ Examples of **incorrect** code for this rule with the above configuration
 
 ```js
 it('is false', () => {
-  // if this has a modifer (i.e. `not.toBeFalsy`), it would be considered fine
+  // if this has a modifier (i.e. `not.toBeFalsy`), it would be considered fine
   expect(a).toBeFalsy();
 });
 


### PR DESCRIPTION
Fix `no-restricted-matchers.md` typo