### PR TITLE
refactor: use `replaceText` in fixers when possible

### DIFF
--- a/src/rules/no-unneeded-async-expect-function.ts
+++ b/src/rules/no-unneeded-async-expect-function.ts
@@ -59,8 +59,8 @@ export default createRule({
               const { sourceCode } = context;
 
               return [
-                fixer.replaceTextRange(
-                  [awaitNode.range[0], awaitNode.range[1]],
+                fixer.replaceText(
+                  awaitNode,
                   sourceCode.getText(innerAsyncFuncCall),
                 ),
               ];

--- a/src/rules/prefer-jest-mocked.ts
+++ b/src/rules/prefer-jest-mocked.ts
@@ -42,8 +42,8 @@ export default createRule({
         return;
       }
 
-      const fnName = context.sourceCode.text.slice(
-        ...followTypeAssertionChain(node.expression).range,
+      const fnName = context.sourceCode.getText(
+        followTypeAssertionChain(node.expression),
       );
 
       context.report({

--- a/src/rules/valid-title.ts
+++ b/src/rules/valid-title.ts
@@ -306,8 +306,8 @@ export default createRule<[Options], MessageIds>({
             messageId: 'accidentalSpace',
             node: argument,
             fix: fixer => [
-              fixer.replaceTextRange(
-                argument.range,
+              fixer.replaceText(
+                argument,
                 quoteStringValue(argument)
                   .replace(/^([`'"]) +?/u, '$1')
                   .replace(/ +?([`'"])$/u, '$1'),
@@ -324,8 +324,8 @@ export default createRule<[Options], MessageIds>({
             messageId: 'duplicatePrefix',
             node: argument,
             fix: fixer => [
-              fixer.replaceTextRange(
-                argument.range,
+              fixer.replaceText(
+                argument,
                 quoteStringValue(argument).replace(/^([`'"]).+? /u, '$1'),
               ),
             ],


### PR DESCRIPTION
A couple of nice little wins here