### PR TITLE
refactor(no-export): remove unneeded length check

### DIFF
--- a/src/rules/no-export.ts
+++ b/src/rules/no-export.ts
@@ -25,7 +25,7 @@ export default createRule({
 
     return {
       'Program:exit'() {
-        if (hasTestCase && exportNodes.length > 0) {
+        if (hasTestCase) {
           for (const node of exportNodes) {
             context.report({ node, messageId: 'unexpectedExport' });
           }


### PR DESCRIPTION
If there are no items, the loop just won't do anything