### PR TITLE
fix(prefer-to-have-been-called): don't crash on matcher without an argument

### DIFF
--- a/src/rules/__tests__/prefer-to-have-been-called.test.ts
+++ b/src/rules/__tests__/prefer-to-have-been-called.test.ts
@@ -21,6 +21,7 @@ ruleTester.run('prefer-to-have-been-called', rule, {
     'expect(method).toBe([])',
     'expect(fn.mock.calls).toEqual([])',
     'expect(fn.mock.calls).toContain(1, 2, 3)',
+    'expect(method).toBeCalledTimes();',
   ],
 
   invalid: [

--- a/src/rules/prefer-to-have-been-called.ts
+++ b/src/rules/prefer-to-have-been-called.ts
@@ -25,7 +25,7 @@ export default createRule({
       CallExpression(node) {
         const jestFnCall = parseJestFnCall(node, context);
 
-        if (jestFnCall?.type !== 'expect') {
+        if (jestFnCall?.type !== 'expect' || jestFnCall.args.length === 0) {
           return;
         }
 


### PR DESCRIPTION
Found while looking into #2013 - hopefully the last one 🤞 