### PR TITLE
fix(prefer-to-have-length): don't crash on `expect` chain without a value

### DIFF
--- a/src/rules/__tests__/prefer-to-have-length.test.ts
+++ b/src/rules/__tests__/prefer-to-have-length.test.ts
@@ -12,6 +12,7 @@ ruleTester.run('prefer-to-have-length', rule, {
   valid: [
     'expect.hasAssertions',
     'expect.hasAssertions()',
+    'expect().toBe(true)',
     'expect(files).toHaveLength(1);',
     "expect(files.name).toBe('file');",
     "expect(files[`name`]).toBe('file');",

--- a/src/rules/prefer-to-have-length.ts
+++ b/src/rules/prefer-to-have-length.ts
@@ -41,7 +41,7 @@ export default createRule({
 
         if (
           !EqualityMatcher.hasOwnProperty(getAccessorValue(matcher)) ||
-          argument.type !== AST_NODE_TYPES.MemberExpression ||
+          argument?.type !== AST_NODE_TYPES.MemberExpression ||
           !isSupportedAccessor(argument.property, 'length')
         ) {
           return;


### PR DESCRIPTION
Resolves #2013