### PR TITLE
fix(ci): pin Danger to pre-built GHCR image instead of rebuilding from source

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Danger
-        uses: danger/danger-js@e9b58820039524318198d8059ec98b0c02b7875c # 13.0.10
+        # Use the pre-built GHCR image instead of the danger/danger-js action, which rebuilds its
+        # Dockerfile from source on every run. That Dockerfile runs `yarn remove typescript && yarn
+        # add typescript` (unpinned) at build time, always fetching whatever `typescript@latest` is
+        # on npm. That recently became TypeScript 7.0.2, whose changed internals break danger-js's
+        # bundled transpiler with `TypeError: ts.transpileModule is not a function`. The pre-built
+        # image is frozen at its own release time (TypeScript 6.0.3 here), so it isn't affected.
+        uses: docker://ghcr.io/danger/danger-js@sha256:8470399d296efbc3b4e9ae16c60a84b32dd3ff893e5c558f35d7e656dd34d0b7 # 13.0.10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Every recent PR's `danger` job in the `Lint` workflow has been failing with:

```
Error:  TypeError: ts.transpileModule is not a function
    at typescriptify (/usr/src/danger/dist/runner/runners/utils/transpiler.js:160:21)
```

**Root cause:** the `danger/danger-js` GitHub Action rebuilds its `Dockerfile` from source on every CI run. That `Dockerfile` runs:

```dockerfile
RUN yarn remove 'typescript' --dev && yarn add 'typescript'
```

with no version pin, so it always resolves to whatever `typescript@latest` is on npm at build time. npm's `latest` tag moved to **TypeScript 7.0.2 on 2026-07-08**, and TS 7's changed internals break danger-js's bundled transpiler. This affects any pinned `danger/danger-js` action version equally, since it's an image-build-time resolution, not something the action's pinned SHA controls.

**Fix:** 
- Switch to the pre-built [ghcr.io/danger/danger-js](https://github.com/danger/danger-js/pkgs/container/danger-js) image, pinned by digest, instead of the source-build action. That image is frozen at its own release time — TypeScript 6.0.3 baked in for `13.0.10`, predating the TS 7 `latest` flip — so it's immune to npm's `typescript@latest` drift going forward, and won't silently break again since the digest is immutable. 
- As a side benefit, pulling the pre-built image also skips the `Dockerfile` build step entirely (no `yarn install` / `tsc` / dependency re-resolution on every run) — the job just pulls a cached layer and runs, which is noticeably faster than rebuilding from source and removes a source of build-time network/registry flakiness.

## Verification

- Reproduced the crash live on this repo's own CI (see failing `danger` job runs on recent PRs, e.g. any PR from the last few days).
- Confirmed the pre-built `ghcr.io/danger/danger-js:13.0.10` image has TypeScript 6.0.3 baked in (checked via `podman run ghcr.io/danger/danger-js:13.0.10 ... node -e "require('typescript/package.json').version"`).
- Validated the fix end-to-end with a real `pull_request` run in my fork: [tronghiant/eslint-plugin-jest/#1](https://github.com/tronghiant/eslint-plugin-jest/actions/runs/30235705635/job/89883019351?pr=1) — the `danger` job passes cleanly with no `ts.transpileModule` error.
- `ubuntu-latest` runners are amd64, matching the pre-built image (which has no arm64 manifest), so no runner changes are needed here.

## Test plan

- [ ] Confirm the `danger` job passes on this PR
