### PR TITLE
fix(prefer-comparison-matcher): don't crash on `expect` chain without a value

### DIFF
--- a/src/rules/__tests__/prefer-comparison-matcher.test.ts
+++ b/src/rules/__tests__/prefer-comparison-matcher.test.ts
@@ -265,6 +265,7 @@ ruleTester.run(`prefer-comparison-matcher`, rule, {
     'expect.assertions(1)',
     'expect(true).toBe(...true)',
     'expect()',
+    'expect().toStrictEqual({})',
     'expect({}).toStrictEqual({})',
     'expect(a === b).toBe(true)',
     'expect(a !== 2).toStrictEqual(true)',

--- a/src/rules/prefer-comparison-matcher.ts
+++ b/src/rules/prefer-comparison-matcher.ts
@@ -90,7 +90,7 @@ export default createRule({
         const matcherArg = getFirstMatcherArg(jestFnCall);
 
         if (
-          comparison.type !== AST_NODE_TYPES.BinaryExpression ||
+          comparison?.type !== AST_NODE_TYPES.BinaryExpression ||
           isComparingToString(comparison) ||
           !EqualityMatcher.hasOwnProperty(getAccessorValue(matcher)) ||
           !isBooleanLiteral(matcherArg)


### PR DESCRIPTION
Resolves #2000