### PR TITLE
fix(prefer-expect-resolves): don't crash on `expect` chain without a value

### DIFF
--- a/src/rules/__tests__/prefer-expect-resolves.test.ts
+++ b/src/rules/__tests__/prefer-expect-resolves.test.ts
@@ -14,6 +14,11 @@ ruleTester.run('prefer-expect-resolves', rule, {
     'expect.hasAssertions()',
     dedent`
       it('passes', async () => {
+        await expect().resolves.toBe(true);
+      });
+    `,
+    dedent`
+      it('passes', async () => {
         await expect(someValue()).resolves.toBe(true);
       });
     `,

--- a/src/rules/prefer-expect-resolves.ts
+++ b/src/rules/prefer-expect-resolves.ts
@@ -32,7 +32,7 @@ export default createRule({
 
       const [awaitNode] = parent.arguments;
 
-      if (awaitNode.type === AST_NODE_TYPES.AwaitExpression) {
+      if (awaitNode?.type === AST_NODE_TYPES.AwaitExpression) {
         context.report({
           node: awaitNode,
           messageId: 'expectResolves',


### PR DESCRIPTION
Resolves #2000